### PR TITLE
docs: replace CI workflow row with embeddable JS library differentiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ Most code graph tools make you choose: **fast local analysis with no AI, or powe
 | MCP / AI agent support | **Yes** | — | **Yes** | **Yes** | **Yes** | — | **Yes** | — |
 | Git diff impact | **Yes** | — | — | — | — | — | — | **Yes** |
 | Watch mode | **Yes** | — | **Yes** | — | — | — | — | — |
-| CI workflow included | **Yes** | — | — | — | — | — | — | — |
 | Cycle detection | **Yes** | — | **Yes** | — | — | — | — | **Yes** |
 | Incremental rebuilds | **Yes** | — | **Yes** | — | — | — | — | — |
 | Zero config | **Yes** | — | **Yes** | — | — | **Yes** | — | — |
+| Embeddable JS library (`npm install`) | **Yes** | — | — | — | — | — | — | — |
 | LLM-optional (works without API keys) | **Yes** | **Yes** | **Yes** | — | **Yes** | **Yes** | **Yes** | **Yes** |
 | Open source | **Yes** | Yes | Yes | Yes | Yes | Yes | Custom | — |
 


### PR DESCRIPTION
Remove "CI workflow included" (trivial) and add "Embeddable JS library (npm install)" — codegraph is the only competitor that can be imported into VS Code extensions, Node.js MCP servers, and JS toolchains.

## Summary

<!-- Briefly describe what this PR does and why -->

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] Maintenance (`chore:`, `ci:`, `build:`)

## Testing checklist

- [ ] I ran `npm test` and all tests pass
- [ ] I ran `npm run lint` with no errors
- [ ] I added/updated tests for my changes (if applicable)

## Breaking changes

<!-- If this is a breaking change, describe what breaks and the migration path -->

N/A

## Related issues

<!-- Link related issues: Fixes #123, Closes #456 -->
