### PR TITLE
fix: run benchmark after publish to prevent workflow cancellation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,9 @@
 name: Benchmark
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
   workflow_dispatch:
 
 permissions: {}
@@ -10,6 +11,9 @@ permissions: {}
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Fix benchmark workflow to run after publish completes, preventing workflow cancellation

## Test plan

- [x] CI-only change — no code modifications