### PR TITLE
fix: upgrade build metadata failure log from debug to warn

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -1043,7 +1043,7 @@ export async function buildGraph(rootDir, opts = {}) {
       built_at: new Date().toISOString(),
     });
   } catch (err) {
-    debug(`Failed to write build metadata: ${err.message}`);
+    warn(`Failed to write build metadata: ${err.message}`);
   }
 
   closeDb(db);


### PR DESCRIPTION
## Summary
- Upgrades the build metadata write failure log level from `debug` to `warn` so users are notified when metadata persistence fails (e.g. disk issues)

## Test plan
- [x] Run `npm test` to verify no regressions
- [x] Run `node src/cli.js build .` and verify incremental rebuilds work correctly
- [x] Branch rebased onto latest main