### PR TITLE
fix(bench): remove unnecessary shell: true from execFileSync

### DIFF
--- a/scripts/lib/bench-config.js
+++ b/scripts/lib/bench-config.js
@@ -70,7 +70,6 @@ export async function resolveBenchmarkSource() {
 				cwd: tmpDir,
 				stdio: 'pipe',
 				timeout: 120_000,
-				shell: true,
 			});
 			break;
 		} catch (err) {


### PR DESCRIPTION
## Summary
- Add the missing v2.4.0 native engine benchmark row (measured retroactively using `@optave/codegraph@2.4.0` from npm + the v2.4.0 native addon)
- Fill in native column across all benchmark sections (raw totals, 50k-file estimates, incremental rebuilds)
- Add note explaining v2.5.0 build time increase from per-function complexity metrics (cognitive, cyclomatic, Halstead, LOC, MI)
- Add note documenting the retroactive measurement methodology for v2.4.0 native

## Test plan
- [x] Verified benchmark numbers by running actual v2.4.0 npm package with native addon
- [x] Cross-checked nodes/edges/DB size match between native and WASM at v2.4.0
- [x] JSON data block updated consistently with markdown tables