### PR TITLE
feat: execution flow tracing (Backlog Item 12)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -648,6 +648,39 @@ program
   });
 
 program
+  .command('flow [name]')
+  .description(
+    'Trace execution flow forward from an entry point (route, command, event) through callees to leaves',
+  )
+  .option('--list', 'List all entry points grouped by type')
+  .option('--depth <n>', 'Max forward traversal depth', '10')
+  .option('-d, --db <path>', 'Path to graph.db')
+  .option('-f, --file <path>', 'Scope to a specific file (partial match)')
+  .option('-k, --kind <kind>', 'Filter by symbol kind')
+  .option('-T, --no-tests', 'Exclude test/spec files from results')
+  .option('--include-tests', 'Include test/spec files (overrides excludeTests config)')
+  .option('-j, --json', 'Output as JSON')
+  .action(async (name, opts) => {
+    if (!name && !opts.list) {
+      console.error('Provide a function/entry point name or use --list to see all entry points.');
+      process.exit(1);
+    }
+    if (opts.kind && !ALL_SYMBOL_KINDS.includes(opts.kind)) {
+      console.error(`Invalid kind "${opts.kind}". Valid: ${ALL_SYMBOL_KINDS.join(', ')}`);
+      process.exit(1);
+    }
+    const { flow } = await import('./flow.js');
+    flow(name, opts.db, {
+      list: opts.list,
+      depth: parseInt(opts.depth, 10),
+      file: opts.file,
+      kind: opts.kind,
+      noTests: resolveNoTests(opts),
+      json: opts.json,
+    });
+  });
+
+program
   .command('watch [dir]')
   .description('Watch project for file changes and incrementally update the graph')
   .action(async (dir) => {

--- a/src/flow.js
+++ b/src/flow.js
@@ -1,0 +1,350 @@
+/**
+ * Execution flow tracing — forward BFS from entry points through callees to leaves.
+ *
+ * Answers "what happens when a user hits POST /login?" by tracing from
+ * framework entry points (routes, commands, events) through their call chains.
+ */
+
+import { openReadonlyOrFail } from './db.js';
+import { isTestFile, kindIcon } from './queries.js';
+import { FRAMEWORK_ENTRY_PREFIXES } from './structure.js';
+
+/**
+ * Determine the entry point type from a node name based on framework prefixes.
+ * @param {string} name
+ * @returns {'route'|'event'|'command'|'exported'|null}
+ */
+export function entryPointType(name) {
+  for (const prefix of FRAMEWORK_ENTRY_PREFIXES) {
+    if (name.startsWith(prefix)) {
+      return prefix.slice(0, -1); // 'route:', 'event:', 'command:' → 'route', 'event', 'command'
+    }
+  }
+  return null;
+}
+
+/**
+ * Query all entry points from the graph, grouped by type.
+ * Entry points are nodes with framework prefixes or role = 'entry'.
+ *
+ * @param {string} [dbPath]
+ * @param {object} [opts]
+ * @param {boolean} [opts.noTests]
+ * @returns {{ entries: object[], byType: object, count: number }}
+ */
+export function listEntryPointsData(dbPath, opts = {}) {
+  const db = openReadonlyOrFail(dbPath);
+  const noTests = opts.noTests || false;
+
+  // Find all framework-prefixed nodes
+  const prefixConditions = FRAMEWORK_ENTRY_PREFIXES.map(() => 'n.name LIKE ?').join(' OR ');
+  const prefixParams = FRAMEWORK_ENTRY_PREFIXES.map((p) => `${p}%`);
+
+  let rows = db
+    .prepare(
+      `SELECT n.name, n.kind, n.file, n.line, n.role
+       FROM nodes n
+       WHERE (${prefixConditions})
+         AND n.kind NOT IN ('file', 'directory')
+       ORDER BY n.name`,
+    )
+    .all(...prefixParams);
+
+  if (noTests) rows = rows.filter((r) => !isTestFile(r.file));
+
+  const entries = rows.map((r) => ({
+    name: r.name,
+    kind: r.kind,
+    file: r.file,
+    line: r.line,
+    role: r.role,
+    type: entryPointType(r.name),
+  }));
+
+  const byType = {};
+  for (const e of entries) {
+    const t = e.type || 'other';
+    if (!byType[t]) byType[t] = [];
+    byType[t].push(e);
+  }
+
+  db.close();
+  return { entries, byType, count: entries.length };
+}
+
+/**
+ * Forward BFS from a matched node through callees to leaves.
+ *
+ * @param {string} name - Node name to trace from (supports partial/prefix-stripped matching)
+ * @param {string} [dbPath]
+ * @param {object} [opts]
+ * @param {number} [opts.depth=10]
+ * @param {boolean} [opts.noTests]
+ * @param {string} [opts.file]
+ * @param {string} [opts.kind]
+ * @returns {{ entry: object|null, depth: number, steps: object[], leaves: object[], cycles: object[], totalReached: number, truncated: boolean }}
+ */
+export function flowData(name, dbPath, opts = {}) {
+  const db = openReadonlyOrFail(dbPath);
+  const maxDepth = opts.depth || 10;
+  const noTests = opts.noTests || false;
+
+  // Phase 1: Direct LIKE match on full name
+  let matchNode = findBestMatch(db, name, opts);
+
+  // Phase 2: Prefix-stripped matching — try adding framework prefixes
+  if (!matchNode) {
+    for (const prefix of FRAMEWORK_ENTRY_PREFIXES) {
+      matchNode = findBestMatch(db, `${prefix}${name}`, opts);
+      if (matchNode) break;
+    }
+  }
+
+  if (!matchNode) {
+    db.close();
+    return {
+      entry: null,
+      depth: maxDepth,
+      steps: [],
+      leaves: [],
+      cycles: [],
+      totalReached: 0,
+      truncated: false,
+    };
+  }
+
+  const epType = entryPointType(matchNode.name);
+  const entry = {
+    name: matchNode.name,
+    kind: matchNode.kind,
+    file: matchNode.file,
+    line: matchNode.line,
+    type: epType || 'exported',
+    role: matchNode.role,
+  };
+
+  // Forward BFS through callees
+  const visited = new Set([matchNode.id]);
+  let frontier = [matchNode.id];
+  const steps = [];
+  const cycles = [];
+  let truncated = false;
+
+  // Track which nodes are at each depth and their depth for leaf detection
+  const nodeDepths = new Map();
+  const idToNode = new Map();
+  idToNode.set(matchNode.id, entry);
+
+  for (let d = 1; d <= maxDepth; d++) {
+    const nextFrontier = [];
+    const levelNodes = [];
+
+    for (const fid of frontier) {
+      const callees = db
+        .prepare(
+          `SELECT DISTINCT n.id, n.name, n.kind, n.file, n.line, n.role
+           FROM edges e JOIN nodes n ON e.target_id = n.id
+           WHERE e.source_id = ? AND e.kind = 'calls'`,
+        )
+        .all(fid);
+
+      for (const c of callees) {
+        if (noTests && isTestFile(c.file)) continue;
+
+        if (visited.has(c.id)) {
+          // Cycle detected
+          const fromNode = idToNode.get(fid);
+          if (fromNode) {
+            cycles.push({ from: fromNode.name, to: c.name, depth: d });
+          }
+          continue;
+        }
+
+        visited.add(c.id);
+        nextFrontier.push(c.id);
+        const nodeInfo = { name: c.name, kind: c.kind, file: c.file, line: c.line };
+        levelNodes.push(nodeInfo);
+        nodeDepths.set(c.id, d);
+        idToNode.set(c.id, nodeInfo);
+      }
+    }
+
+    if (levelNodes.length > 0) {
+      steps.push({ depth: d, nodes: levelNodes });
+    }
+
+    frontier = nextFrontier;
+    if (frontier.length === 0) break;
+
+    if (d === maxDepth && frontier.length > 0) {
+      truncated = true;
+    }
+  }
+
+  // Identify leaves: visited nodes that have no outgoing 'calls' edges to other visited nodes
+  // (or no outgoing calls at all)
+  const leaves = [];
+  for (const [id, depth] of nodeDepths) {
+    const outgoing = db
+      .prepare(
+        `SELECT DISTINCT n.id
+         FROM edges e JOIN nodes n ON e.target_id = n.id
+         WHERE e.source_id = ? AND e.kind = 'calls'`,
+      )
+      .all(id);
+
+    if (outgoing.length === 0) {
+      const node = idToNode.get(id);
+      if (node) {
+        leaves.push({ ...node, depth });
+      }
+    }
+  }
+
+  db.close();
+  return {
+    entry,
+    depth: maxDepth,
+    steps,
+    leaves,
+    cycles,
+    totalReached: visited.size - 1, // exclude the entry node itself
+    truncated,
+  };
+}
+
+/**
+ * Find the best matching node using the same relevance scoring as queries.js findMatchingNodes.
+ */
+function findBestMatch(db, name, opts = {}) {
+  const kinds = opts.kind
+    ? [opts.kind]
+    : [
+        'function',
+        'method',
+        'class',
+        'interface',
+        'type',
+        'struct',
+        'enum',
+        'trait',
+        'record',
+        'module',
+      ];
+  const placeholders = kinds.map(() => '?').join(', ');
+  const params = [`%${name}%`, ...kinds];
+
+  let fileCondition = '';
+  if (opts.file) {
+    fileCondition = ' AND n.file LIKE ?';
+    params.push(`%${opts.file}%`);
+  }
+
+  const rows = db
+    .prepare(
+      `SELECT n.*, COALESCE(fi.cnt, 0) AS fan_in
+       FROM nodes n
+       LEFT JOIN (
+         SELECT target_id, COUNT(*) AS cnt FROM edges WHERE kind = 'calls' GROUP BY target_id
+       ) fi ON fi.target_id = n.id
+       WHERE n.name LIKE ? AND n.kind IN (${placeholders})${fileCondition}`,
+    )
+    .all(...params);
+
+  const noTests = opts.noTests || false;
+  const nodes = noTests ? rows.filter((n) => !isTestFile(n.file)) : rows;
+
+  if (nodes.length === 0) return null;
+
+  const lowerQuery = name.toLowerCase();
+  for (const node of nodes) {
+    const lowerName = node.name.toLowerCase();
+    const bareName = lowerName.includes('.') ? lowerName.split('.').pop() : lowerName;
+
+    let matchScore;
+    if (lowerName === lowerQuery || bareName === lowerQuery) {
+      matchScore = 100;
+    } else if (lowerName.startsWith(lowerQuery) || bareName.startsWith(lowerQuery)) {
+      matchScore = 60;
+    } else if (lowerName.includes(`.${lowerQuery}`) || lowerName.includes(`${lowerQuery}.`)) {
+      matchScore = 40;
+    } else {
+      matchScore = 10;
+    }
+
+    const fanInBonus = Math.min(Math.log2(node.fan_in + 1) * 5, 25);
+    node._relevance = matchScore + fanInBonus;
+  }
+
+  nodes.sort((a, b) => b._relevance - a._relevance);
+  return nodes[0];
+}
+
+/**
+ * CLI formatter — text or JSON output.
+ */
+export function flow(name, dbPath, opts = {}) {
+  if (opts.list) {
+    const data = listEntryPointsData(dbPath, { noTests: opts.noTests });
+    if (opts.json) {
+      console.log(JSON.stringify(data, null, 2));
+      return;
+    }
+    if (data.count === 0) {
+      console.log('No entry points found. Run "codegraph build" first.');
+      return;
+    }
+    console.log(`\nEntry points (${data.count} total):\n`);
+    for (const [type, entries] of Object.entries(data.byType)) {
+      console.log(`  ${type} (${entries.length}):`);
+      for (const e of entries) {
+        console.log(`    [${kindIcon(e.kind)}] ${e.name}  ${e.file}:${e.line}`);
+      }
+      console.log();
+    }
+    return;
+  }
+
+  const data = flowData(name, dbPath, opts);
+  if (opts.json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (!data.entry) {
+    console.log(`No matching entry point or function found for "${name}".`);
+    return;
+  }
+
+  const e = data.entry;
+  const typeTag = e.type !== 'exported' ? ` (${e.type})` : '';
+  console.log(`\nFlow from: [${kindIcon(e.kind)}] ${e.name}${typeTag}  ${e.file}:${e.line}`);
+  console.log(
+    `Depth: ${data.depth}  Reached: ${data.totalReached} nodes  Leaves: ${data.leaves.length}`,
+  );
+  if (data.truncated) {
+    console.log(`  (truncated at depth ${data.depth})`);
+  }
+  console.log();
+
+  if (data.steps.length === 0) {
+    console.log('  (leaf node — no callees)');
+    return;
+  }
+
+  for (const step of data.steps) {
+    console.log(`  depth ${step.depth}:`);
+    for (const n of step.nodes) {
+      const isLeaf = data.leaves.some((l) => l.name === n.name && l.file === n.file);
+      const leafTag = isLeaf ? ' [leaf]' : '';
+      console.log(`    [${kindIcon(n.kind)}] ${n.name}  ${n.file}:${n.line}${leafTag}`);
+    }
+  }
+
+  if (data.cycles.length > 0) {
+    console.log('\n  Cycles detected:');
+    for (const c of data.cycles) {
+      console.log(`    ${c.from} -> ${c.to} (at depth ${c.depth})`);
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,6 @@ export {
   openReadonlyOrFail,
   setBuildMeta,
 } from './db.js';
-
 // Embeddings
 export {
   buildEmbeddings,
@@ -48,6 +47,8 @@ export {
 } from './embedder.js';
 // Export (DOT/Mermaid/JSON)
 export { exportDOT, exportJSON, exportMermaid } from './export.js';
+// Execution flow tracing
+export { entryPointType, flowData, listEntryPointsData } from './flow.js';
 // Logger
 export { setVerbose } from './logger.js';
 // Native engine
@@ -68,6 +69,7 @@ export {
   fnDepsData,
   fnImpactData,
   impactAnalysisData,
+  kindIcon,
   moduleMapData,
   queryNameData,
   rolesData,
@@ -90,6 +92,7 @@ export {
 export {
   buildStructure,
   classifyNodeRoles,
+  FRAMEWORK_ENTRY_PREFIXES,
   formatHotspots,
   formatModuleBoundaries,
   formatStructure,

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -338,6 +338,44 @@ const BASE_TOOLS = [
       },
     },
   },
+  {
+    name: 'execution_flow',
+    description:
+      'Trace execution flow forward from an entry point (route, command, event) through callees to leaf functions. Answers "what happens when X is called?"',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description:
+            'Entry point or function name (e.g. "POST /login", "build"). Supports prefix-stripped matching.',
+        },
+        depth: { type: 'number', description: 'Max forward traversal depth', default: 10 },
+        file: {
+          type: 'string',
+          description: 'Scope search to functions in this file (partial match)',
+        },
+        kind: {
+          type: 'string',
+          enum: ALL_SYMBOL_KINDS,
+          description: 'Filter to a specific symbol kind',
+        },
+        no_tests: { type: 'boolean', description: 'Exclude test files', default: false },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'list_entry_points',
+    description:
+      'List all framework entry points (routes, commands, events) in the codebase, grouped by type',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        no_tests: { type: 'boolean', description: 'Exclude test files', default: false },
+      },
+    },
+  },
 ];
 
 const LIST_REPOS_TOOL = {
@@ -624,6 +662,23 @@ export async function startMCPServer(customDbPath, options = {}) {
                 minJaccard: args.min_jaccard,
                 noTests: args.no_tests,
               });
+          break;
+        }
+        case 'execution_flow': {
+          const { flowData } = await import('./flow.js');
+          result = flowData(args.name, dbPath, {
+            depth: args.depth,
+            file: args.file,
+            kind: args.kind,
+            noTests: args.no_tests,
+          });
+          break;
+        }
+        case 'list_entry_points': {
+          const { listEntryPointsData } = await import('./flow.js');
+          result = listEntryPointsData(dbPath, {
+            noTests: args.no_tests,
+          });
           break;
         }
         case 'list_repos': {

--- a/src/queries.js
+++ b/src/queries.js
@@ -172,7 +172,7 @@ function findMatchingNodes(db, name, opts = {}) {
   return nodes;
 }
 
-function kindIcon(kind) {
+export function kindIcon(kind) {
   switch (kind) {
     case 'function':
       return 'f';

--- a/src/structure.js
+++ b/src/structure.js
@@ -226,6 +226,8 @@ export function buildStructure(db, fileSymbols, _rootDir, lineCountMap, director
 
 // ─── Node role classification ─────────────────────────────────────────
 
+export const FRAMEWORK_ENTRY_PREFIXES = ['route:', 'event:', 'command:'];
+
 function median(sorted) {
   if (sorted.length === 0) return 0;
   const mid = Math.floor(sorted.length / 2);
@@ -235,7 +237,7 @@ function median(sorted) {
 export function classifyNodeRoles(db) {
   const rows = db
     .prepare(
-      `SELECT n.id, n.kind, n.file,
+      `SELECT n.id, n.name, n.kind, n.file,
         COALESCE(fi.cnt, 0) AS fan_in,
         COALESCE(fo.cnt, 0) AS fan_out
       FROM nodes n
@@ -287,7 +289,10 @@ export function classifyNodeRoles(db) {
     const isExported = exportedIds.has(row.id);
 
     let role;
-    if (row.fan_in === 0 && !isExported) {
+    const isFrameworkEntry = FRAMEWORK_ENTRY_PREFIXES.some((p) => row.name.startsWith(p));
+    if (isFrameworkEntry) {
+      role = 'entry';
+    } else if (row.fan_in === 0 && !isExported) {
       role = 'dead';
     } else if (row.fan_in === 0 && isExported) {
       role = 'entry';

--- a/tests/integration/flow.test.js
+++ b/tests/integration/flow.test.js
@@ -1,0 +1,270 @@
+/**
+ * Integration tests for execution flow tracing (Backlog Item 12).
+ *
+ * Uses a hand-crafted in-memory DB with known graph topology:
+ *
+ *   route:GET /users -> validateAuth -> checkToken [leaf]
+ *                    -> fetchUsers   -> queryDB [leaf]
+ *                                    -> formatResponse [leaf]
+ *   command:build    -> loadConfig [leaf]
+ *                    -> processFiles -> parseFile [leaf]
+ *   event:connection -> setupSocket [leaf]
+ *   orphanFn         (no callers, no prefix → dead)
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { initSchema } from '../../src/db.js';
+import { entryPointType, flowData, listEntryPointsData } from '../../src/flow.js';
+import { classifyNodeRoles, FRAMEWORK_ENTRY_PREFIXES } from '../../src/structure.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function insertNode(db, name, kind, file, line) {
+  return db
+    .prepare('INSERT INTO nodes (name, kind, file, line) VALUES (?, ?, ?, ?)')
+    .run(name, kind, file, line).lastInsertRowid;
+}
+
+function insertEdge(db, sourceId, targetId, kind, confidence = 1.0) {
+  db.prepare(
+    'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, 0)',
+  ).run(sourceId, targetId, kind, confidence);
+}
+
+// ─── Fixture DB ────────────────────────────────────────────────────────
+
+let tmpDir, dbPath;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-flow-'));
+  fs.mkdirSync(path.join(tmpDir, '.codegraph'));
+  dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  initSchema(db);
+
+  // File nodes
+  const fRoutes = insertNode(db, 'routes.js', 'file', 'routes.js', 0);
+  const fAuth = insertNode(db, 'auth.js', 'file', 'auth.js', 0);
+  const fUsers = insertNode(db, 'users.js', 'file', 'users.js', 0);
+  insertNode(db, 'build.js', 'file', 'build.js', 0);
+  insertNode(db, 'socket.js', 'file', 'socket.js', 0);
+  insertNode(db, 'orphan.js', 'file', 'orphan.js', 0);
+
+  // Route entry point
+  const getUsers = insertNode(db, 'route:GET /users', 'function', 'routes.js', 5);
+  // Auth functions
+  const validateAuth = insertNode(db, 'validateAuth', 'function', 'auth.js', 1);
+  const checkToken = insertNode(db, 'checkToken', 'function', 'auth.js', 10);
+  // User functions
+  const fetchUsers = insertNode(db, 'fetchUsers', 'function', 'users.js', 1);
+  const queryDB = insertNode(db, 'queryDB', 'function', 'users.js', 10);
+  const formatResponse = insertNode(db, 'formatResponse', 'function', 'users.js', 20);
+
+  // Command entry point
+  const cmdBuild = insertNode(db, 'command:build', 'function', 'build.js', 1);
+  const loadConfig = insertNode(db, 'loadConfig', 'function', 'build.js', 10);
+  const processFiles = insertNode(db, 'processFiles', 'function', 'build.js', 20);
+  const parseFile = insertNode(db, 'parseFile', 'function', 'build.js', 30);
+
+  // Event entry point
+  const evtConnection = insertNode(db, 'event:connection', 'function', 'socket.js', 1);
+  const setupSocket = insertNode(db, 'setupSocket', 'function', 'socket.js', 10);
+
+  // Orphan (no prefix, no callers)
+  insertNode(db, 'orphanFn', 'function', 'orphan.js', 1);
+
+  // Import edges
+  insertEdge(db, fRoutes, fAuth, 'imports');
+  insertEdge(db, fRoutes, fUsers, 'imports');
+
+  // Call edges: route:GET /users -> validateAuth -> checkToken
+  insertEdge(db, getUsers, validateAuth, 'calls');
+  insertEdge(db, validateAuth, checkToken, 'calls');
+  // route:GET /users -> fetchUsers -> queryDB, formatResponse
+  insertEdge(db, getUsers, fetchUsers, 'calls');
+  insertEdge(db, fetchUsers, queryDB, 'calls');
+  insertEdge(db, fetchUsers, formatResponse, 'calls');
+
+  // command:build -> loadConfig, processFiles -> parseFile
+  insertEdge(db, cmdBuild, loadConfig, 'calls');
+  insertEdge(db, cmdBuild, processFiles, 'calls');
+  insertEdge(db, processFiles, parseFile, 'calls');
+
+  // event:connection -> setupSocket
+  insertEdge(db, evtConnection, setupSocket, 'calls');
+
+  // Classify roles (so we can test the fix)
+  classifyNodeRoles(db);
+
+  db.close();
+});
+
+afterAll(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── entryPointType ────────────────────────────────────────────────────
+
+describe('entryPointType', () => {
+  test('identifies route prefix', () => {
+    expect(entryPointType('route:GET /users')).toBe('route');
+  });
+
+  test('identifies event prefix', () => {
+    expect(entryPointType('event:connection')).toBe('event');
+  });
+
+  test('identifies command prefix', () => {
+    expect(entryPointType('command:build')).toBe('command');
+  });
+
+  test('returns null for non-prefixed names', () => {
+    expect(entryPointType('fetchUsers')).toBeNull();
+    expect(entryPointType('orphanFn')).toBeNull();
+  });
+});
+
+// ─── FRAMEWORK_ENTRY_PREFIXES ──────────────────────────────────────────
+
+describe('FRAMEWORK_ENTRY_PREFIXES', () => {
+  test('exports expected prefixes', () => {
+    expect(FRAMEWORK_ENTRY_PREFIXES).toContain('route:');
+    expect(FRAMEWORK_ENTRY_PREFIXES).toContain('event:');
+    expect(FRAMEWORK_ENTRY_PREFIXES).toContain('command:');
+  });
+});
+
+// ─── flowData ──────────────────────────────────────────────────────────
+
+describe('flowData', () => {
+  test('forward BFS from route entry reaches 5 nodes, finds 3 leaves', () => {
+    const data = flowData('route:GET /users', dbPath);
+    expect(data.entry).not.toBeNull();
+    expect(data.entry.name).toBe('route:GET /users');
+    expect(data.entry.type).toBe('route');
+    expect(data.totalReached).toBe(5);
+    expect(data.leaves).toHaveLength(3);
+    const leafNames = data.leaves.map((l) => l.name).sort();
+    expect(leafNames).toEqual(['checkToken', 'formatResponse', 'queryDB']);
+  });
+
+  test('prefix-stripped matching: "GET /users" matches "route:GET /users"', () => {
+    const data = flowData('GET /users', dbPath);
+    expect(data.entry).not.toBeNull();
+    expect(data.entry.name).toBe('route:GET /users');
+  });
+
+  test('trace from non-entry node works (fetchUsers -> 2 callees)', () => {
+    const data = flowData('fetchUsers', dbPath);
+    expect(data.entry).not.toBeNull();
+    expect(data.entry.name).toBe('fetchUsers');
+    expect(data.entry.type).toBe('exported');
+    expect(data.totalReached).toBe(2);
+    const reachedNames = data.steps.flatMap((s) => s.nodes.map((n) => n.name)).sort();
+    expect(reachedNames).toEqual(['formatResponse', 'queryDB']);
+  });
+
+  test('depth limit truncates correctly', () => {
+    const data = flowData('route:GET /users', dbPath, { depth: 1 });
+    expect(data.depth).toBe(1);
+    // At depth 1, should only reach validateAuth and fetchUsers
+    expect(data.totalReached).toBe(2);
+    expect(data.truncated).toBe(true);
+  });
+
+  test('nonexistent name returns entry: null', () => {
+    const data = flowData('nonExistentFunction', dbPath);
+    expect(data.entry).toBeNull();
+    expect(data.totalReached).toBe(0);
+    expect(data.steps).toHaveLength(0);
+  });
+
+  test('leaf node returns zero steps', () => {
+    const data = flowData('checkToken', dbPath);
+    expect(data.entry).not.toBeNull();
+    expect(data.entry.name).toBe('checkToken');
+    expect(data.totalReached).toBe(0);
+    expect(data.steps).toHaveLength(0);
+  });
+
+  test('command:build traces correctly', () => {
+    const data = flowData('command:build', dbPath);
+    expect(data.entry).not.toBeNull();
+    expect(data.entry.type).toBe('command');
+    expect(data.totalReached).toBe(3);
+    const leafNames = data.leaves.map((l) => l.name).sort();
+    expect(leafNames).toEqual(['loadConfig', 'parseFile']);
+  });
+
+  test('prefix-stripped matching for command: "build" matches "command:build"', () => {
+    const data = flowData('build', dbPath);
+    expect(data.entry).not.toBeNull();
+    expect(data.entry.name).toBe('command:build');
+  });
+});
+
+// ─── listEntryPointsData ──────────────────────────────────────────────
+
+describe('listEntryPointsData', () => {
+  test('finds all 3 framework entries, excludes orphanFn', () => {
+    const data = listEntryPointsData(dbPath);
+    expect(data.count).toBe(3);
+    const names = data.entries.map((e) => e.name).sort();
+    expect(names).toEqual(['command:build', 'event:connection', 'route:GET /users']);
+    expect(names).not.toContain('orphanFn');
+  });
+
+  test('groups by type correctly', () => {
+    const data = listEntryPointsData(dbPath);
+    expect(data.byType.route).toHaveLength(1);
+    expect(data.byType.command).toHaveLength(1);
+    expect(data.byType.event).toHaveLength(1);
+    expect(data.byType.route[0].name).toBe('route:GET /users');
+    expect(data.byType.command[0].name).toBe('command:build');
+    expect(data.byType.event[0].name).toBe('event:connection');
+  });
+
+  test('each entry includes type, kind, file, line', () => {
+    const data = listEntryPointsData(dbPath);
+    for (const e of data.entries) {
+      expect(e).toHaveProperty('name');
+      expect(e).toHaveProperty('kind');
+      expect(e).toHaveProperty('file');
+      expect(e).toHaveProperty('line');
+      expect(e).toHaveProperty('type');
+    }
+  });
+});
+
+// ─── Classification fix ───────────────────────────────────────────────
+
+describe('framework entry point classification fix', () => {
+  test('framework entry points classified as entry, not dead', () => {
+    const db = new Database(dbPath, { readonly: true });
+    const rows = db
+      .prepare(
+        `SELECT name, role FROM nodes
+         WHERE name LIKE 'route:%' OR name LIKE 'command:%' OR name LIKE 'event:%'`,
+      )
+      .all();
+    db.close();
+
+    expect(rows.length).toBe(3);
+    for (const r of rows) {
+      expect(r.role).toBe('entry');
+    }
+  });
+
+  test('orphanFn is classified as dead', () => {
+    const db = new Database(dbPath, { readonly: true });
+    const row = db.prepare(`SELECT role FROM nodes WHERE name = 'orphanFn'`).get();
+    db.close();
+    expect(row.role).toBe('dead');
+  });
+});

--- a/tests/unit/mcp.test.js
+++ b/tests/unit/mcp.test.js
@@ -27,6 +27,8 @@ const ALL_TOOL_NAMES = [
   'hotspots',
   'co_changes',
   'node_roles',
+  'execution_flow',
+  'list_entry_points',
   'list_repos',
 ];
 


### PR DESCRIPTION
## Summary

- **New `flow` command** — traces execution flow forward from entry points (routes, commands, events) through callees to leaf functions via BFS. Answers "what happens when a user hits POST /login?" in one query
- **Fix entry point misclassification** — framework-prefixed nodes (`route:`, `event:`, `command:`) were classified as `dead` because they have zero fan-in; now correctly classified as `entry`
- **Two new MCP tools** — `execution_flow` and `list_entry_points` for AI agent integration

## Changes

| File | Action |
|------|--------|
| `src/flow.js` | **New** — `flowData()`, `listEntryPointsData()`, `entryPointType()`, `flow()` CLI formatter |
| `src/structure.js` | Fix `classifyNodeRoles()` — add `n.name` to SQL, check framework prefixes before dead classification, export `FRAMEWORK_ENTRY_PREFIXES` |
| `src/queries.js` | Export `kindIcon()` (was private) |
| `src/cli.js` | Add `flow [name]` command with `--list`, `--depth`, `-f`, `-k`, `-T`, `-j` |
| `src/mcp.js` | Add `execution_flow` + `list_entry_points` tools to `BASE_TOOLS` and handler dispatch |
| `src/index.js` | Add flow exports + `kindIcon` + `FRAMEWORK_ENTRY_PREFIXES` |
| `tests/integration/flow.test.js` | **New** — 18 integration tests with hand-crafted fixture DB |
| `tests/unit/mcp.test.js` | Add new tool names to expected list |

## Test plan

- [x] 18 new integration tests pass: forward BFS, prefix-stripped matching, depth truncation, leaf detection, entry point listing, classification fix
- [x] All 373 existing tests still pass (no regressions)
- [x] Lint clean (biome)
- [ ] Manual: `codegraph build .` then `codegraph flow --list` shows framework entries
- [ ] Manual: `codegraph flow "build" -T` traces forward from command entry
- [ ] Manual: `codegraph roles --role entry -T` shows framework entries as `entry` not `dead`