### PR TITLE
fix: benchmark uses stale native addon from npm

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,14 +46,21 @@ jobs:
       - name: Install native addon from Publish
         if: github.event_name == 'workflow_run'
         run: |
+          ARTIFACT_DIR="${{ runner.temp }}/native-artifact"
+          NODE_FILE="$ARTIFACT_DIR/codegraph-core.node"
+          if [ ! -f "$NODE_FILE" ]; then
+            echo "::error::Native addon not found at $NODE_FILE"
+            ls -la "$ARTIFACT_DIR" || true
+            exit 1
+          fi
           PKG_DIR="node_modules/@optave/codegraph-linux-x64-gnu"
           mkdir -p "$PKG_DIR"
-          cp "${{ runner.temp }}/native-artifact"/*.node "$PKG_DIR/codegraph-core.node"
-          # Ensure package.json exists so require() resolves
+          cp "$NODE_FILE" "$PKG_DIR/codegraph-core.node"
           if [ ! -f "$PKG_DIR/package.json" ]; then
             echo '{"name":"@optave/codegraph-linux-x64-gnu","main":"codegraph-core.node"}' > "$PKG_DIR/package.json"
           fi
           echo "Installed native addon from Publish workflow run ${{ github.event.workflow_run.id }}"
+          echo "  sha256: $(sha256sum "$PKG_DIR/codegraph-core.node" | cut -d' ' -f1)"
 
       - name: Run build benchmark
         run: node scripts/benchmark.js 2>/dev/null > benchmark-result.json
@@ -138,14 +145,21 @@ jobs:
       - name: Install native addon from Publish
         if: github.event_name == 'workflow_run'
         run: |
+          ARTIFACT_DIR="${{ runner.temp }}/native-artifact"
+          NODE_FILE="$ARTIFACT_DIR/codegraph-core.node"
+          if [ ! -f "$NODE_FILE" ]; then
+            echo "::error::Native addon not found at $NODE_FILE"
+            ls -la "$ARTIFACT_DIR" || true
+            exit 1
+          fi
           PKG_DIR="node_modules/@optave/codegraph-linux-x64-gnu"
           mkdir -p "$PKG_DIR"
-          cp "${{ runner.temp }}/native-artifact"/*.node "$PKG_DIR/codegraph-core.node"
-          # Ensure package.json exists so require() resolves
+          cp "$NODE_FILE" "$PKG_DIR/codegraph-core.node"
           if [ ! -f "$PKG_DIR/package.json" ]; then
             echo '{"name":"@optave/codegraph-linux-x64-gnu","main":"codegraph-core.node"}' > "$PKG_DIR/package.json"
           fi
           echo "Installed native addon from Publish workflow run ${{ github.event.workflow_run.id }}"
+          echo "  sha256: $(sha256sum "$PKG_DIR/codegraph-core.node" | cut -d' ' -f1)"
 
       - name: Cache HuggingFace models
         uses: actions/cache@v4
@@ -242,14 +256,21 @@ jobs:
       - name: Install native addon from Publish
         if: github.event_name == 'workflow_run'
         run: |
+          ARTIFACT_DIR="${{ runner.temp }}/native-artifact"
+          NODE_FILE="$ARTIFACT_DIR/codegraph-core.node"
+          if [ ! -f "$NODE_FILE" ]; then
+            echo "::error::Native addon not found at $NODE_FILE"
+            ls -la "$ARTIFACT_DIR" || true
+            exit 1
+          fi
           PKG_DIR="node_modules/@optave/codegraph-linux-x64-gnu"
           mkdir -p "$PKG_DIR"
-          cp "${{ runner.temp }}/native-artifact"/*.node "$PKG_DIR/codegraph-core.node"
-          # Ensure package.json exists so require() resolves
+          cp "$NODE_FILE" "$PKG_DIR/codegraph-core.node"
           if [ ! -f "$PKG_DIR/package.json" ]; then
             echo '{"name":"@optave/codegraph-linux-x64-gnu","main":"codegraph-core.node"}' > "$PKG_DIR/package.json"
           fi
           echo "Installed native addon from Publish workflow run ${{ github.event.workflow_run.id }}"
+          echo "  sha256: $(sha256sum "$PKG_DIR/codegraph-core.node" | cut -d' ' -f1)"
 
       - name: Run query benchmark
         run: node scripts/query-benchmark.js 2>/dev/null > query-benchmark-result.json
@@ -334,14 +355,21 @@ jobs:
       - name: Install native addon from Publish
         if: github.event_name == 'workflow_run'
         run: |
+          ARTIFACT_DIR="${{ runner.temp }}/native-artifact"
+          NODE_FILE="$ARTIFACT_DIR/codegraph-core.node"
+          if [ ! -f "$NODE_FILE" ]; then
+            echo "::error::Native addon not found at $NODE_FILE"
+            ls -la "$ARTIFACT_DIR" || true
+            exit 1
+          fi
           PKG_DIR="node_modules/@optave/codegraph-linux-x64-gnu"
           mkdir -p "$PKG_DIR"
-          cp "${{ runner.temp }}/native-artifact"/*.node "$PKG_DIR/codegraph-core.node"
-          # Ensure package.json exists so require() resolves
+          cp "$NODE_FILE" "$PKG_DIR/codegraph-core.node"
           if [ ! -f "$PKG_DIR/package.json" ]; then
             echo '{"name":"@optave/codegraph-linux-x64-gnu","main":"codegraph-core.node"}' > "$PKG_DIR/package.json"
           fi
           echo "Installed native addon from Publish workflow run ${{ github.event.workflow_run.id }}"
+          echo "  sha256: $(sha256sum "$PKG_DIR/codegraph-core.node" | cut -d' ' -f1)"
 
       - name: Run incremental benchmark
         run: node scripts/incremental-benchmark.js 2>/dev/null > incremental-benchmark-result.json


### PR DESCRIPTION
## Summary

- Downloads the just-built native artifact from the triggering Publish workflow and overlays it on top of what `npm ci` installed
- Ensures all 4 benchmark jobs (build, embedding, query, incremental) test the freshly compiled addon rather than the last stable npm release (v2.4.0)
- Adds `actions: read` permission to each job for cross-workflow artifact access
- Both new steps guarded by `if: github.event_name == 'workflow_run'` — manual `workflow_dispatch` runs skip them gracefully

## Test plan

- [ ] Push to main → Publish triggers → Benchmark triggers → verify "Install native addon from Publish" step runs
- [ ] Native benchmark numbers should reflect the just-compiled addon
- [ ] Manual `workflow_dispatch` still works (skips artifact download, falls back to npm)