### PR TITLE
fix(ci): isolate publish concurrency by event type

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: publish
+  group: publish-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
## Summary
- Scopes the publish workflow concurrency group by `github.event_name` (`publish-push`, `publish-release`, `publish-workflow_dispatch`)
- Dev publishes (push to main) can no longer cancel an in-progress stable release, and vice versa
- Dev publishes still cancel other in-flight dev publishes as before

## Test plan
- [ ] Merge a PR to main while a release publish is in progress — both should run to completion
- [ ] Merge two PRs to main in quick succession — the second dev publish should cancel the first