### PR TITLE
feat: add CODEOWNERS integration

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -824,6 +824,29 @@ program
   });
 
 program
+  .command('owners [target]')
+  .description('Show CODEOWNERS mapping for files and functions')
+  .option('-d, --db <path>', 'Path to graph.db')
+  .option('--owner <owner>', 'Filter to a specific owner')
+  .option('--boundary', 'Show cross-owner boundary edges')
+  .option('-f, --file <path>', 'Scope to a specific file')
+  .option('-k, --kind <kind>', 'Filter by symbol kind')
+  .option('-T, --no-tests', 'Exclude test/spec files')
+  .option('--include-tests', 'Include test/spec files (overrides excludeTests config)')
+  .option('-j, --json', 'Output as JSON')
+  .action(async (target, opts) => {
+    const { owners } = await import('./owners.js');
+    owners(opts.db, {
+      owner: opts.owner,
+      boundary: opts.boundary,
+      file: opts.file || target,
+      kind: opts.kind,
+      noTests: resolveNoTests(opts),
+      json: opts.json,
+    });
+  });
+
+program
   .command('branch-compare <base> <target>')
   .description('Compare code structure between two branches/refs')
   .option('--depth <n>', 'Max transitive caller depth', '3')

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,8 @@ export { setVerbose } from './logger.js';
 export { manifesto, manifestoData, RULE_DEFS } from './manifesto.js';
 // Native engine
 export { isNativeAvailable } from './native.js';
+// Ownership (CODEOWNERS)
+export { matchOwners, owners, ownersData, ownersForFiles, parseCodeowners } from './owners.js';
 // Pagination utilities
 export { MCP_DEFAULTS, MCP_MAX_LIMIT, paginate, paginateResult } from './paginate.js';
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -491,6 +491,28 @@ const BASE_TOOLS = [
       },
     },
   },
