### PR TITLE
perf: reduce WASM boundary crossings in JS extractor

### DIFF
--- a/src/extractors/javascript.js
+++ b/src/extractors/javascript.js
@@ -139,9 +139,11 @@ export function extractSymbols(tree, _filePath) {
           if (callInfo) {
             calls.push(callInfo);
           }
+          if (fn.type === 'member_expression') {
+            const cbDef = extractCallbackDefinition(node, fn);
+            if (cbDef) definitions.push(cbDef);
+          }
         }
-        const cbDef = extractCallbackDefinition(node);
-        if (cbDef) definitions.push(cbDef);
         break;
       }
 
@@ -320,10 +322,6 @@ function extractReceiverName(objNode) {
   if (objNode.type === 'identifier') return objNode.text;
   if (objNode.type === 'this') return 'this';
   if (objNode.type === 'super') return 'super';
-  if (objNode.type === 'member_expression') {
-    const prop = objNode.childForFieldName('property');
-    if (prop) return objNode.text;
-  }
   return objNode.text;
 }
 
@@ -432,8 +430,8 @@ const EXPRESS_METHODS = new Set([
 ]);
 const EVENT_METHODS = new Set(['on', 'once', 'addEventListener', 'addListener']);
 
-function extractCallbackDefinition(callNode) {
-  const fn = callNode.childForFieldName('function');
+function extractCallbackDefinition(callNode, fn) {
+  if (!fn) fn = callNode.childForFieldName('function');
   if (!fn || fn.type !== 'member_expression') return null;
 
   const prop = fn.childForFieldName('property');


### PR DESCRIPTION
## Summary

- Gate `extractCallbackDefinition` behind `fn.type === 'member_expression'` check — skips ~60-70% of calls (simple `foo()` expressions), saving 2+ WASM boundary crossings each
- Pass pre-read `fn` node into `extractCallbackDefinition` to avoid redundant `childForFieldName('function')` — saves 1 crossing per remaining call
- Remove dead `member_expression` branch in `extractReceiverName` that called `childForFieldName('property')` only to return the same `objNode.text` fallback — saves 1 crossing per member expression receiver

Targets the 32% WASM performance regression (5.0 → 6.6 ms/file) between v2.0.0 and v2.1.0. All three are pure optimizations with zero semantic change.

## Test plan

- [x] Full test suite passes (471 tests, 0 failures)
- [ ] Run `node scripts/benchmark.js` to compare WASM ms/file against 6.6 baseline (target: closer to 5.0)