### PR TITLE
feat!: granular node types, GitNexus comparison, PreToolUse hooks

### DIFF
--- a/.claude/hooks/enrich-context.sh
+++ b/.claude/hooks/enrich-context.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# enrich-context.sh — PreToolUse hook for Read and Grep tools
+# Provides dependency context from codegraph when reading/searching files.
+# Always exits 0 (informational only, never blocks).
+
+set -euo pipefail
+
+# Read the tool input from stdin
+INPUT=$(cat)
+
+# Extract file path based on tool type
+# Read tool uses tool_input.file_path, Grep uses tool_input.path
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+
+# Guard: no file path found
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Guard: codegraph DB must exist
+DB_PATH="${CLAUDE_PROJECT_DIR:-.}/.codegraph/graph.db"
+if [ ! -f "$DB_PATH" ]; then
+  exit 0
+fi
+
+# Guard: codegraph must be available
+if ! command -v codegraph &>/dev/null && ! command -v npx &>/dev/null; then
+  exit 0
+fi
+
+# Convert absolute path to relative (strip project dir prefix)
+REL_PATH="$FILE_PATH"
+if [[ "$FILE_PATH" == "${CLAUDE_PROJECT_DIR}"* ]]; then
+  REL_PATH="${FILE_PATH#"${CLAUDE_PROJECT_DIR}"/}"
+fi
+# Normalize backslashes to forward slashes (Windows compatibility)
+REL_PATH="${REL_PATH//\\//}"
+
+# Run codegraph deps and capture output
+DEPS=""
+if command -v codegraph &>/dev/null; then
+  DEPS=$(codegraph deps "$REL_PATH" --json -d "$DB_PATH" 2>/dev/null) || true
+else
+  DEPS=$(npx --yes @optave/codegraph deps "$REL_PATH" --json -d "$DB_PATH" 2>/dev/null) || true
+fi
+
+# Guard: no output or error
+if [ -z "$DEPS" ] || [ "$DEPS" = "null" ]; then
+  exit 0
+fi
+
+# Output as informational context (never deny)
+echo "$DEPS" | jq -c '{
+  hookSpecificOutput: (
+    "Codegraph context for " + (.file // "unknown") + ":\n" +
+    "  Imports: " + ((.results[0].imports // []) | length | tostring) + " files\n" +
+    "  Imported by: " + ((.results[0].importedBy // []) | length | tostring) + " files\n" +
+    "  Definitions: " + ((.results[0].definitions // []) | length | tostring) + " symbols"
+  )
+}' 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,26 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/enrich-context.sh\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/enrich-context.sh\"",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ JS source is plain JavaScript (ES modules) in `src/`. No transpilation step. The
 | `index.js` | Programmatic API exports |
 | `builder.js` | Graph building: file collection, parsing, import resolution, incremental hashing |
 | `parser.js` | tree-sitter WASM wrapper; `LANGUAGE_REGISTRY` + per-language extractors for functions, classes, methods, imports, exports, call sites |
-| `queries.js` | Query functions: symbol search, file deps, impact analysis, diff-impact |
+| `queries.js` | Query functions: symbol search, file deps, impact analysis, diff-impact; `SYMBOL_KINDS` constant defines all node kinds |
 | `embedder.js` | Semantic search with `@huggingface/transformers`; multi-query RRF ranking |
 | `db.js` | SQLite schema and operations (`better-sqlite3`) |
 | `mcp.js` | MCP server exposing graph queries to AI agents |
@@ -60,6 +60,7 @@ JS source is plain JavaScript (ES modules) in `src/`. No transpilation step. The
 - Platform-specific prebuilt binaries published as optional npm packages (`@optave/codegraph-{platform}-{arch}`)
 - WASM grammars are built from devDeps on `npm install` (via `prepare` script) and not committed to git — used as fallback when native addon is unavailable
 - **Language parser registry:** `LANGUAGE_REGISTRY` in `parser.js` is the single source of truth for all supported languages — maps each language to `{ id, extensions, grammarFile, extractor, required }`. `EXTENSIONS` in `constants.js` is derived from the registry. Adding a new language requires one registry entry + extractor function
+- **Node kinds:** `SYMBOL_KINDS` in `queries.js` lists all valid kinds: `function`, `method`, `class`, `interface`, `type`, `struct`, `enum`, `trait`, `record`, `module`. Language-specific types use their native kind (e.g. Go structs → `struct`, Rust traits → `trait`, Ruby modules → `module`) rather than mapping everything to `class`/`interface`
 - `@huggingface/transformers` and `@modelcontextprotocol/sdk` are optional dependencies, lazy-loaded
 - Non-required parsers (all except JS/TS/TSX) fail gracefully if their WASM grammar is unavailable
 - Import resolution uses a 6-level priority system with confidence scoring (import-aware → same-file → directory → parent → global → method hierarchy)

--- a/README.md
+++ b/README.md
@@ -45,27 +45,27 @@ Most dependency graph tools only tell you which **files** import which — codeg
 
 ### Feature comparison
 
-| Capability | codegraph | Madge | dep-cruiser | Skott | Nx graph | Sourcetrail |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| Function-level analysis | **Yes** | — | — | — | — | **Yes** |
-| Multi-language | **10** | 1 | 1 | 1 | Any (project) | 4 |
-| Semantic search | **Yes** | — | — | — | — | — |
-| MCP / AI agent support | **Yes** | — | — | — | — | — |
-| Git diff impact | **Yes** | — | — | — | Partial | — |
-| Persistent database | **Yes** | — | — | — | — | Yes |
-| Watch mode | **Yes** | — | — | — | Daemon | — |
-| CI workflow included | **Yes** | — | Rules | — | Yes | — |
-| Cycle detection | **Yes** | Yes | Yes | Yes | — | — |
-| Zero config | **Yes** | Yes | — | Yes | — | — |
-| Fully local / no telemetry | **Yes** | Yes | Yes | Yes | Partial | Yes |
-| Free & open source | **Yes** | Yes | Yes | Yes | Partial | Archived |
+| Capability | codegraph | Madge | dep-cruiser | Skott | Nx graph | Sourcetrail | GitNexus |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Function-level analysis | **Yes** | — | — | — | — | **Yes** | **Yes** |
+| Multi-language | **11** | 1 | 1 | 1 | Any (project) | 4 | 9 |
+| Semantic search | **Yes** | — | — | — | — | — | **Yes** |
+| MCP / AI agent support | **Yes** | — | — | — | — | — | **Yes** |
+| Git diff impact | **Yes** | — | — | — | Partial | — | **Yes** |
+| Persistent database | **Yes** | — | — | — | — | Yes | **Yes** |
+| Watch mode | **Yes** | — | — | — | Daemon | — | — |
+| CI workflow included | **Yes** | — | Rules | — | Yes | — | — |
+| Cycle detection | **Yes** | Yes | Yes | Yes | — | — | — |
+| Zero config | **Yes** | Yes | — | Yes | — | — | **Yes** |
+| Fully local / no telemetry | **Yes** | Yes | Yes | Yes | Partial | Yes | **Yes** |
+| Free & open source | **Yes** | Yes | Yes | Yes | Partial | Archived | No |
 
 ### What makes codegraph different
 
 | | Differentiator | In practice |
 |---|---|---|
 | **🔬** | **Function-level, not just files** | Traces `handleAuth()` → `validateToken()` → `decryptJWT()` and shows 14 callers across 9 files break if `decryptJWT` changes |
-| **🌐** | **Multi-language, one CLI** | JS/TS + Python + Go + Rust + Java + C# + PHP + Ruby + Terraform in a single graph — no juggling Madge, pyan, and cflow |
+| **🌐** | **Multi-language, one CLI** | JS/TS + Python + Go + Rust + Java + C# + PHP + Ruby + HCL in a single graph — no juggling Madge, pyan, and cflow |
 | **🤖** | **AI-agent ready** | Built-in [MCP server](https://modelcontextprotocol.io/) — AI assistants query your graph directly via `codegraph fn <name>` |
 | **💥** | **Git diff impact** | `codegraph diff-impact` shows changed functions, their callers, and full blast radius — ships with a GitHub Actions workflow |
 | **🔒** | **Fully local, zero telemetry** | No accounts, no API keys, no cloud, no data exfiltration — Apache-2.0, free forever |
@@ -88,6 +88,7 @@ Many tools in this space are cloud-based or SaaS — meaning your code leaves yo
 | [Understand](https://scitools.com/) | Deep multi-language static analysis | $100+/month per seat, proprietary, GUI-only, no CI or AI integration |
 | [Snyk Code](https://snyk.io/) | AI-powered security scanning | Cloud-based — code sent to Snyk servers for analysis, not a dependency graph tool |
 | [pyan](https://github.com/Technologicat/pyan) / [cflow](https://www.gnu.org/software/cflow/) | Function-level call graphs | Single-language each (Python / C only), no persistence, no queries |
+| [GitNexus](https://gitnexus.dev/) | Function-level graph with hybrid search and MCP | PolyForm Noncommercial license, no watch mode, no cycle detection, no CI workflow |
 
 ---
 
@@ -228,7 +229,7 @@ codegraph mcp                  # Start MCP server for AI assistants
 | `-j, --json` | Output as JSON |
 | `-v, --verbose` | Enable debug output |
 | `--engine <engine>` | Parser engine: `native`, `wasm`, or `auto` (default: `auto`) |
-| `-k, --kind <kind>` | Filter by kind: `function`, `method`, `class` (search) |
+| `-k, --kind <kind>` | Filter by kind: `function`, `method`, `class`, `struct`, `enum`, `trait`, `record`, `module` (search) |
 | `--file <pattern>` | Filter by file path pattern (search) |
 | `--rrf-k <n>` | RRF smoothing constant for multi-query search (default 60) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Codegraph is a strong local-first code graph CLI. This roadmap describes planned
 | Phase | Theme | Key Deliverables | Status |
 |-------|-------|-----------------|--------|
 | [**1**](#phase-1--rust-core) | Rust Core | Rust parsing engine via napi-rs, parallel parsing, incremental tree-sitter, JS orchestration layer | **Complete** (v1.3.0) |
-| [**2**](#phase-2--foundation-hardening) | Foundation Hardening | Parser registry, complete MCP, test coverage, enhanced config | **Complete** (v1.4.0) |
+| [**2**](#phase-2--foundation-hardening) | Foundation Hardening | Parser registry, complete MCP, test coverage, enhanced config, multi-repo MCP | **Partial** — core complete (v1.4.0), 2.5 planned |
 | [**3**](#phase-3--intelligent-embeddings) | Intelligent Embeddings | LLM-generated descriptions, hybrid search | Planned |
 | [**4**](#phase-4--natural-language-queries) | Natural Language Queries | `ask` command, conversational sessions | Planned |
 | [**5**](#phase-5--expanded-language-support) | Expanded Language Support | 8 new languages (12 → 20), parser utilities | Planned |
@@ -170,6 +170,20 @@ New configuration options in `.codegraphrc.json`:
 - ✅ `apiKeyCommand` — shell out to external secret managers (1Password, Bitwarden, Vault, pass, macOS Keychain) at runtime via `execFileSync` (no shell injection). Priority: command output > env var > file config > defaults. Graceful fallback on failure.
 
 **Affected files:** `src/config.js`
+
+### 2.5 — Multi-Repo MCP
+
+Support querying multiple codebases from a single MCP server instance.
+
+- Registry file at `~/.codegraph/registry.json` mapping repo names to their `.codegraph/graph.db` paths
+- Lazy DB connections — only opened when a repo is first queried
+- Add optional `repo` parameter to all MCP tools to target a specific repository
+- Auto-registration: `codegraph build` adds the current project to the registry
+- New CLI commands: `codegraph registry list|add|remove` for manual management
+- Default behavior: when `repo` is omitted, use the local `.codegraph/graph.db` (backwards compatible)
+
+**New files:** `src/registry.js`
+**Affected files:** `src/mcp.js`, `src/cli.js`, `src/builder.js`
 
 ---
 

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -51,7 +51,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 let name = node_text(&name_node, source).to_string();
                 symbols.definitions.push(Definition {
                     name: name.clone(),
-                    kind: "class".to_string(),
+                    kind: "struct".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,
@@ -65,7 +65,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 let name = node_text(&name_node, source).to_string();
                 symbols.definitions.push(Definition {
                     name: name.clone(),
-                    kind: "class".to_string(),
+                    kind: "record".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,
@@ -112,7 +112,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: node_text(&name_node, source).to_string(),
-                    kind: "class".to_string(),
+                    kind: "enum".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,

--- a/crates/codegraph-core/src/extractors/go.rs
+++ b/crates/codegraph-core/src/extractors/go.rs
@@ -76,7 +76,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                             "struct_type" => {
                                 symbols.definitions.push(Definition {
                                     name,
-                                    kind: "class".to_string(),
+                                    kind: "struct".to_string(),
                                     line: start_line(node),
                                     end_line: Some(end_line(node)),
                                     decorators: None,

--- a/crates/codegraph-core/src/extractors/java.rs
+++ b/crates/codegraph-core/src/extractors/java.rs
@@ -120,7 +120,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: node_text(&name_node, source).to_string(),
-                    kind: "class".to_string(),
+                    kind: "enum".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,

--- a/crates/codegraph-core/src/extractors/php.rs
+++ b/crates/codegraph-core/src/extractors/php.rs
@@ -131,7 +131,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: node_text(&name_node, source).to_string(),
-                    kind: "interface".to_string(),
+                    kind: "trait".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,
@@ -143,7 +143,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: node_text(&name_node, source).to_string(),
-                    kind: "class".to_string(),
+                    kind: "enum".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,

--- a/crates/codegraph-core/src/extractors/ruby.rs
+++ b/crates/codegraph-core/src/extractors/ruby.rs
@@ -52,7 +52,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: node_text(&name_node, source).to_string(),
-                    kind: "class".to_string(),
+                    kind: "module".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -50,7 +50,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: node_text(&name_node, source).to_string(),
-                    kind: "class".to_string(),
+                    kind: "struct".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,
@@ -62,7 +62,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             if let Some(name_node) = node.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: node_text(&name_node, source).to_string(),
-                    kind: "class".to_string(),
+                    kind: "enum".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,
@@ -75,7 +75,7 @@ fn walk_node(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 let trait_name = node_text(&name_node, source).to_string();
                 symbols.definitions.push(Definition {
                     name: trait_name.clone(),
-                    kind: "interface".to_string(),
+                    kind: "trait".to_string(),
                     line: start_line(node),
                     end_line: Some(end_line(node)),
                     decorators: None,

--- a/src/cycles.js
+++ b/src/cycles.js
@@ -31,8 +31,8 @@ export function findCycles(db, opts = {}) {
       FROM edges e
       JOIN nodes n1 ON e.source_id = n1.id
       JOIN nodes n2 ON e.target_id = n2.id
-      WHERE n1.kind IN ('function', 'method', 'class')
-        AND n2.kind IN ('function', 'method', 'class')
+      WHERE n1.kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module')
+        AND n2.kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module')
         AND e.kind = 'calls'
         AND n1.id != n2.id
     `)

--- a/src/export.js
+++ b/src/export.js
@@ -62,7 +62,7 @@ export function exportDOT(db, opts = {}) {
       FROM edges e
       JOIN nodes n1 ON e.source_id = n1.id
       JOIN nodes n2 ON e.target_id = n2.id
-      WHERE n1.kind IN ('function', 'method', 'class') AND n2.kind IN ('function', 'method', 'class')
+      WHERE n1.kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module') AND n2.kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module')
       AND e.kind = 'calls'
     `)
       .all();
@@ -111,7 +111,7 @@ export function exportMermaid(db, opts = {}) {
       FROM edges e
       JOIN nodes n1 ON e.source_id = n1.id
       JOIN nodes n2 ON e.target_id = n2.id
-      WHERE n1.kind IN ('function', 'method', 'class') AND n2.kind IN ('function', 'method', 'class')
+      WHERE n1.kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module') AND n2.kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module')
       AND e.kind = 'calls'
     `)
       .all();

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -143,7 +143,7 @@ const TOOLS = [
   {
     name: 'list_functions',
     description:
-      'List functions, methods, and classes in the codebase, optionally filtered by file or name pattern',
+      'List functions, methods, classes, structs, enums, traits, records, and modules in the codebase, optionally filtered by file or name pattern',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/parser.js
+++ b/src/parser.js
@@ -731,7 +731,7 @@ export function extractGoSymbols(tree, _filePath) {
             if (typeNode.type === 'struct_type') {
               definitions.push({
                 name: nameNode.text,
-                kind: 'class',
+                kind: 'struct',
                 line: node.startPosition.row + 1,
                 endLine: nodeEndLine(node),
               });
@@ -876,7 +876,7 @@ export function extractRustSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'struct',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -889,7 +889,7 @@ export function extractRustSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'enum',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -902,7 +902,7 @@ export function extractRustSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'interface',
+            kind: 'trait',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -1186,7 +1186,7 @@ export function extractJavaSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'enum',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -1320,7 +1320,7 @@ export function extractCSharpSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'struct',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -1334,7 +1334,7 @@ export function extractCSharpSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'record',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -1378,7 +1378,7 @@ export function extractCSharpSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'enum',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -1588,7 +1588,7 @@ export function extractRubySymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'module',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -1818,7 +1818,7 @@ export function extractPHPSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'interface',
+            kind: 'trait',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });
@@ -1831,7 +1831,7 @@ export function extractPHPSymbols(tree, _filePath) {
         if (nameNode) {
           definitions.push({
             name: nameNode.text,
-            kind: 'class',
+            kind: 'enum',
             line: node.startPosition.row + 1,
             endLine: nodeEndLine(node),
           });

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -173,10 +173,10 @@ export async function watchProject(rootDir, opts = {}) {
     countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
     countEdgesForFile: null,
     findNodeInFile: db.prepare(
-      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface') AND file = ?",
+      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module') AND file = ?",
     ),
     findNodeByName: db.prepare(
-      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface')",
+      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module')",
     ),
   };
 

--- a/tests/parsers/csharp.test.js
+++ b/tests/parsers/csharp.test.js
@@ -60,14 +60,14 @@ describe('C# parser', () => {
   it('extracts enum declarations', () => {
     const symbols = parseCSharp(`public enum Color { Red, Green, Blue }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'Color', kind: 'class' }),
+      expect.objectContaining({ name: 'Color', kind: 'enum' }),
     );
   });
 
   it('extracts struct declarations', () => {
     const symbols = parseCSharp(`public struct Point { public int X; public int Y; }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'Point', kind: 'class' }),
+      expect.objectContaining({ name: 'Point', kind: 'struct' }),
     );
   });
 

--- a/tests/parsers/go.test.js
+++ b/tests/parsers/go.test.js
@@ -37,10 +37,10 @@ func (s Server) Name() string { return "" }`);
     );
   });
 
-  it('extracts struct types as class kind', () => {
+  it('extracts struct types as struct kind', () => {
     const symbols = parseGo(`package main\ntype User struct { Name string; Age int }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'User', kind: 'class' }),
+      expect.objectContaining({ name: 'User', kind: 'struct' }),
     );
   });
 

--- a/tests/parsers/java.test.js
+++ b/tests/parsers/java.test.js
@@ -60,7 +60,7 @@ describe('Java parser', () => {
   it('extracts enum declarations', () => {
     const symbols = parseJava(`public enum Color { RED, GREEN, BLUE }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'Color', kind: 'class' }),
+      expect.objectContaining({ name: 'Color', kind: 'enum' }),
     );
   });
 

--- a/tests/parsers/php.test.js
+++ b/tests/parsers/php.test.js
@@ -56,7 +56,7 @@ describe('PHP parser', () => {
   public function getCreatedAt() {}
 }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'HasTimestamps', kind: 'interface' }),
+      expect.objectContaining({ name: 'HasTimestamps', kind: 'trait' }),
     );
   });
 
@@ -112,7 +112,7 @@ function run() {
   it('extracts enum declarations', () => {
     const symbols = parsePHP(`<?php enum Color { case Red; case Green; case Blue; }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'Color', kind: 'class' }),
+      expect.objectContaining({ name: 'Color', kind: 'enum' }),
     );
   });
 });

--- a/tests/parsers/ruby.test.js
+++ b/tests/parsers/ruby.test.js
@@ -64,7 +64,7 @@ end`);
   end
 end`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'Serializable', kind: 'class' }),
+      expect.objectContaining({ name: 'Serializable', kind: 'module' }),
     );
     expect(symbols.definitions).toContainEqual(
       expect.objectContaining({ name: 'Serializable.serialize', kind: 'method' }),

--- a/tests/parsers/rust.test.js
+++ b/tests/parsers/rust.test.js
@@ -25,21 +25,21 @@ describe('Rust parser', () => {
   it('extracts struct declarations', () => {
     const symbols = parseRust(`struct User { name: String, age: u32 }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'User', kind: 'class' }),
+      expect.objectContaining({ name: 'User', kind: 'struct' }),
     );
   });
 
   it('extracts enum declarations', () => {
     const symbols = parseRust(`enum Color { Red, Green, Blue }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'Color', kind: 'class' }),
+      expect.objectContaining({ name: 'Color', kind: 'enum' }),
     );
   });
 
   it('extracts trait declarations', () => {
     const symbols = parseRust(`trait Drawable { fn draw(&self); fn area(&self) -> f64; }`);
     expect(symbols.definitions).toContainEqual(
-      expect.objectContaining({ name: 'Drawable', kind: 'interface' }),
+      expect.objectContaining({ name: 'Drawable', kind: 'trait' }),
     );
     expect(symbols.definitions).toContainEqual(
       expect.objectContaining({ name: 'Drawable.draw', kind: 'method' }),


### PR DESCRIPTION
## Summary
- **Granular node types**: Go structs to `struct`, Rust structs/enums/traits to `struct`/`enum`/`trait`, Java enums to `enum`, C# structs/records/enums to `struct`/`record`/`enum`, PHP traits/enums to `trait`/`enum`, Ruby modules to `module` — in both WASM and native Rust extractors
- **Query layer**: Added `SYMBOL_KINDS` constant, extended `kindIcon()`, updated all `kind IN` SQL filters across queries, builder, export, embedder, cycles, watcher, and MCP
- **README**: Added GitNexus column to comparison table, updated `--kind` flag docs
- **ROADMAP**: Added Phase 2.5 Multi-Repo MCP
- **PreToolUse hooks**: Read/Grep context enrichment via `codegraph deps`
- **CLAUDE.md**: Documented node kinds design decision

## Test plan
- [x] `npm run lint` — clean (46 files)
- [x] `npm test` — 296 passed, 0 failures
- [ ] Manual: build a project with Go/Rust/Java code, verify `codegraph query <struct>` returns `kind: struct`

BREAKING CHANGE: Node kinds changed for structs, enums, traits, records, and modules. Users must rebuild with `codegraph build --no-incremental`.