+  {
+    name: 'code_owners',
+    description:
+      'Show CODEOWNERS mapping for files and functions. Shows ownership coverage, per-owner breakdown, and cross-owner boundary edges.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', description: 'Scope to a specific file (partial match)' },
+        owner: { type: 'string', description: 'Filter to a specific owner (e.g. @team-name)' },
+        boundary: {
+          type: 'boolean',
+          description: 'Show cross-owner boundary edges',
+          default: false,
+        },
+        kind: {
+          type: 'string',
+          description: 'Filter by symbol kind (function, method, class, etc.)',
+        },
+        no_tests: { type: 'boolean', description: 'Exclude test files', default: false },
+      },
+    },
+  },
 ];
 
 const LIST_REPOS_TOOL = {
@@ -855,6 +877,17 @@ export async function startMCPServer(customDbPath, options = {}) {
             functions: args.functions,
             resolution: args.resolution,
             drift: args.drift,
+            noTests: args.no_tests,
+          });
+          break;
+        }
+        case 'code_owners': {
+          const { ownersData } = await import('./owners.js');
+          result = ownersData(dbPath, {
+            file: args.file,
+            owner: args.owner,
+            boundary: args.boundary,
+            kind: args.kind,
             noTests: args.no_tests,
           });
           break;

--- a/src/owners.js
+++ b/src/owners.js
@@ -1,0 +1,342 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { findDbPath, openReadonlyOrFail } from './db.js';
+
+import { isTestFile } from './queries.js';
+
+// ─── CODEOWNERS Parsing ──────────────────────────────────────────────
+
+const CODEOWNERS_PATHS = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'];
+
+/**
+ * Find and parse a CODEOWNERS file from the standard locations.
+ * @param {string} rootDir - Repository root directory
+ * @returns {{ rules: Array<{pattern: string, owners: string[], regex: RegExp}>, path: string } | null}
+ */
+export function parseCodeowners(rootDir) {
+  for (const rel of CODEOWNERS_PATHS) {
+    const fullPath = path.join(rootDir, rel);
+    if (fs.existsSync(fullPath)) {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      return { rules: parseCodeownersContent(content), path: rel };
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse CODEOWNERS file content into rules.
+ * @param {string} content - Raw CODEOWNERS file content
+ * @returns {Array<{pattern: string, owners: string[], regex: RegExp}>}
+ */
+export function parseCodeownersContent(content) {
+  const rules = [];
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 2) continue;
+    const pattern = parts[0];
+    const owners = parts.slice(1).filter((p) => p.startsWith('@') || p.includes('@'));
+    if (owners.length === 0) continue;
+    rules.push({ pattern, owners, regex: patternToRegex(pattern) });
+  }
+  return rules;
+}
+
+/**
+ * Convert a CODEOWNERS glob pattern to a RegExp.
+ *
+ * CODEOWNERS semantics:
+ * - Leading `/` anchors to repo root; without it, matches anywhere
+ * - `*` matches anything except `/`
+ * - `**` matches everything including `/`
+ * - Trailing `/` matches directory contents
+ * - A bare filename like `Makefile` matches anywhere
+ */
+export function patternToRegex(pattern) {
+  let p = pattern;
+  const anchored = p.startsWith('/');
+  if (anchored) p = p.slice(1);
+
+  const dirMatch = p.endsWith('/');
+  if (dirMatch) p = p.slice(0, -1);
+
+  // Escape regex specials except * and ?
+  let regex = p.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+
+  // Replace ? first (single non-slash char) before ** handling
+  regex = regex.replace(/\?/g, '[^/]');
+
+  // Handle **/ (zero or more directories) and /** (everything below)
+  // Use placeholders to prevent single-* replacement from clobbering
+  regex = regex.replace(/\*\*\//g, '<DSS>');
+  regex = regex.replace(/\/\*\*/g, '<DSE>');
+  regex = regex.replace(/\*\*/g, '<DS>');
+  regex = regex.replace(/\*/g, '[^/]*');
+  regex = regex.replace(/<DSS>/g, '(.*/)?');
+  regex = regex.replace(/<DSE>/g, '/.*');
+  regex = regex.replace(/<DS>/g, '.*');
+
+  if (dirMatch) {
+    // Pattern like `docs/` matches everything under docs/
+    regex = anchored ? `^${regex}/` : `(?:^|/)${regex}/`;
+  } else if (anchored) {
+    regex = `^${regex}$`;
+  } else if (!regex.includes('/')) {
+    // Bare filename like `Makefile` or `*.js` — match anywhere
+    regex = `(?:^|/)${regex}$`;
+  } else {
+    // Pattern with path separators but not anchored — match at start or after /
+    regex = `(?:^|/)${regex}$`;
+  }
+
+  return new RegExp(regex);
+}
+
+/**
+ * Find the owners for a file path. CODEOWNERS uses last-match-wins semantics.
+ * @param {string} filePath - Relative file path (forward slashes)
+ * @param {Array<{pattern: string, owners: string[], regex: RegExp}>} rules
+ * @returns {string[]}
+ */
+export function matchOwners(filePath, rules) {
+  let owners = [];
+  for (const rule of rules) {
+    if (rule.regex.test(filePath)) {
+      owners = rule.owners;
+    }
+  }
+  return owners;
+}
+
+// ─── Data Functions ──────────────────────────────────────────────────
+
+/**
+ * Lightweight helper for diff-impact integration.
+ * Returns owner mapping for a list of file paths.
+ * @param {string[]} filePaths - Relative file paths
+ * @param {string} repoRoot - Repository root directory
+ * @returns {{ owners: Map<string, string[]>, affectedOwners: string[], suggestedReviewers: string[] }}
+ */
+export function ownersForFiles(filePaths, repoRoot) {
+  const parsed = parseCodeowners(repoRoot);
+  if (!parsed) return { owners: new Map(), affectedOwners: [], suggestedReviewers: [] };
+
+  const ownersMap = new Map();
+  const ownerSet = new Set();
+  for (const file of filePaths) {
+    const fileOwners = matchOwners(file, parsed.rules);
+    ownersMap.set(file, fileOwners);
+    for (const o of fileOwners) ownerSet.add(o);
+  }
+  const affectedOwners = [...ownerSet].sort();
+  return { owners: ownersMap, affectedOwners, suggestedReviewers: affectedOwners };
+}
+
+/**
+ * Full ownership data for the graph.
+ * @param {string} [customDbPath]
+ * @param {object} [opts]
+ * @param {string} [opts.owner] - Filter to a specific owner
+ * @param {string} [opts.file] - Filter by partial file path
+ * @param {string} [opts.kind] - Filter by symbol kind
+ * @param {boolean} [opts.noTests] - Exclude test files
+ * @param {boolean} [opts.boundary] - Show cross-owner boundary edges
+ */
+export function ownersData(customDbPath, opts = {}) {
+  const db = openReadonlyOrFail(customDbPath);
+  const dbPath = findDbPath(customDbPath);
+  const repoRoot = path.resolve(path.dirname(dbPath), '..');
+
+  const parsed = parseCodeowners(repoRoot);
+  if (!parsed) {
+    db.close();
+    return {
+      codeownersFile: null,
+      files: [],
+      symbols: [],
+      boundaries: [],
+      summary: {
+        totalFiles: 0,
+        ownedFiles: 0,
+        unownedFiles: 0,
+        coveragePercent: 0,
+        ownerCount: 0,
+        byOwner: [],
+      },
+    };
+  }
+
+  // Get all distinct files from nodes
+  let allFiles = db
+    .prepare('SELECT DISTINCT file FROM nodes')
+    .all()
+    .map((r) => r.file);
+
+  if (opts.noTests) allFiles = allFiles.filter((f) => !isTestFile(f));
+  if (opts.file) {
+    const filter = opts.file;
+    allFiles = allFiles.filter((f) => f.includes(filter));
+  }
+
+  // Map files to owners
+  const fileOwners = allFiles.map((file) => ({
+    file,
+    owners: matchOwners(file, parsed.rules),
+  }));
+
+  // Build owner-to-files index
+  const ownerIndex = new Map();
+  let ownedCount = 0;
+  for (const fo of fileOwners) {
+    if (fo.owners.length > 0) ownedCount++;
+    for (const o of fo.owners) {
+      if (!ownerIndex.has(o)) ownerIndex.set(o, []);
+      ownerIndex.get(o).push(fo.file);
+    }
+  }
+
+  // Filter files if --owner specified
+  let filteredFiles = fileOwners;
+  if (opts.owner) {
+    filteredFiles = fileOwners.filter((fo) => fo.owners.includes(opts.owner));
+  }
+
+  // Get symbols for filtered files
+  const fileSet = new Set(filteredFiles.map((fo) => fo.file));
+  let symbols = db
+    .prepare('SELECT name, kind, file, line FROM nodes')
+    .all()
+    .filter((n) => fileSet.has(n.file));
+
+  if (opts.noTests) symbols = symbols.filter((s) => !isTestFile(s.file));
+  if (opts.kind) symbols = symbols.filter((s) => s.kind === opts.kind);
+
+  const symbolsWithOwners = symbols.map((s) => ({
+    ...s,
+    owners: matchOwners(s.file, parsed.rules),
+  }));
+
+  // Boundary analysis — cross-owner call edges
+  const boundaries = [];
+  if (opts.boundary) {
+    const edges = db
+      .prepare(
+        `SELECT e.id, e.kind AS edgeKind,
+                s.name AS srcName, s.kind AS srcKind, s.file AS srcFile, s.line AS srcLine,
+                t.name AS tgtName, t.kind AS tgtKind, t.file AS tgtFile, t.line AS tgtLine
+         FROM edges e
+         JOIN nodes s ON e.source_id = s.id
+         JOIN nodes t ON e.target_id = t.id
+         WHERE e.kind = 'calls'`,
+      )
+      .all();
+
+    for (const e of edges) {
+      if (opts.noTests && (isTestFile(e.srcFile) || isTestFile(e.tgtFile))) continue;
+      const srcOwners = matchOwners(e.srcFile, parsed.rules);
+      const tgtOwners = matchOwners(e.tgtFile, parsed.rules);
+      // Cross-boundary: different owner sets
+      const srcKey = srcOwners.sort().join(',');
+      const tgtKey = tgtOwners.sort().join(',');
+      if (srcKey !== tgtKey) {
+        boundaries.push({
+          from: {
+            name: e.srcName,
+            kind: e.srcKind,
+            file: e.srcFile,
+            line: e.srcLine,
+            owners: srcOwners,
+          },
+          to: {
+            name: e.tgtName,
+            kind: e.tgtKind,
+            file: e.tgtFile,
+            line: e.tgtLine,
+            owners: tgtOwners,
+          },
+          edgeKind: e.edgeKind,
+        });
+      }
+    }
+  }
+
+  // Summary
+  const byOwner = [...ownerIndex.entries()]
+    .map(([owner, files]) => ({ owner, fileCount: files.length }))
+    .sort((a, b) => b.fileCount - a.fileCount);
+
+  db.close();
+  return {
+    codeownersFile: parsed.path,
+    files: filteredFiles,
+    symbols: symbolsWithOwners,
+    boundaries,
+    summary: {
+      totalFiles: allFiles.length,
+      ownedFiles: ownedCount,
+      unownedFiles: allFiles.length - ownedCount,
+      coveragePercent: allFiles.length > 0 ? Math.round((ownedCount / allFiles.length) * 100) : 0,
+      ownerCount: ownerIndex.size,
+      byOwner,
+    },
+  };
+}
+
+// ─── CLI Display ─────────────────────────────────────────────────────
+
+/**
+ * CLI display function for the `owners` command.
+ * @param {string} [customDbPath]
+ * @param {object} [opts]
+ */
+export function owners(customDbPath, opts = {}) {
+  const data = ownersData(customDbPath, opts);
+  if (opts.json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (!data.codeownersFile) {
+    console.log('No CODEOWNERS file found.');
+    return;
+  }
+
+  console.log(`\nCODEOWNERS: ${data.codeownersFile}\n`);
+
+  const s = data.summary;
+  console.log(
+    `  Coverage: ${s.coveragePercent}% (${s.ownedFiles}/${s.totalFiles} files owned, ${s.ownerCount} owners)\n`,
+  );
+
+  if (s.byOwner.length > 0) {
+    console.log('  Owners:\n');
+    for (const o of s.byOwner) {
+      console.log(`    ${o.owner}  ${o.fileCount} files`);
+    }
+    console.log();
+  }
+
+  if (data.files.length > 0 && opts.owner) {
+    console.log(`  Files owned by ${opts.owner}:\n`);
+    for (const f of data.files) {
+      console.log(`    ${f.file}`);
+    }
+    console.log();
+  }
+
+  if (data.boundaries.length > 0) {
+    console.log(`  Cross-owner boundaries: ${data.boundaries.length} edges\n`);
+    const shown = data.boundaries.slice(0, 30);
+    for (const b of shown) {
+      const srcOwner = b.from.owners.join(', ') || '(unowned)';
+      const tgtOwner = b.to.owners.join(', ') || '(unowned)';
+      console.log(`    ${b.from.name} [${srcOwner}] -> ${b.to.name} [${tgtOwner}]`);
+    }
+    if (data.boundaries.length > 30) {
+      console.log(`    ... and ${data.boundaries.length - 30} more`);
+    }
+    console.log();
+  }
+}

--- a/src/queries.js
+++ b/src/queries.js
@@ -5,6 +5,7 @@ import { coChangeForFiles } from './cochange.js';
 import { findCycles } from './cycles.js';
 import { findDbPath, openReadonlyOrFail } from './db.js';
 import { debug } from './logger.js';
+import { ownersForFiles } from './owners.js';
 import { paginateResult } from './paginate.js';
 import { LANGUAGE_REGISTRY } from './parser.js';
 
@@ -998,6 +999,22 @@ export function diffImpactData(customDbPath, opts = {}) {
     /* co_changes table doesn't exist — skip silently */
   }
 
+  // Look up CODEOWNERS for changed + affected files
+  let ownership = null;
+  try {
+    const allFilePaths = [...new Set([...changedRanges.keys(), ...affectedFiles])];
+    const ownerResult = ownersForFiles(allFilePaths, repoRoot);
+    if (ownerResult.affectedOwners.length > 0) {
+      ownership = {
+        owners: Object.fromEntries(ownerResult.owners),
+        affectedOwners: ownerResult.affectedOwners,
+        suggestedReviewers: ownerResult.suggestedReviewers,
+      };
+    }
+  } catch {
+    /* CODEOWNERS missing or unreadable — skip silently */
+  }
+
   db.close();
   return {
     changedFiles: changedRanges.size,
@@ -1005,11 +1022,13 @@ export function diffImpactData(customDbPath, opts = {}) {
     affectedFunctions: functionResults,
     affectedFiles: [...affectedFiles],
     historicallyCoupled,
+    ownership,
     summary: {
       functionsChanged: affectedFunctions.length,
       callersAffected: allAffected.size,
       filesAffected: affectedFiles.size,
       historicallyCoupledCount: historicallyCoupled.length,
+      ownersAffected: ownership ? ownership.affectedOwners.length : 0,
     },
   };
 }
@@ -2845,10 +2864,17 @@ export function diffImpact(customDbPath, opts = {}) {
       );
     }
   }
+  if (data.ownership) {
+    console.log(`\n  Affected owners: ${data.ownership.affectedOwners.join(', ')}`);
+    console.log(`  Suggested reviewers: ${data.ownership.suggestedReviewers.join(', ')}`);
+  }
   if (data.summary) {
     let summaryLine = `\n  Summary: ${data.summary.functionsChanged} functions changed -> ${data.summary.callersAffected} callers affected across ${data.summary.filesAffected} files`;
     if (data.summary.historicallyCoupledCount > 0) {
       summaryLine += `, ${data.summary.historicallyCoupledCount} historically coupled`;
+    }
+    if (data.summary.ownersAffected > 0) {
+      summaryLine += `, ${data.summary.ownersAffected} owners affected`;
     }
     console.log(`${summaryLine}\n`);
   }

--- a/tests/integration/owners.test.js
+++ b/tests/integration/owners.test.js
@@ -1,0 +1,194 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { initSchema } from '../../src/db.js';
+import { ownersData, ownersForFiles } from '../../src/owners.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function insertNode(db, name, kind, file, line) {
+  return db
+    .prepare('INSERT INTO nodes (name, kind, file, line) VALUES (?, ?, ?, ?)')
+    .run(name, kind, file, line).lastInsertRowid;
+}
+
+function insertEdge(db, sourceId, targetId, kind, confidence = 1.0) {
+  db.prepare(
+    'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, 0)',
+  ).run(sourceId, targetId, kind, confidence);
+}
+
+// ─── Fixture DB ────────────────────────────────────────────────────────
+
+let tmpDir, dbPath;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-owners-'));
+  fs.mkdirSync(path.join(tmpDir, '.codegraph'));
+  dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  initSchema(db);
+
+  // ── Function nodes across directories ──
+  const fnLogin = insertNode(db, 'login', 'function', 'src/auth/login.js', 5);
+  const fnSession = insertNode(db, 'createSession', 'function', 'src/auth/session.js', 5);
+  const fnQuery = insertNode(db, 'query', 'function', 'src/data/db.js', 5);
+  const fnCache = insertNode(db, 'getCache', 'function', 'src/data/cache.js', 5);
+  const fnHandler = insertNode(db, 'handleRequest', 'function', 'src/api/handler.js', 5);
+  insertNode(db, 'formatOutput', 'method', 'src/utils/format.js', 10);
+  insertNode(db, 'testLogin', 'function', 'tests/auth.test.js', 5);
+
+  // ── Cross-owner call edges ──
+  // auth -> data (cross-boundary)
+  insertEdge(db, fnLogin, fnQuery, 'calls');
+  // auth -> auth (same owner)
+  insertEdge(db, fnLogin, fnSession, 'calls');
+  // api -> auth (cross-boundary)
+  insertEdge(db, fnHandler, fnLogin, 'calls');
+  // api -> data (cross-boundary)
+  insertEdge(db, fnHandler, fnCache, 'calls');
+
+  // ── CODEOWNERS file ──
+  const codeowners = `# Ownership rules
+* @default-team
+/src/auth/ @security-team
+/src/data/ @data-team
+/src/api/ @api-team
+/src/utils/ @utils-team
+`;
+  fs.writeFileSync(path.join(tmpDir, 'CODEOWNERS'), codeowners);
+
+  db.close();
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── ownersData ────────────────────────────────────────────────────────
+
+describe('ownersData', () => {
+  test('returns correct coverage and owner counts', () => {
+    const data = ownersData(dbPath);
+    expect(data.codeownersFile).toBe('CODEOWNERS');
+    expect(data.summary.totalFiles).toBe(7);
+    expect(data.summary.ownedFiles).toBe(7); // * @default-team catches all
+    expect(data.summary.coveragePercent).toBe(100);
+    expect(data.summary.ownerCount).toBeGreaterThanOrEqual(5);
+  });
+
+  test('maps files to correct owners (last-match-wins)', () => {
+    const data = ownersData(dbPath);
+    const authFile = data.files.find((f) => f.file === 'src/auth/login.js');
+    expect(authFile.owners).toEqual(['@security-team']);
+    const dataFile = data.files.find((f) => f.file === 'src/data/db.js');
+    expect(dataFile.owners).toEqual(['@data-team']);
+    const testFile = data.files.find((f) => f.file === 'tests/auth.test.js');
+    expect(testFile.owners).toEqual(['@default-team']);
+  });
+
+  test('--owner filter returns only matching files', () => {
+    const data = ownersData(dbPath, { owner: '@security-team' });
+    expect(data.files.every((f) => f.owners.includes('@security-team'))).toBe(true);
+    expect(data.files.length).toBe(2); // login.js, session.js
+  });
+
+  test('--file filter scopes to matching paths', () => {
+    const data = ownersData(dbPath, { file: 'src/data/' });
+    expect(data.files.length).toBe(2);
+    expect(data.files.every((f) => f.file.includes('src/data/'))).toBe(true);
+  });
+
+  test('--noTests excludes test files', () => {
+    const data = ownersData(dbPath, { noTests: true });
+    expect(data.files.some((f) => f.file.includes('test'))).toBe(false);
+    expect(data.summary.totalFiles).toBe(6);
+  });
+
+  test('--kind filters symbols', () => {
+    const data = ownersData(dbPath, { kind: 'method' });
+    expect(data.symbols.every((s) => s.kind === 'method')).toBe(true);
+    expect(data.symbols.length).toBe(1); // formatOutput
+  });
+
+  test('--boundary returns cross-owner edges', () => {
+    const data = ownersData(dbPath, { boundary: true });
+    expect(data.boundaries.length).toBeGreaterThan(0);
+    // login -> query crosses auth -> data
+    const authToData = data.boundaries.find(
+      (b) => b.from.name === 'login' && b.to.name === 'query',
+    );
+    expect(authToData).toBeDefined();
+    expect(authToData.from.owners).toEqual(['@security-team']);
+    expect(authToData.to.owners).toEqual(['@data-team']);
+  });
+
+  test('same-owner edges are excluded from boundaries', () => {
+    const data = ownersData(dbPath, { boundary: true });
+    const sameOwner = data.boundaries.find(
+      (b) => b.from.name === 'login' && b.to.name === 'createSession',
+    );
+    expect(sameOwner).toBeUndefined();
+  });
+});
+
+// ─── ownersForFiles ──────────────────────────────────────────────────
+
+describe('ownersForFiles', () => {
+  test('returns correct owners map', () => {
+    const result = ownersForFiles(['src/auth/login.js', 'src/data/db.js', 'README.md'], tmpDir);
+    expect(result.owners.get('src/auth/login.js')).toEqual(['@security-team']);
+    expect(result.owners.get('src/data/db.js')).toEqual(['@data-team']);
+    expect(result.owners.get('README.md')).toEqual(['@default-team']);
+  });
+
+  test('returns affected owners and suggested reviewers', () => {
+    const result = ownersForFiles(['src/auth/login.js', 'src/data/db.js'], tmpDir);
+    expect(result.affectedOwners).toContain('@security-team');
+    expect(result.affectedOwners).toContain('@data-team');
+    expect(result.suggestedReviewers.length).toBeGreaterThan(0);
+  });
+
+  test('returns empty when no CODEOWNERS', () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeowners-empty-'));
+    try {
+      const result = ownersForFiles(['src/app.js'], emptyDir);
+      expect(result.owners.size).toBe(0);
+      expect(result.affectedOwners).toEqual([]);
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── No CODEOWNERS ───────────────────────────────────────────────────
+
+describe('graceful degradation', () => {
+  test('ownersData returns null codeownersFile when missing', () => {
+    // Create a temp DB without CODEOWNERS
+    const noOwnerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-noowners-'));
+    fs.mkdirSync(path.join(noOwnerDir, '.codegraph'));
+    const noOwnerDb = path.join(noOwnerDir, '.codegraph', 'graph.db');
+    const db = new Database(noOwnerDb);
+    db.pragma('journal_mode = WAL');
+    initSchema(db);
+    insertNode(db, 'hello', 'function', 'src/main.js', 1);
+    db.close();
+
+    try {
+      const data = ownersData(noOwnerDb);
+      expect(data.codeownersFile).toBeNull();
+      expect(data.files).toEqual([]);
+      expect(data.symbols).toEqual([]);
+      expect(data.boundaries).toEqual([]);
+      expect(data.summary.totalFiles).toBe(0);
+    } finally {
+      fs.rmSync(noOwnerDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/mcp.test.js
+++ b/tests/unit/mcp.test.js
@@ -33,6 +33,7 @@ const ALL_TOOL_NAMES = [
   'complexity',
   'manifesto',
   'communities',
+  'code_owners',
   'list_repos',
 ];
 

--- a/tests/unit/owners.test.js
+++ b/tests/unit/owners.test.js
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  matchOwners,
+  parseCodeowners,
+  parseCodeownersContent,
+  patternToRegex,
+} from '../../src/owners.js';
+
+// ─── parseCodeownersContent ──────────────────────────────────────────
+
+describe('parseCodeownersContent', () => {
+  it('skips comments and empty lines', () => {
+    const content = `# This is a comment
+
+# Another comment
+*.js @frontend
+`;
+    const rules = parseCodeownersContent(content);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].pattern).toBe('*.js');
+    expect(rules[0].owners).toEqual(['@frontend']);
+  });
+
+  it('parses multi-owner rules', () => {
+    const rules = parseCodeownersContent('src/ @team-a @team-b @user1');
+    expect(rules).toHaveLength(1);
+    expect(rules[0].owners).toEqual(['@team-a', '@team-b', '@user1']);
+  });
+
+  it('parses email-style owners', () => {
+    const rules = parseCodeownersContent('*.py dev@example.com @python-team');
+    expect(rules).toHaveLength(1);
+    expect(rules[0].owners).toEqual(['dev@example.com', '@python-team']);
+  });
+
+  it('skips lines with no owners', () => {
+    const rules = parseCodeownersContent('*.js\nsrc/ @team');
+    expect(rules).toHaveLength(1);
+    expect(rules[0].pattern).toBe('src/');
+  });
+
+  it('handles multiple rules', () => {
+    const content = `* @default
+/src/ @dev-team
+*.test.js @qa-team`;
+    const rules = parseCodeownersContent(content);
+    expect(rules).toHaveLength(3);
+  });
+});
+
+// ─── patternToRegex ──────────────────────────────────────────────────
+
+describe('patternToRegex', () => {
+  it('matches *.js anywhere', () => {
+    const re = patternToRegex('*.js');
+    expect(re.test('app.js')).toBe(true);
+    expect(re.test('src/app.js')).toBe(true);
+    expect(re.test('src/deep/app.js')).toBe(true);
+    expect(re.test('app.ts')).toBe(false);
+  });
+
+  it('matches /src/*.js anchored to root', () => {
+    const re = patternToRegex('/src/*.js');
+    expect(re.test('src/app.js')).toBe(true);
+    expect(re.test('src/utils.js')).toBe(true);
+    expect(re.test('src/deep/app.js')).toBe(false);
+    expect(re.test('lib/src/app.js')).toBe(false);
+  });
+
+  it('matches /docs/**/*.md with double-star', () => {
+    const re = patternToRegex('/docs/**/*.md');
+    expect(re.test('docs/readme.md')).toBe(true);
+    expect(re.test('docs/api/ref.md')).toBe(true);
+    expect(re.test('docs/deep/nested/file.md')).toBe(true);
+    expect(re.test('lib/docs/readme.md')).toBe(false);
+    expect(re.test('docs/readme.txt')).toBe(false);
+  });
+
+  it('matches src/ as directory (contents under it)', () => {
+    const re = patternToRegex('src/');
+    expect(re.test('src/app.js')).toBe(true);
+    expect(re.test('src/deep/file.js')).toBe(true);
+    expect(re.test('lib/src/app.js')).toBe(true);
+    expect(re.test('srcfile.js')).toBe(false);
+  });
+
+  it('matches /Makefile anchored bare filename', () => {
+    const re = patternToRegex('/Makefile');
+    expect(re.test('Makefile')).toBe(true);
+    expect(re.test('sub/Makefile')).toBe(false);
+  });
+
+  it('matches * (everything)', () => {
+    const re = patternToRegex('*');
+    expect(re.test('anything.js')).toBe(true);
+    expect(re.test('src/deep/file.py')).toBe(true);
+  });
+
+  it('matches bare filename anywhere', () => {
+    const re = patternToRegex('Makefile');
+    expect(re.test('Makefile')).toBe(true);
+    expect(re.test('sub/Makefile')).toBe(true);
+  });
+
+  it('matches /src/ anchored directory', () => {
+    const re = patternToRegex('/src/');
+    expect(re.test('src/app.js')).toBe(true);
+    expect(re.test('src/deep/file.js')).toBe(true);
+    expect(re.test('lib/src/app.js')).toBe(false);
+  });
+});
+
+// ─── matchOwners ─────────────────────────────────────────────────────
+
+describe('matchOwners', () => {
+  it('returns last-match-wins', () => {
+    const rules = parseCodeownersContent(`* @default
+/src/ @dev-team
+/src/auth/ @security-team`);
+    expect(matchOwners('src/auth/login.js', rules)).toEqual(['@security-team']);
+    expect(matchOwners('src/utils.js', rules)).toEqual(['@dev-team']);
+    expect(matchOwners('README.md', rules)).toEqual(['@default']);
+  });
+
+  it('returns empty array for unowned files', () => {
+    const rules = parseCodeownersContent('/src/ @dev-team');
+    expect(matchOwners('lib/utils.js', rules)).toEqual([]);
+  });
+
+  it('handles multiple overlapping rules', () => {
+    const rules = parseCodeownersContent(`* @fallback
+*.js @js-team
+/src/*.js @src-team`);
+    expect(matchOwners('src/app.js', rules)).toEqual(['@src-team']);
+    expect(matchOwners('lib/app.js', rules)).toEqual(['@js-team']);
+    expect(matchOwners('readme.md', rules)).toEqual(['@fallback']);
+  });
+});
+
+// ─── parseCodeowners ─────────────────────────────────────────────────
+
+describe('parseCodeowners', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeowners-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no CODEOWNERS file exists', () => {
+    expect(parseCodeowners(tmpDir)).toBeNull();
+  });
+
+  it('finds CODEOWNERS at root', () => {
+    fs.writeFileSync(path.join(tmpDir, 'CODEOWNERS'), '* @root-team\n');
+    const result = parseCodeowners(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result.path).toBe('CODEOWNERS');
+    expect(result.rules).toHaveLength(1);
+  });
+
+  it('finds .github/CODEOWNERS', () => {
+    fs.mkdirSync(path.join(tmpDir, '.github'));
+    fs.writeFileSync(path.join(tmpDir, '.github', 'CODEOWNERS'), '/src/ @dev\n');
+    const result = parseCodeowners(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result.path).toBe('.github/CODEOWNERS');
+  });
+
+  it('finds docs/CODEOWNERS', () => {
+    fs.mkdirSync(path.join(tmpDir, 'docs'));
+    fs.writeFileSync(path.join(tmpDir, 'docs', 'CODEOWNERS'), '/docs/ @docs-team\n');
+    const result = parseCodeowners(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result.path).toBe('docs/CODEOWNERS');
+  });
+
+  it('prefers root CODEOWNERS over .github/', () => {
+    fs.writeFileSync(path.join(tmpDir, 'CODEOWNERS'), '* @root\n');
+    fs.mkdirSync(path.join(tmpDir, '.github'));
+    fs.writeFileSync(path.join(tmpDir, '.github', 'CODEOWNERS'), '* @github\n');
+    const result = parseCodeowners(tmpDir);
+    expect(result.path).toBe('CODEOWNERS');
+    expect(result.rules[0].owners).toEqual(['@root']);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/owners.js` module: CODEOWNERS parser, matcher, and data functions (`ownersData`, `ownersForFiles`, `owners` CLI display)
- Add `codegraph owners [target]` CLI command with `--owner`, `--boundary`, `-f`, `-k`, `-T`, `-j` options
- Add `code_owners` MCP tool for AI agent access
- Integrate ownership into `diff-impact`: shows affected owners and suggested reviewers
- No new dependencies — CODEOWNERS glob patterns handled by a ~30-line `patternToRegex`
- No DB schema changes — ownership derived at query time from CODEOWNERS + node file paths
- Graceful degradation when no CODEOWNERS file exists

Closes #18

## Test plan

- [x] 21 unit tests for parser, regex, matching, file discovery (`tests/unit/owners.test.js`)
- [x] 12 integration tests with temp DB + CODEOWNERS fixture (`tests/integration/owners.test.js`)
- [x] MCP tool list test updated (`tests/unit/mcp.test.js`)
- [ ] Manual: create CODEOWNERS, run `codegraph owners`, `codegraph owners --boundary`, `codegraph diff-impact --staged`