### PR TITLE
fix: sync v2.0.0 release and use PR for publish version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -229,12 +230,29 @@ jobs:
         if: "!inputs.dry-run"
         run: npm publish --access public --provenance
 
-      - name: Push version commit and tag
-        if: github.event_name == 'workflow_dispatch' && !inputs.dry-run
+      - name: Push version bump via PR
+        if: "!inputs.dry-run"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin main
-          TAG="v${{ steps.version.outputs.new_version }}"
-          # Skip if tag already exists on remote (e.g. created by a GitHub release)
+          VERSION="${{ steps.version.outputs.new_version }}"
+          TAG="v${VERSION}"
+          BRANCH="release/v${VERSION}"
+
+          # Check if there are version bump changes to push
+          if git diff --quiet HEAD; then
+            echo "No version bump commit to push — skipping PR"
+          else
+            git push origin "HEAD:refs/heads/${BRANCH}"
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: release v${VERSION}" \
+              --body "Automated version bump to \`${VERSION}\` and CHANGELOG update from publish workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            echo "::notice::Version bump PR created for ${BRANCH} → main"
+          fi
+
+          # Push tag (skip if it already exists on remote)
           if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
             echo "Tag $TAG already exists on remote — skipping tag push"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
-## [1.5.0](https://github.com/optave/codegraph/compare/v1.4.0...v1.5.0) (2026-02-22)
+## [2.0.0](https://github.com/optave/codegraph/compare/v1.4.0...v2.0.0) (2026-02-22)
 
 **Phase 2.5 — Multi-Repo MCP & Structural Analysis.** This release adds multi-repo support for AI agents, structural analysis with architectural metrics, and hardens security across the MCP server and SQL layers.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optave/codegraph",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Local code graph CLI — parse codebases with tree-sitter, build dependency graphs, query them",
   "type": "module",
   "main": "src/index.js",
@@ -61,10 +61,10 @@
   "optionalDependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@optave/codegraph-darwin-arm64": "1.4.0",
-    "@optave/codegraph-darwin-x64": "1.4.0",
-    "@optave/codegraph-linux-x64-gnu": "1.4.0",
-    "@optave/codegraph-win32-x64-msvc": "1.4.0"
+    "@optave/codegraph-darwin-arm64": "2.0.0",
+    "@optave/codegraph-darwin-x64": "2.0.0",
+    "@optave/codegraph-linux-x64-gnu": "2.0.0",
+    "@optave/codegraph-win32-x64-msvc": "2.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",


### PR DESCRIPTION
## Summary
- **Sync v2.0.0**: Bumps `package.json` from 1.4.0 → 2.0.0 (including `optionalDependencies`) and renames the CHANGELOG header from 1.5.0 → 2.0.0 to match what was actually published on npm. The CI version bump commit couldn't be pushed to `main` due to branch protection.
- **Fix publish workflow**: Replaces the direct `git push origin main` with creating a `release/vX.Y.Z` branch and opening a PR via `gh pr create`. This respects branch protection rules that require PRs and status checks. Also adds `pull-requests: write` permission to the publish job.

## Test plan
- [ ] Verify `package.json` version is `2.0.0` and optionalDependencies reference `2.0.0`
- [ ] Verify CHANGELOG heading reads `2.0.0` instead of `1.5.0`
- [ ] On next publish run, confirm the workflow creates a `release/vX.Y.Z` PR instead of pushing directly to main