### PR TITLE
docs: add examples link to features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Full agent setup: [AI Agent Guide](docs/guides/ai-agent-guide.md) &middot; [CLAU
 | 🤖 | **MCP server** | 19-tool MCP server for AI assistants; single-repo by default, opt-in multi-repo |
 | ⚡ | **Always fresh** | Three-tier incremental detection — sub-second rebuilds even on large codebases |
 
+See [docs/examples](docs/examples) for real-world CLI and MCP usage examples.
+
 ## 📦 Commands
 
 ### Build & Watch


### PR DESCRIPTION
## Summary
- Added a link to `docs/examples` (CLI and MCP usage examples) below the features table in README.md