### PR TITLE
feat: add query + incremental regression benchmarks

### DIFF
--- a/scripts/update-benchmark-report.js
+++ b/scripts/update-benchmark-report.js
@@ -154,6 +154,35 @@ fs.mkdirSync(path.dirname(benchmarkPath), { recursive: true });
 fs.writeFileSync(benchmarkPath, md);
 console.error(`Updated ${path.relative(root, benchmarkPath)}`);
 
+// ── Regression detection ─────────────────────────────────────────────────
+const REGRESSION_THRESHOLD = 0.15; // 15% regression triggers a warning
+const prev = history[1] || null;
+
+function checkRegression(label, current, previous) {
+	if (previous == null || previous === 0) return;
+	const pct = (current - previous) / previous;
+	if (pct > REGRESSION_THRESHOLD) {
+		const msg = `${label}: ${previous} → ${current} (+${Math.round(pct * 100)}%, threshold ${Math.round(REGRESSION_THRESHOLD * 100)}%)`;
+		if (process.env.GITHUB_ACTIONS) {
+			console.error(`::warning title=Benchmark Regression::${msg}`);
+		} else {
+			console.error(`⚠ REGRESSION: ${msg}`);
+		}
+	}
+}
+
+if (prev) {
+	for (const engineKey of ['native', 'wasm']) {
+		const e = latest[engineKey];
+		const p = prev[engineKey];
+		if (!e || !p) continue;
+		const tag = `[${engineKey}]`;
+		checkRegression(`${tag} Build ms/file`, e.perFile.buildTimeMs, p.perFile.buildTimeMs);
+		checkRegression(`${tag} Query time`, e.queryTimeMs, p.queryTimeMs);
+		checkRegression(`${tag} DB bytes/file`, e.perFile.dbSizeBytes, p.perFile.dbSizeBytes);
+	}
+}
+
 // ── Patch README.md ──────────────────────────────────────────────────────
 if (fs.existsSync(readmePath)) {
 	let readme = fs.readFileSync(readmePath, 'utf8');

--- a/scripts/update-embedding-report.js
+++ b/scripts/update-embedding-report.js
@@ -132,3 +132,35 @@ md += `\n<!-- EMBEDDING_BENCHMARK_DATA\n${JSON.stringify(history, null, 2)}\n-->
 fs.mkdirSync(path.dirname(reportPath), { recursive: true });
 fs.writeFileSync(reportPath, md);
 console.error(`Updated ${path.relative(root, reportPath)}`);
+
+// ── Regression detection ─────────────────────────────────────────────────
+const REGRESSION_THRESHOLD = 0.15; // 15% regression triggers a warning
+const prev = history[1] || null;
+
+function checkRegression(label, current, previous, lowerIsBetter = true) {
+	if (previous == null || previous === 0) return;
+	const pct = (current - previous) / previous;
+	const regressed = lowerIsBetter ? pct > REGRESSION_THRESHOLD : pct < -REGRESSION_THRESHOLD;
+	if (regressed) {
+		const delta = lowerIsBetter ? `+${Math.round(pct * 100)}%` : `${Math.round(pct * 100)}%`;
+		const msg = `${label}: ${previous} → ${current} (${delta}, threshold ${Math.round(REGRESSION_THRESHOLD * 100)}%)`;
+		if (process.env.GITHUB_ACTIONS) {
+			console.error(`::warning title=Benchmark Regression::${msg}`);
+		} else {
+			console.error(`⚠ REGRESSION: ${msg}`);
+		}
+	}
+}
+
+if (prev) {
+	for (const [modelKey, m] of Object.entries(latest.models)) {
+		const pm = prev.models?.[modelKey];
+		if (!pm) continue;
+		const tag = `[${modelKey}]`;
+		// Hit rates: higher is better (regression = drop)
+		checkRegression(`${tag} Hit@1`, m.hits1 / m.total, pm.hits1 / pm.total, false);
+		checkRegression(`${tag} Hit@5`, m.hits5 / m.total, pm.hits5 / pm.total, false);
+		// Embed time: lower is better (regression = increase)
+		checkRegression(`${tag} Embed time`, m.embedTimeMs, pm.embedTimeMs);
+	}
+}

--- a/scripts/update-incremental-report.js
+++ b/scripts/update-incremental-report.js
@@ -148,3 +148,40 @@ md += `<!-- INCREMENTAL_BENCHMARK_DATA\n${JSON.stringify(history, null, 2)}\n-->
 fs.mkdirSync(path.dirname(reportPath), { recursive: true });
 fs.writeFileSync(reportPath, md);
 console.error(`Updated ${path.relative(root, reportPath)}`);
+
+// ── Regression detection ─────────────────────────────────────────────────
+const REGRESSION_THRESHOLD = 0.15; // 15% regression triggers a warning
+const prev = history[1] || null;
+
+function checkRegression(label, current, previous) {
+	if (previous == null || previous === 0) return;
+	const pct = (current - previous) / previous;
+	if (pct > REGRESSION_THRESHOLD) {
+		const msg = `${label}: ${previous} → ${current} (+${Math.round(pct * 100)}%, threshold ${Math.round(REGRESSION_THRESHOLD * 100)}%)`;
+		if (process.env.GITHUB_ACTIONS) {
+			console.error(`::warning title=Benchmark Regression::${msg}`);
+		} else {
+			console.error(`⚠ REGRESSION: ${msg}`);
+		}
+	}
+}
+
+if (prev) {
+	for (const engineKey of ['native', 'wasm']) {
+		const e = latest[engineKey];
+		const p = prev[engineKey];
+		if (!e || !p) continue;
+		const tag = `[${engineKey}]`;
+		checkRegression(`${tag} Full build`, e.fullBuildMs, p.fullBuildMs);
+		checkRegression(`${tag} No-op rebuild`, e.noopRebuildMs, p.noopRebuildMs);
+		checkRegression(`${tag} 1-file rebuild`, e.oneFileRebuildMs, p.oneFileRebuildMs);
+	}
+	const re = latest.resolve;
+	const rp = prev.resolve;
+	if (re && rp) {
+		checkRegression(`[resolve] JS fallback`, re.jsFallbackMs, rp.jsFallbackMs);
+		if (re.nativeBatchMs != null && rp.nativeBatchMs != null) {
+			checkRegression(`[resolve] Native batch`, re.nativeBatchMs, rp.nativeBatchMs);
+		}
+	}
+}

--- a/scripts/update-query-report.js
+++ b/scripts/update-query-report.js
@@ -142,3 +142,36 @@ md += `<!-- QUERY_BENCHMARK_DATA\n${JSON.stringify(history, null, 2)}\n-->\n`;
 fs.mkdirSync(path.dirname(reportPath), { recursive: true });
 fs.writeFileSync(reportPath, md);
 console.error(`Updated ${path.relative(root, reportPath)}`);
+
+// ── Regression detection ─────────────────────────────────────────────────
+const REGRESSION_THRESHOLD = 0.15; // 15% regression triggers a warning
+const prev = history[1] || null;
+
+function checkRegression(label, current, previous) {
+	if (previous == null || previous === 0) return;
+	const pct = (current - previous) / previous;
+	if (pct > REGRESSION_THRESHOLD) {
+		const msg = `${label}: ${previous} → ${current} (+${Math.round(pct * 100)}%, threshold ${Math.round(REGRESSION_THRESHOLD * 100)}%)`;
+		if (process.env.GITHUB_ACTIONS) {
+			console.error(`::warning title=Benchmark Regression::${msg}`);
+		} else {
+			console.error(`⚠ REGRESSION: ${msg}`);
+		}
+	}
+}
+
+if (prev) {
+	for (const engineKey of ['native', 'wasm']) {
+		const e = latest[engineKey];
+		const p = prev[engineKey];
+		if (!e || !p) continue;
+		const tag = `[${engineKey}]`;
+		checkRegression(`${tag} fnDeps d1`, e.fnDeps.depth1Ms, p.fnDeps.depth1Ms);
+		checkRegression(`${tag} fnDeps d3`, e.fnDeps.depth3Ms, p.fnDeps.depth3Ms);
+		checkRegression(`${tag} fnDeps d5`, e.fnDeps.depth5Ms, p.fnDeps.depth5Ms);
+		checkRegression(`${tag} fnImpact d1`, e.fnImpact.depth1Ms, p.fnImpact.depth1Ms);
+		checkRegression(`${tag} fnImpact d3`, e.fnImpact.depth3Ms, p.fnImpact.depth3Ms);
+		checkRegression(`${tag} fnImpact d5`, e.fnImpact.depth5Ms, p.fnImpact.depth5Ms);
+		checkRegression(`${tag} diffImpact`, e.diffImpact.latencyMs, p.diffImpact.latencyMs);
+	}
+}


### PR DESCRIPTION
## Summary

- Add **query benchmark** (`scripts/query-benchmark.js`): measures `fnDepsData` and `fnImpactData` at depth 1/3/5 (median of 5 runs) plus `diffImpactData` with a synthetic staged diff, both engines
- Add **incremental benchmark** (`scripts/incremental-benchmark.js`): measures full/no-op/1-file rebuild tiers and import resolution throughput (native batch vs JS fallback), both engines
- Add report updaters (`update-query-report.js`, `update-incremental-report.js`) following the exact pattern of existing updaters — trend arrows, HTML comment history, deduplicate by version
- Add **regression threshold alerts** to all 4 report updaters (build, embedding, query, incremental) — 15% regression triggers `::warning` annotations in GitHub Actions
- Add 2 new CI jobs to `benchmark.yml` (`query-benchmark`, `incremental-benchmark`)
- Add 2 new rows to the CONTRIBUTING.md regression benchmarks table
- Add **Lightweight Footprint** section to README with live shields.io badges: unpacked size, dependency GitHub stars, and npm weekly downloads

## Test plan

- [x] `node scripts/query-benchmark.js 2>/dev/null | jq .` — produces valid JSON
- [x] `node scripts/incremental-benchmark.js 2>/dev/null | jq .` — produces valid JSON
- [x] Pipe into updaters — correct markdown generated
- [x] Regression detection fires correctly on simulated regressions
- [x] `npm run lint` passes
- [x] Workflow YAML validates
- [x] shields.io badge URLs return 200