### PR TITLE
fix: harden benchmark workflow against transient npm failures

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,8 +28,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
 
-      - run: npm install
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Run build benchmark
         run: node scripts/benchmark.js 2>/dev/null > benchmark-result.json
@@ -91,8 +93,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
 
-      - run: npm install
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Cache HuggingFace models
         uses: actions/cache@v4
@@ -166,8 +170,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
 
-      - run: npm install
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Run query benchmark
         run: node scripts/query-benchmark.js 2>/dev/null > query-benchmark-result.json
@@ -229,8 +235,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: "npm"
 
-      - run: npm install
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Run incremental benchmark
         run: node scripts/incremental-benchmark.js 2>/dev/null > incremental-benchmark-result.json


### PR DESCRIPTION
## Summary
- Add `cache: "npm"` to `setup-node` in all 4 benchmark jobs so packages are cached across runs
- Switch `npm install` → `npm ci --prefer-offline --no-audit --no-fund` to prefer cached packages and skip unnecessary network requests
- Fixes transient npm 403 errors (e.g. `yargs-parser@21.1.1`) that were failing the `query-benchmark` job

## Note
The `gh pr create` permission error in `build-benchmark` is a **repo settings** issue — enable "Allow GitHub Actions to create and approve pull requests" under Settings > Actions > General.

## Test plan
- [ ] Re-run benchmark workflow via `workflow_dispatch` after merge
- [ ] Confirm all 4 jobs pass the `Install dependencies` step