### PR TITLE
feat: dev releases on merge to main, stable releases from GitHub Releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,14 @@
 name: Publish
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
+
+concurrency:
+  group: publish
+  cancel-in-progress: true
 
 permissions: {}
 
@@ -10,6 +16,8 @@ jobs:
   preflight:
     name: Preflight checks
     runs-on: ubuntu-latest
+    # Skip dev publish when the push is a stable release version bump
+    if: github.event_name == 'release' || !startsWith(github.event.head_commit.message, 'chore: release v')
     permissions:
       contents: read
     steps:
@@ -19,6 +27,39 @@ jobs:
           node-version: "22"
       - run: npm install
       - run: npm test
+
+  compute-version:
+    needs: preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+      npm_tag: ${{ steps.compute.outputs.npm_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version
+        id: compute
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+            NPM_TAG="latest"
+            echo "Stable release: $VERSION (from tag $TAG)"
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            NEXT_PATCH=$((PATCH + 1))
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-dev.${SHORT_SHA}"
+            NPM_TAG="dev"
+            echo "Dev release: $VERSION"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
 
   build-native:
     needs: preflight
@@ -81,7 +122,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    needs: build-native
+    needs: [compute-version, build-native]
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
@@ -106,30 +147,18 @@ jobs:
 
       - run: npm install
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump version
+      - name: Set version
         id: version
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           git checkout -- package-lock.json
-          CURRENT=$(node -p "require('./package.json').version")
+          npm version "$VERSION" --no-git-tag-version
+          node scripts/sync-native-versions.js
+          echo "Publishing version $VERSION"
 
-          # Extract version from the release tag
-          TAG="${{ github.event.release.tag_name }}"
-          RELEASE_VERSION="${TAG#v}"
-          if [ "$CURRENT" != "$RELEASE_VERSION" ]; then
-            echo "::warning::package.json ($CURRENT) doesn't match release tag ($TAG) — bumping to match"
-            npx commit-and-tag-version --release-as "$RELEASE_VERSION" --skip.tag --skip.changelog
-          else
-            echo "Version $CURRENT already matches tag $TAG"
-          fi
-
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Will publish version $NEW_VERSION"
+      - name: Disable prepublishOnly
+        run: npm pkg set scripts.prepublishOnly=""
 
       - name: Download native artifacts
         uses: actions/download-artifact@v4
@@ -137,21 +166,23 @@ jobs:
           path: artifacts/
 
       - name: Verify version not already on npm
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
           PKG="@optave/codegraph"
           echo "Checking if $PKG@$VERSION already exists on npm..."
           if npm view "$PKG@$VERSION" version 2>/dev/null; then
-            echo "::error::$PKG@$VERSION is already published on npm. Bump to a higher version."
+            echo "::error::$PKG@$VERSION is already published on npm."
             exit 1
           fi
           echo "$PKG@$VERSION is not yet published — proceeding"
 
       - name: Publish platform packages
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          NPM_TAG: ${{ needs.compute-version.outputs.npm_tag }}
         shell: bash
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
-
           declare -A PACKAGES=(
             ["linux-x64"]="@optave/codegraph-linux-x64-gnu"
             ["darwin-arm64"]="@optave/codegraph-darwin-arm64"
@@ -185,21 +216,29 @@ jobs:
           }
           PKGJSON
 
-            echo "Publishing ${pkg_name}@${VERSION}"
-            npm publish "./pkg/$platform" --access public --provenance --tag latest
+            echo "Publishing ${pkg_name}@${VERSION} with --tag ${NPM_TAG}"
+            npm publish "./pkg/$platform" --access public --provenance --tag "$NPM_TAG"
           done
 
-      - name: Disable prepublishOnly
-        run: npm pkg set scripts.prepublishOnly=""
-
       - name: Publish main package
-        run: npm publish --access public --provenance --tag latest
+        env:
+          NPM_TAG: ${{ needs.compute-version.outputs.npm_tag }}
+        run: npm publish --access public --provenance --tag "$NPM_TAG"
+
+      # ── Stable-only: version bump PR and tag ──
+
+      - name: Configure git
+        if: github.event_name == 'release'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Push version bump via PR
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.new_version }}"
           TAG="v${VERSION}"
           BRANCH="release/v${VERSION}"
 
@@ -207,6 +246,8 @@ jobs:
           if git diff --quiet HEAD; then
             echo "No version bump commit to push — skipping PR"
           else
+            git add -A
+            git commit -m "chore: release v${VERSION}"
             git push origin "HEAD:refs/heads/${BRANCH}"
             gh pr create \
               --base main \
@@ -223,3 +264,25 @@ jobs:
             git tag -a "$TAG" -m "release: $TAG"
             git push origin "$TAG"
           fi
+
+      # ── Dev-only: summary with install instructions ──
+
+      - name: Summary
+        if: github.event_name == 'push'
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Dev Release Published
+
+          **Version:** \`${VERSION}\`
+          **Commit:** \`${{ github.sha }}\`
+
+          ### Install
+
+          \`\`\`bash
+          npm install @optave/codegraph@dev
+          # or pin this exact version:
+          npm install @optave/codegraph@${VERSION}
+          \`\`\`
+          EOF


### PR DESCRIPTION
## Summary

Consolidates dev and stable publishing into a single `publish.yml` workflow (required by npm Trusted Publishing's one-workflow-per-package constraint).

- **`push` to `main`** (PR merges) → publishes prerelease versions like `2.0.1-dev.abc1234` with `--tag dev`
- **GitHub Release event** → publishes stable versions with `--tag latest`

### Key design choices

- **Single workflow file** — npm OIDC Trusted Publishing restricts each package to one configured workflow provider
- **`compute-version` job** — computes version + npm tag, shared via outputs to the publish job
- **Concurrency group** with `cancel-in-progress: true` — rapid merges only publish the latest main commit
- **Skip logic** — commits starting with `chore: release v` skip dev publish (avoids publishing the stable version bump as a dev release)
- **No git side-effects for dev** — no commits, tags, CHANGELOG, or PRs for dev releases
- **Stable-only steps** — version bump PR and tag push gated behind `if: github.event_name == 'release'`
- **Unified version setting** — both paths use `npm version --no-git-tag-version` + `sync-native-versions.js`

### npm dist-tags after this

| Command | Gets |
|---------|------|
| `npm install @optave/codegraph` | Stable (`latest`) |
| `npm install @optave/codegraph@dev` | Latest dev from main |
| `npm install @optave/codegraph@2.0.1-dev.abc1234` | Specific dev build |

## Test plan

- [ ] Merge a PR to main — verify publish triggers and publishes `2.0.1-dev.{sha}` with `--tag dev`
- [ ] Run `npm view @optave/codegraph dist-tags` — should show both `latest` and `dev`
- [ ] Create a GitHub Release — verify stable publish with `--tag latest`
- [ ] Verify stable release version bump PR is created correctly
- [ ] Merge a `chore: release v*` commit — verify dev publish is skipped