### PR TITLE
fix(cli): graceful error for cycles, export, embed when no graph.db exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "codegraph": "./src/cli.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,12 +2,11 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import Database from 'better-sqlite3';
 import { Command } from 'commander';
 import { buildGraph } from './builder.js';
 import { loadConfig } from './config.js';
 import { findCycles, formatCycles } from './cycles.js';
-import { findDbPath } from './db.js';
+import { openReadonlyOrFail } from './db.js';
 import { buildEmbeddings, EMBEDDING_STRATEGIES, MODELS, search } from './embedder.js';
 import { exportDOT, exportJSON, exportMermaid } from './export.js';
 import { setVerbose } from './logger.js';
@@ -275,7 +274,7 @@ program
   .option('--min-confidence <score>', 'Minimum edge confidence threshold (default: 0.5)', '0.5')
   .option('-o, --output <file>', 'Write to file instead of stdout')
   .action((opts) => {
-    const db = new Database(findDbPath(opts.db), { readonly: true });
+    const db = openReadonlyOrFail(opts.db);
     const exportOpts = {
       fileLevel: !opts.functions,
       noTests: resolveNoTests(opts),
@@ -314,7 +313,7 @@ program
   .option('--include-tests', 'Include test/spec files (overrides excludeTests config)')
   .option('-j, --json', 'Output as JSON')
   .action((opts) => {
-    const db = new Database(findDbPath(opts.db), { readonly: true });
+    const db = openReadonlyOrFail(opts.db);
     const cycles = findCycles(db, { fileLevel: !opts.functions, noTests: resolveNoTests(opts) });
     db.close();
 

--- a/src/embedder.js
+++ b/src/embedder.js
@@ -324,6 +324,14 @@ export async function buildEmbeddings(rootDir, modelKey, customDbPath, options =
   const strategy = options.strategy || 'structured';
   const dbPath = customDbPath || findDbPath(null);
 
+  if (!fs.existsSync(dbPath)) {
+    console.error(
+      `No codegraph database found at ${dbPath}.\n` +
+        `Run "codegraph build" first to analyze your codebase.`,
+    );
+    process.exit(1);
+  }
+
   const db = new Database(dbPath);
   initEmbeddingsSchema(db);
 


### PR DESCRIPTION
## Summary
- `codegraph cycles`, `codegraph export`, and `codegraph embed` crashed with a `better-sqlite3` stack trace when run without a graph.db
- Fixed by using `openReadonlyOrFail()` in cli.js and adding `fs.existsSync()` guard in embedder.js
- Also exports `./package.json` in the package exports map so `require('@optave/codegraph/package.json')` works

## Found during
Dogfooding v2.2.3-dev.44e8146 — see #77 and #78

## Test plan
- [x] `codegraph cycles` without graph → graceful error message
- [x] `codegraph export` without graph → graceful error message
- [x] `codegraph embed` without graph → graceful error message
- [x] All three commands work normally with a graph
- [x] `npm test` passes (29/29 test files, 476/476 tests)
- [x] `npm run lint` passes (0 warnings)