### PR TITLE
fix(ci): rewrite Claude Code workflow for working automated PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  pull_request:
+    types: [opened, synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -9,11 +11,93 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
-  claude:
+  automated-review:
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Automated AI Review
+        id: automated-review
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          direct_prompt: |
+            ## Review this pull request
+
+            You are reviewing a PR for **codegraph** — a local code dependency graph CLI that parses
+            codebases with tree-sitter (WASM), builds function-level dependency graphs in SQLite, and
+            supports semantic search with local embeddings.
+
+            ### Phase 1: Root Cause Analysis
+            Before reviewing code, determine:
+            - **What problem is this PR solving?** Is it fixing a real issue or hiding symptoms?
+            - **Is the approach justified?** Are configuration/linting changes relaxing rules to silence errors?
+            - ⚠️ REJECT if changes silence warnings without fixing underlying issues
+            - ⚠️ REJECT if test expectations are lowered to make tests pass
+            - If you cannot determine the root cause, REQUEST MORE INFORMATION
+
+            ### Phase 2: Configuration Change Detection (HIGH SCRUTINY)
+            Check for HIGH-RISK changes:
+            - Biome/linting rules disabled or relaxed
+            - Test timeouts increased or coverage thresholds lowered
+            - Build configuration or module resolution modified
+            - TypeScript strict mode flags disabled
+            - **If >3 rules are relaxed → REQUEST justification for each**
+
+            ### Phase 3: Test Integrity
+            Watch for RED FLAGS:
+            - Removed or weakened assertions
+            - Tests made less strict (conditional assertions, skipped validation)
+            - Test files modified alongside the code they test without clear reason
+            - `eslint-disable` or workaround comments without justification
+            - Large PRs (>20 files) mixing unrelated concerns
+
+            ### Phase 4: Code Quality
+            Only after passing Phases 1-3:
+            - Code quality and best practices
+            - Potential bugs (especially in tree-sitter extractors, import resolution, SQLite operations)
+            - Security concerns (command injection in CLI, SQL injection in queries)
+            - Performance (unnecessary full rebuilds, missing incremental hash checks)
+            - Test coverage for new functionality
+
+            ### Rating (STRICT — default to 2-3 stars)
+            - ⭐ Critical issues, REJECT
+            - ⭐⭐ Significant concerns, REQUEST CHANGES
+            - ⭐⭐⭐ Acceptable with minor concerns, APPROVE with conditions
+            - ⭐⭐⭐⭐ Good quality, well-tested, APPROVE
+            - ⭐⭐⭐⭐⭐ Exceptional (< 5% of PRs)
+
+            ### Final Assessment (MANDATORY)
+            ```
+            ## Root Cause Analysis
+            **Problem Being Solved**: [...]
+            **Why This Approach**: [...]
+            **Risk Assessment**: [...]
+
+            ## Critical Concerns (if any)
+            [...]
+
+            ## Final Recommendation
+            - Rating: ⭐⭐☆☆☆ (X/5)
+            - Action: [REJECT | REQUEST CHANGES | APPROVE WITH CONDITIONS | APPROVE]
+            - Reasoning: [...]
+            ```
+
+            Be skeptical but fair. Reference exact line numbers. Explain WHY something is problematic.
+            NEVER default to approval — require the PR to prove its value.
+
+  interactive-claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -22,44 +106,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
+      - name: Run Interactive AI Assistant
+        id: interactive-claude
+        uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |
             actions: read
-
-  review:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_tools: 'Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Read,Glob,Grep'


### PR DESCRIPTION
## Summary
- **Fixed**: Claude Code review job was running (~$4/run) but never posting comments because `allowed_tools` is not a valid input on `@v1` and the plugin config was broken
- **Switched** from `anthropics/claude-code-action@v1` to `@beta` which supports `direct_prompt` for automated PR reviews
- **Added** phased review prompt (root cause analysis → config scrutiny → test integrity → code quality) with strict rating calibration
- **Added** bot PR filtering to skip Dependabot/Renovate PRs
- **Downgraded** permissions from `write` to `read` (beta action handles posting via OIDC)

## What was broken
1. `allowed_tools` input doesn't exist on the action — silently ignored, Claude's Bash calls were permission-denied
2. Plugin marketplace config (`code-review@claude-code-plugins`) wasn't loading
3. `prompt` on `@v1` is meant for mention-triggered flows, not automated reviews

## Test plan
- [ ] Open a test PR and verify the `automated-review` job posts a review comment
- [ ] Verify `interactive-claude` still responds to `@claude` mentions
- [ ] Verify bot PRs (dependabot) are skipped