### PR TITLE
fix(docs): correct MCP tool count in README (24/25 → 26/27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Optional: `@huggingface/transformers` (semantic search), `@modelcontextprotocol/
 
 ### MCP Server
 
-Codegraph includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server with 24 tools (25 in multi-repo mode), so AI assistants can query your dependency graph directly:
+Codegraph includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server with 26 tools (27 in multi-repo mode), so AI assistants can query your dependency graph directly:
 
 ```bash
 codegraph mcp                  # Single-repo mode (default) — only local project


### PR DESCRIPTION
## Summary
- Fixed MCP tool count in README.md: 24→26 (single-repo) and 25→27 (multi-repo)
- `BASE_TOOLS` in `src/mcp.js` contains 26 tools; adding `list_repos` in multi-repo mode makes 27
- Rebased onto main — the other 4 occurrences were already corrected in #214's merged version; this fixes the remaining instance in the AI Agent Integration section (line 493)

## Test plan
- [x] Verified `BASE_TOOLS` count in `src/mcp.js` (26 tools)
- [x] Verified `buildToolList(true)` adds `list_repos` (27 total)
- [x] Grepped README for any remaining `24-tool` or `24 tools` references — none found