### PR TITLE
fix(ci): use npm pkg delete instead of set to empty string

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,7 +158,7 @@ jobs:
           echo "Publishing version $VERSION"
 
       - name: Disable prepublishOnly
-        run: npm pkg set scripts.prepublishOnly=""
+        run: npm pkg delete scripts.prepublishOnly
 
       - name: Download native artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- `npm pkg set scripts.prepublishOnly=""` fails on newer npm versions — the empty `""` is not recognized as a valid key=value pair
- Replace with `npm pkg delete scripts.prepublishOnly` which removes the key entirely (same effect, works across all npm versions)

## Test plan
- [ ] Merge and verify the publish workflow succeeds on next push to main