### PR TITLE
fix(ci): fix publish workflow YAML parse error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Preflight checks
     runs-on: ubuntu-latest
     # Skip dev publish when the push is a stable release version bump
-    if: github.event_name == 'release' || !startsWith(github.event.head_commit.message, 'chore: release v')
+    if: ${{ github.event_name == 'release' || !startsWith(github.event.head_commit.message, 'chore: release v') }}
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- Line 20 of `publish.yml` uses `!startsWith(...)` in a bare `if:` expression — YAML interprets the `!` as a tag prefix, causing a parse error before any jobs run
- Wraps the expression in `${{ }}` so YAML sees it as a plain string

Every push to `main` since PR #26 was merged has been failing instantly with _"You have an error in your yaml syntax on line 20"_.

## Test plan
- [ ] Merge and verify the next push-triggered Publish run starts jobs successfully