### PR TITLE
fix: model disposal, roles, incremental builds, docs reorg

### DIFF
--- a/scripts/embedding-benchmark.js
+++ b/scripts/embedding-benchmark.js
@@ -24,7 +24,7 @@ const root = path.resolve(__dirname, '..');
 const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
 const dbPath = path.join(root, '.codegraph', 'graph.db');
 
-const { buildEmbeddings, MODELS, searchData } = await import(
+const { buildEmbeddings, MODELS, searchData, disposeModel } = await import(
 	new URL('../src/embedder.js', import.meta.url).href
 );
 
@@ -129,6 +129,7 @@ for (const key of modelKeys) {
 	} catch (err) {
 		console.error(`  FAILED: ${err.message}`);
 	}
+	await disposeModel();
 }
 
 // Restore console.log for JSON output

--- a/src/embedder.js
+++ b/src/embedder.js
@@ -238,10 +238,25 @@ async function loadTransformers() {
   }
 }
 
+/**
+ * Dispose the current ONNX session and free memory.
+ * Safe to call when no model is loaded (no-op).
+ */
+export async function disposeModel() {
+  if (extractor) {
+    await extractor.dispose();
+    extractor = null;
+  }
+  activeModel = null;
+}
+
 async function loadModel(modelKey) {
   const config = getModelConfig(modelKey);
 
   if (extractor && activeModel === config.name) return { extractor, config };
+
+  // Dispose previous model before loading a different one
+  await disposeModel();
 
   const transformers = await loadTransformers();
   pipeline = transformers.pipeline;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export {
   buildEmbeddings,
   cosineSim,
   DEFAULT_MODEL,
+  disposeModel,
   EMBEDDING_STRATEGIES,
   embed,
   estimateTokens,


### PR DESCRIPTION
## Summary

- **Model disposal**: Add `disposeModel()` to embedder that releases ONNX sessions between model loads, preventing OOM in the embedding benchmark when running large models (bge-large) after smaller ones. `loadModel()` now auto-disposes on model switch.
- **Node role classification**: New `roles` command classifying nodes as entry/core/utility/adapter/dead/leaf based on graph topology.
- **Incremental build improvements**: Preserve structure data during incremental rebuilds; avoid disk reads for line counts.
- **Docs reorganization**: Move guides to `docs/guides/`, roadmap to `docs/roadmap/`, fix broken links.
- **Search/CLI improvements**: Add `--json` to search, `--file` glob filter, `--exclude` to prune, exclude worktrees from vitest.
- **MCP**: Expose roles tool in MCP server.
- **Lint/format**: Fix lint warnings in roles feature.

## Test plan

- [x] All 516 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Manual verification: `disposeModel()` loads, embeds, and disposes without error
- [x] Roles integration tests cover all classification categories