### PR TITLE
fix(ci): resilient version set in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,7 +184,7 @@ jobs:
           VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           git checkout -- package-lock.json
-          npm version "$VERSION" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           node scripts/sync-native-versions.js
           echo "Publishing version $VERSION"
 


### PR DESCRIPTION
## Summary
- Adds `--allow-same-version` to the `npm version` call in the publish workflow
- When a `release/vX.Y.Z` PR is merged before the release event triggers the workflow, `package.json` already has the target version — `npm version` would fail with "Version not changed"
- This makes the step idempotent so retries and race conditions between the release PR merge and the release event are handled gracefully

## Test plan
- [x] Retry the v2.3.0 release via `workflow_dispatch` after merging this