### PR TITLE
feat: add `codegraph path` for A→B symbol pathfinding

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -250,6 +250,7 @@ jobs:
             exit 0
           }
 
+          # When fewer than 5 dev releases exist, OLD_TAGS is empty and the loop is a no-op
           echo "$OLD_TAGS" | while read -r tag; do
             [ -z "$tag" ] && continue
             echo "Deleting old dev release: $tag"
@@ -272,8 +273,14 @@ jobs:
           Tarballs attached to [GitHub release \`${TAG}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${TAG}).
 
           \`\`\`bash
-          # Install the main package from the release tarball:
+          # Install the main package (uses WASM fallback):
           npm install ${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG}/optave-codegraph-${VERSION}.tgz
+
+          # For native performance, also install your platform package:
+          # Linux x64:
+          npm install ${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG}/optave-codegraph-linux-x64-gnu-${VERSION}.tgz
+          # macOS arm64:
+          npm install ${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG}/optave-codegraph-darwin-arm64-${VERSION}.tgz
           \`\`\`
           EOF
 


### PR DESCRIPTION
## Summary

- Adds `codegraph path <from> <to>` — BFS shortest-path search on the call graph's edges table
- Given two symbol names, finds the shortest call chain connecting them with hop count, intermediate nodes, edge kinds, and alternate path count
- Supports `--reverse` (follow edges backward), `--max-depth`, `--kinds` (edge kind filter), `--from-file`/`--to-file` (disambiguation), `-T`, `-j`, `-k`

## Changes

**Core (5 source files):**
- `src/queries.js` — `pathData()` data function + `symbolPath()` display function
- `src/cli.js` — `codegraph path <from> <to>` command registration
- `src/mcp.js` — `symbol_path` MCP tool (17 → 18 tools)
- `src/index.js` — `pathData` re-exported for programmatic API

**Tests (3 test files):**
- `tests/integration/queries.test.js` — 11 test cases (1-hop, multi-hop, reverse, self-path, maxDepth, no-match, noTests, alternateCount, candidates)
- `tests/integration/cli.test.js` — CLI smoke test for `path --json`
- `tests/unit/mcp.test.js` — `symbol_path` in tool name list + schema test

**Docs (7 files):**
- `README.md` — commands, features table, flags, CLAUDE.md template, tool counts
- `docs/ai-agent-guide.md` — command reference card + MCP tool mapping
- `docs/recommended-practices.md` — tool list + count
- `docs/examples/CLI.md` — 4 real output examples (1-hop, multi-hop, reverse, no-path)
- `docs/examples/MCP.md` — 3 JSON examples (multi-hop, reverse, not-found)
- `.claude/skills/dogfood/SKILL.md` — expected tool count
- `generated/COMPETITIVE_ANALYSIS.md` — tool count references
- GitHub repo description updated (13-tool → 18-tool)

## Example

```
$ codegraph path resolveNoTests openDb -T

Path from resolveNoTests to openDb (2 hops):

  f resolveNoTests (function) -- src/cli.js:59
    --[calls]--> f buildGraph (function) -- src/builder.js:335
      --[calls]--> f openDb (function) -- src/db.js:76
```

## Test plan

- [x] 11 pathData unit tests pass (direct, multi-hop, reverse, self, maxDepth, no-match, noTests, alternates)
- [x] CLI smoke test passes (`path --json`)
- [x] MCP schema test passes (`symbol_path` in tool list + required params)
- [x] Full test suite passes (320 tests, 0 failures in affected files)
- [x] Lint clean (`npm run lint`)
- [x] Dogfood: `codegraph path buildGraph openDb -T` works on own codebase