### PR TITLE
feat: add architecture boundary rules to manifesto

### DIFF
--- a/src/boundaries.js
+++ b/src/boundaries.js
@@ -1,0 +1,342 @@
+import { debug } from './logger.js';
+import { isTestFile } from './queries.js';
+
+// ─── Glob-to-Regex ───────────────────────────────────────────────────
+
+/**
+ * Convert a simple glob pattern to a RegExp.
+ * Supports `**` (any path segment), `*` (non-slash), `?` (single non-slash char).
+ * @param {string} pattern
+ * @returns {RegExp}
+ */
+export function globToRegex(pattern) {
+  let re = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '*' && pattern[i + 1] === '*') {
+      // ** matches any number of path segments
+      re += '.*';
+      i += 2;
+      // Skip trailing slash after **
+      if (pattern[i] === '/') i++;
+    } else if (ch === '*') {
+      // * matches non-slash characters
+      re += '[^/]*';
+      i++;
+    } else if (ch === '?') {
+      re += '[^/]';
+      i++;
+    } else if (/[.+^${}()|[\]\\]/.test(ch)) {
+      re += `\\${ch}`;
+      i++;
+    } else {
+      re += ch;
+      i++;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+// ─── Presets ─────────────────────────────────────────────────────────
+
+/**
+ * Built-in preset definitions.
+ * Each defines layers ordered from innermost (most protected) to outermost.
+ * Inner layers cannot import from outer layers.
+ */
+export const PRESETS = {
+  hexagonal: {
+    layers: ['domain', 'application', 'adapters', 'infrastructure'],
+    description: 'Inner layers cannot import outer layers',
+  },
+  layered: {
+    layers: ['data', 'business', 'presentation'],
+    description: 'Inward-only dependency direction',
+  },
+  clean: {
+    layers: ['entities', 'usecases', 'interfaces', 'frameworks'],
+    description: 'Inward-only dependency direction',
+  },
+};
+
+// ─── Module Resolution ───────────────────────────────────────────────
+
+/**
+ * Parse module definitions into a Map of name → { regex, pattern, layer? }.
+ * Supports string shorthand and object form.
+ * @param {object} boundaryConfig - The `manifesto.boundaries` config object
+ * @returns {Map<string, { regex: RegExp, pattern: string, layer?: string }>}
+ */
+export function resolveModules(boundaryConfig) {
+  const modules = new Map();
+  const defs = boundaryConfig?.modules;
+  if (!defs || typeof defs !== 'object') return modules;
+
+  for (const [name, value] of Object.entries(defs)) {
+    if (typeof value === 'string') {
+      modules.set(name, { regex: globToRegex(value), pattern: value });
+    } else if (value && typeof value === 'object' && value.match) {
+      modules.set(name, {
+        regex: globToRegex(value.match),
+        pattern: value.match,
+        ...(value.layer ? { layer: value.layer } : {}),
+      });
+    }
+  }
+  return modules;
+}
+
+// ─── Validation ──────────────────────────────────────────────────────
+
+/**
+ * Validate a boundary configuration object.
+ * @param {object} config - The `manifesto.boundaries` config
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateBoundaryConfig(config) {
+  const errors = [];
+
+  if (!config || typeof config !== 'object') {
+    return { valid: false, errors: ['boundaries config must be an object'] };
+  }
+
+  // Validate modules
+  if (
+    !config.modules ||
+    typeof config.modules !== 'object' ||
+    Object.keys(config.modules).length === 0
+  ) {
+    errors.push('boundaries.modules must be a non-empty object');
+  } else {
+    for (const [name, value] of Object.entries(config.modules)) {
+      if (typeof value === 'string') continue;
+      if (value && typeof value === 'object' && typeof value.match === 'string') continue;
+      errors.push(`boundaries.modules.${name}: must be a glob string or { match: "<glob>" }`);
+    }
+  }
+
+  // Validate preset
+  if (config.preset != null) {
+    if (typeof config.preset !== 'string' || !PRESETS[config.preset]) {
+      errors.push(
+        `boundaries.preset: must be one of ${Object.keys(PRESETS).join(', ')} (got "${config.preset}")`,
+      );
+    }
+  }
+
+  // Validate rules
+  if (config.rules) {
+    if (!Array.isArray(config.rules)) {
+      errors.push('boundaries.rules must be an array');
+    } else {
+      const moduleNames = config.modules ? new Set(Object.keys(config.modules)) : new Set();
+      for (let i = 0; i < config.rules.length; i++) {
+        const rule = config.rules[i];
+        if (!rule.from) {
+          errors.push(`boundaries.rules[${i}]: missing "from" field`);
+        } else if (!moduleNames.has(rule.from)) {
+          errors.push(`boundaries.rules[${i}]: "from" references unknown module "${rule.from}"`);
+        }
+        if (rule.notTo && rule.onlyTo) {
+          errors.push(`boundaries.rules[${i}]: cannot have both "notTo" and "onlyTo"`);
+        }
+        if (!rule.notTo && !rule.onlyTo) {
+          errors.push(`boundaries.rules[${i}]: must have either "notTo" or "onlyTo"`);
+        }
+        if (rule.notTo) {
+          if (!Array.isArray(rule.notTo)) {
+            errors.push(`boundaries.rules[${i}]: "notTo" must be an array`);
+          } else {
+            for (const target of rule.notTo) {
+              if (!moduleNames.has(target)) {
+                errors.push(
+                  `boundaries.rules[${i}]: "notTo" references unknown module "${target}"`,
+                );
+              }
+            }
+          }
+        }
+        if (rule.onlyTo) {
+          if (!Array.isArray(rule.onlyTo)) {
+            errors.push(`boundaries.rules[${i}]: "onlyTo" must be an array`);
+          } else {
+            for (const target of rule.onlyTo) {
+              if (!moduleNames.has(target)) {
+                errors.push(
+                  `boundaries.rules[${i}]: "onlyTo" references unknown module "${target}"`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Validate preset + layer assignments
+  if (config.preset && PRESETS[config.preset] && config.modules) {
+    const presetLayers = new Set(PRESETS[config.preset].layers);
+    for (const [name, value] of Object.entries(config.modules)) {
+      if (typeof value === 'object' && value.layer) {
+        if (!presetLayers.has(value.layer)) {
+          errors.push(
+            `boundaries.modules.${name}: layer "${value.layer}" not in preset "${config.preset}" (valid: ${[...presetLayers].join(', ')})`,
+          );
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ─── Preset Rule Generation ─────────────────────────────────────────
+
+/**
+ * Generate notTo rules from preset layer assignments.
+ * Inner layers cannot import from outer layers.
+ */
+function generatePresetRules(modules, presetName) {
+  const preset = PRESETS[presetName];
+  if (!preset) return [];
+
+  const layers = preset.layers;
+  const layerIndex = new Map(layers.map((l, i) => [l, i]));
+
+  // Group modules by layer
+  const modulesByLayer = new Map();
+  for (const [name, mod] of modules) {
+    if (mod.layer && layerIndex.has(mod.layer)) {
+      if (!modulesByLayer.has(mod.layer)) modulesByLayer.set(mod.layer, []);
+      modulesByLayer.get(mod.layer).push(name);
+    }
+  }
+
+  const rules = [];
+  // For each layer, forbid imports to any outer (higher-index) layer
+  for (const [layer, modNames] of modulesByLayer) {
+    const idx = layerIndex.get(layer);
+    const outerModules = [];
+    for (const [otherLayer, otherModNames] of modulesByLayer) {
+      if (layerIndex.get(otherLayer) > idx) {
+        outerModules.push(...otherModNames);
+      }
+    }
+    if (outerModules.length > 0) {
+      for (const from of modNames) {
+        rules.push({ from, notTo: outerModules });
+      }
+    }
+  }
+
+  return rules;
+}
+
+// ─── Evaluation ──────────────────────────────────────────────────────
+
+/**
+ * Classify a file path into a module name. Returns the first matching module or null.
+ */
+function classifyFile(filePath, modules) {
+  for (const [name, mod] of modules) {
+    if (mod.regex.test(filePath)) return name;
+  }
+  return null;
+}
+
+/**
+ * Evaluate boundary rules against the dependency graph.
+ *
+ * @param {object} db - Open SQLite database (readonly)
+ * @param {object} boundaryConfig - The `manifesto.boundaries` config
+ * @param {object} [opts]
+ * @param {string[]} [opts.scopeFiles] - Only check edges from these files (diff-impact mode)
+ * @param {boolean} [opts.noTests] - Exclude test files
+ * @returns {{ violations: object[], violationCount: number }}
+ */
+export function evaluateBoundaries(db, boundaryConfig, opts = {}) {
+  if (!boundaryConfig) return { violations: [], violationCount: 0 };
+
+  const { valid, errors } = validateBoundaryConfig(boundaryConfig);
+  if (!valid) {
+    debug('boundary config validation failed: %s', errors.join('; '));
+    return { violations: [], violationCount: 0 };
+  }
+
+  const modules = resolveModules(boundaryConfig);
+  if (modules.size === 0) return { violations: [], violationCount: 0 };
+
+  // Merge user rules with preset-generated rules
+  let allRules = [];
+  if (boundaryConfig.preset) {
+    allRules = generatePresetRules(modules, boundaryConfig.preset);
+  }
+  if (boundaryConfig.rules && Array.isArray(boundaryConfig.rules)) {
+    allRules = allRules.concat(boundaryConfig.rules);
+  }
+  if (allRules.length === 0) return { violations: [], violationCount: 0 };
+
+  // Query file-level import edges
+  let edges;
+  try {
+    edges = db
+      .prepare(
+        `SELECT DISTINCT n1.file AS source, n2.file AS target
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE n1.file != n2.file AND e.kind IN ('imports', 'imports-type')`,
+      )
+      .all();
+  } catch (err) {
+    debug('boundary edge query failed: %s', err.message);
+    return { violations: [], violationCount: 0 };
+  }
+
+  // Filter by scope and tests
+  if (opts.noTests) {
+    edges = edges.filter((e) => !isTestFile(e.source) && !isTestFile(e.target));
+  }
+  if (opts.scopeFiles) {
+    const scope = new Set(opts.scopeFiles);
+    edges = edges.filter((e) => scope.has(e.source));
+  }
+
+  // Check each edge against rules
+  const violations = [];
+
+  for (const edge of edges) {
+    const fromModule = classifyFile(edge.source, modules);
+    const toModule = classifyFile(edge.target, modules);
+
+    // Skip edges where source or target is not in any module
+    if (!fromModule || !toModule) continue;
+
+    for (const rule of allRules) {
+      if (rule.from !== fromModule) continue;
+
+      let isViolation = false;
+
+      if (rule.notTo?.includes(toModule)) {
+        isViolation = true;
+      } else if (rule.onlyTo && !rule.onlyTo.includes(toModule)) {
+        isViolation = true;
+      }
+
+      if (isViolation) {
+        violations.push({
+          rule: 'boundaries',
+          name: `${fromModule} -> ${toModule}`,
+          file: edge.source,
+          targetFile: edge.target,
+          message: rule.message || `${fromModule} must not depend on ${toModule}`,
+          value: 1,
+          threshold: 0,
+        });
+      }
+    }
+  }
+
+  return { violations, violationCount: violations.length };
+}

--- a/src/config.js
+++ b/src/config.js
@@ -36,7 +36,9 @@ export const DEFAULTS = {
       fanIn: { warn: null, fail: null },
       fanOut: { warn: null, fail: null },
       noCycles: { warn: null, fail: null },
+      boundaries: { warn: null, fail: null },
     },
+    boundaries: null,
   },
   coChange: {
     since: '1 year ago',

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@
 export { audit, auditData } from './audit.js';
 // Batch querying
 export { BATCH_COMMANDS, batch, batchData } from './batch.js';
+// Architecture boundary rules
+export { evaluateBoundaries, PRESETS, validateBoundaryConfig } from './boundaries.js';
 // Branch comparison
 export { branchCompareData, branchCompareMermaid } from './branch-compare.js';
 // Graph building

--- a/src/manifesto.js
+++ b/src/manifesto.js
@@ -1,3 +1,4 @@
+import { evaluateBoundaries } from './boundaries.js';
 import { loadConfig } from './config.js';
 import { findCycles } from './cycles.js';
 import { openReadonlyOrFail } from './db.js';
@@ -55,6 +56,12 @@ export const RULE_DEFS = [
   { name: 'fanIn', level: 'file', metric: 'fan_in', defaults: { warn: null, fail: null } },
   { name: 'fanOut', level: 'file', metric: 'fan_out', defaults: { warn: null, fail: null } },
   { name: 'noCycles', level: 'graph', metric: 'noCycles', defaults: { warn: null, fail: null } },
+  {
+    name: 'boundaries',
+    level: 'graph',
+    metric: 'boundaries',
+    defaults: { warn: null, fail: null },
+  },
 ];
 
 // ─── Helpers ──────────────────────────────────────────────────────────
@@ -319,6 +326,59 @@ function evaluateGraphRules(db, rules, opts, violations, ruleResults) {
   });
 }
 
+function evaluateBoundaryRules(db, rules, config, opts, violations, ruleResults) {
+  const thresholds = rules.boundaries;
+  const boundaryConfig = config.manifesto?.boundaries;
+
+  // Auto-enable at warn level when boundary config exists but threshold not set
+  const effectiveThresholds = { ...thresholds };
+  if (boundaryConfig && !isEnabled(thresholds)) {
+    effectiveThresholds.warn = true;
+  }
+
+  if (!isEnabled(effectiveThresholds) || !boundaryConfig) {
+    ruleResults.push({
+      name: 'boundaries',
+      level: 'graph',
+      status: 'pass',
+      thresholds: effectiveThresholds,
+      violationCount: 0,
+    });
+    return;
+  }
+
+  const result = evaluateBoundaries(db, boundaryConfig, { noTests: opts.noTests || false });
+  const hasBoundaryViolations = result.violationCount > 0;
+
+  if (!hasBoundaryViolations) {
+    ruleResults.push({
+      name: 'boundaries',
+      level: 'graph',
+      status: 'pass',
+      thresholds: effectiveThresholds,
+      violationCount: 0,
+    });
+    return;
+  }
+
+  const level = effectiveThresholds.fail != null ? 'fail' : 'warn';
+
+  for (const v of result.violations) {
+    violations.push({
+      ...v,
+      level,
+    });
+  }
+
+  ruleResults.push({
+    name: 'boundaries',
+    level: 'graph',
+    status: level,
+    thresholds: effectiveThresholds,
+    violationCount: result.violationCount,
+  });
+}
+
 // ─── Public API ───────────────────────────────────────────────────────
 
 /**
@@ -344,6 +404,7 @@ export function manifestoData(customDbPath, opts = {}) {
     evaluateFunctionRules(db, rules, opts, violations, ruleResults);
     evaluateFileRules(db, rules, opts, violations, ruleResults);
     evaluateGraphRules(db, rules, opts, violations, ruleResults);
+    evaluateBoundaryRules(db, rules, config, opts, violations, ruleResults);
 
     const failViolations = violations.filter((v) => v.level === 'fail');
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,7 +1,9 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { evaluateBoundaries } from './boundaries.js';
 import { coChangeForFiles } from './cochange.js';
+import { loadConfig } from './config.js';
 import { findCycles } from './cycles.js';
 import { findDbPath, openReadonlyOrFail } from './db.js';
 import { debug } from './logger.js';
@@ -1018,6 +1020,24 @@ export function diffImpactData(customDbPath, opts = {}) {
     /* CODEOWNERS missing or unreadable — skip silently */
   }
 
+  // Check boundary violations scoped to changed files
+  let boundaryViolations = [];
+  let boundaryViolationCount = 0;
+  try {
+    const config = loadConfig(repoRoot);
+    const boundaryConfig = config.manifesto?.boundaries;
+    if (boundaryConfig) {
+      const result = evaluateBoundaries(db, boundaryConfig, {
+        scopeFiles: [...changedRanges.keys()],
+        noTests,
+      });
+      boundaryViolations = result.violations;
+      boundaryViolationCount = result.violationCount;
+    }
+  } catch {
+    /* boundary check failed — skip silently */
+  }
+
   db.close();
   const base = {
     changedFiles: changedRanges.size,
@@ -1026,12 +1046,15 @@ export function diffImpactData(customDbPath, opts = {}) {
     affectedFiles: [...affectedFiles],
     historicallyCoupled,
     ownership,
+    boundaryViolations,
+    boundaryViolationCount,
     summary: {
       functionsChanged: affectedFunctions.length,
       callersAffected: allAffected.size,
       filesAffected: affectedFiles.size,
       historicallyCoupledCount: historicallyCoupled.length,
       ownersAffected: ownership ? ownership.affectedOwners.length : 0,
+      boundaryViolationCount,
     },
   };
   return paginateResult(base, 'affectedFunctions', { limit: opts.limit, offset: opts.offset });
@@ -1997,7 +2020,7 @@ export function contextData(name, customDbPath, opts = {}) {
   const dbPath = findDbPath(customDbPath);
   const repoRoot = path.resolve(path.dirname(dbPath), '..');
 
-  let nodes = findMatchingNodes(db, name, { noTests, file: opts.file, kind: opts.kind });
+  const nodes = findMatchingNodes(db, name, { noTests, file: opts.file, kind: opts.kind });
   if (nodes.length === 0) {
     db.close();
     return { name, results: [] };
@@ -3023,6 +3046,13 @@ export function diffImpact(customDbPath, opts = {}) {
     console.log(`\n  Affected owners: ${data.ownership.affectedOwners.join(', ')}`);
     console.log(`  Suggested reviewers: ${data.ownership.suggestedReviewers.join(', ')}`);
   }
+  if (data.boundaryViolations && data.boundaryViolations.length > 0) {
+    console.log(`\n  Boundary violations (${data.boundaryViolationCount}):\n`);
+    for (const v of data.boundaryViolations) {
+      console.log(`    [${v.name}] ${v.file} -> ${v.targetFile}`);
+      if (v.message) console.log(`      ${v.message}`);
+    }
+  }
   if (data.summary) {
     let summaryLine = `\n  Summary: ${data.summary.functionsChanged} functions changed -> ${data.summary.callersAffected} callers affected across ${data.summary.filesAffected} files`;
     if (data.summary.historicallyCoupledCount > 0) {
@@ -3030,6 +3060,9 @@ export function diffImpact(customDbPath, opts = {}) {
     }
     if (data.summary.ownersAffected > 0) {
       summaryLine += `, ${data.summary.ownersAffected} owners affected`;
+    }
+    if (data.summary.boundaryViolationCount > 0) {
+      summaryLine += `, ${data.summary.boundaryViolationCount} boundary violations`;
     }
     console.log(`${summaryLine}\n`);
   }

--- a/tests/integration/manifesto.test.js
+++ b/tests/integration/manifesto.test.js
@@ -339,6 +339,192 @@ describe('manifestoData', () => {
     }
   });
 
+  test('boundaries rule passes when no boundary config exists', () => {
+    const data = manifestoData(dbPath);
+    const boundariesRule = data.rules.find((r) => r.name === 'boundaries');
+    expect(boundariesRule).toBeDefined();
+    expect(boundariesRule.status).toBe('pass');
+    expect(boundariesRule.violationCount).toBe(0);
+  });
+
+  test('boundaries rule detects violations with warn threshold', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-manifesto-boundaries-'));
+    fs.mkdirSync(path.join(configDir, '.codegraph'));
+    const bDbPath = path.join(configDir, '.codegraph', 'graph.db');
+
+    // Create a DB with cross-module imports
+    const bDb = new Database(bDbPath);
+    bDb.pragma('journal_mode = WAL');
+    initSchema(bDb);
+
+    const ctrl1 = insertNode(bDb, 'src/controllers/a.js', 'file', 'src/controllers/a.js', 1);
+    const ctrl2 = insertNode(bDb, 'src/controllers/b.js', 'file', 'src/controllers/b.js', 1);
+    const svc1 = insertNode(bDb, 'src/services/x.js', 'file', 'src/services/x.js', 1);
+    insertEdge(bDb, ctrl1, ctrl2, 'imports'); // controller -> controller violation
+    insertEdge(bDb, ctrl1, svc1, 'imports'); // controller -> service (allowed)
+    bDb.close();
+
+    fs.writeFileSync(
+      path.join(configDir, '.codegraphrc.json'),
+      JSON.stringify({
+        manifesto: {
+          boundaries: {
+            modules: {
+              controllers: 'src/controllers/**',
+              services: 'src/services/**',
+            },
+            rules: [{ from: 'controllers', notTo: ['controllers'] }],
+          },
+        },
+      }),
+    );
+
+    const origCwd = process.cwd();
+    try {
+      process.chdir(configDir);
+      const data = manifestoData(bDbPath);
+      const boundariesRule = data.rules.find((r) => r.name === 'boundaries');
+      expect(boundariesRule.status).toBe('warn');
+      expect(boundariesRule.violationCount).toBe(1);
+
+      const bViolations = data.violations.filter((v) => v.rule === 'boundaries');
+      expect(bViolations.length).toBe(1);
+      expect(bViolations[0].level).toBe('warn');
+      expect(bViolations[0].name).toBe('controllers -> controllers');
+    } finally {
+      process.chdir(origCwd);
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test('boundaries rule with fail threshold sets passed=false', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-manifesto-bfail-'));
+    fs.mkdirSync(path.join(configDir, '.codegraph'));
+    const bDbPath = path.join(configDir, '.codegraph', 'graph.db');
+
+    const bDb = new Database(bDbPath);
+    bDb.pragma('journal_mode = WAL');
+    initSchema(bDb);
+
+    const ctrl1 = insertNode(bDb, 'src/controllers/a.js', 'file', 'src/controllers/a.js', 1);
+    const ctrl2 = insertNode(bDb, 'src/controllers/b.js', 'file', 'src/controllers/b.js', 1);
+    insertEdge(bDb, ctrl1, ctrl2, 'imports');
+    bDb.close();
+
+    fs.writeFileSync(
+      path.join(configDir, '.codegraphrc.json'),
+      JSON.stringify({
+        manifesto: {
+          rules: { boundaries: { warn: null, fail: true } },
+          boundaries: {
+            modules: {
+              controllers: 'src/controllers/**',
+            },
+            rules: [{ from: 'controllers', notTo: ['controllers'] }],
+          },
+        },
+      }),
+    );
+
+    const origCwd = process.cwd();
+    try {
+      process.chdir(configDir);
+      const data = manifestoData(bDbPath);
+      expect(data.passed).toBe(false);
+
+      const boundariesRule = data.rules.find((r) => r.name === 'boundaries');
+      expect(boundariesRule.status).toBe('fail');
+    } finally {
+      process.chdir(origCwd);
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test('boundaries auto-enables at warn when boundary config exists without threshold', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-manifesto-bauto-'));
+    fs.mkdirSync(path.join(configDir, '.codegraph'));
+    const bDbPath = path.join(configDir, '.codegraph', 'graph.db');
+
+    const bDb = new Database(bDbPath);
+    bDb.pragma('journal_mode = WAL');
+    initSchema(bDb);
+
+    const ctrl1 = insertNode(bDb, 'src/controllers/a.js', 'file', 'src/controllers/a.js', 1);
+    const ctrl2 = insertNode(bDb, 'src/controllers/b.js', 'file', 'src/controllers/b.js', 1);
+    insertEdge(bDb, ctrl1, ctrl2, 'imports');
+    bDb.close();
+
+    // No explicit boundaries threshold — should auto-enable at warn
+    fs.writeFileSync(
+      path.join(configDir, '.codegraphrc.json'),
+      JSON.stringify({
+        manifesto: {
+          boundaries: {
+            modules: { controllers: 'src/controllers/**' },
+            rules: [{ from: 'controllers', notTo: ['controllers'] }],
+          },
+        },
+      }),
+    );
+
+    const origCwd = process.cwd();
+    try {
+      process.chdir(configDir);
+      const data = manifestoData(bDbPath);
+      const boundariesRule = data.rules.find((r) => r.name === 'boundaries');
+      expect(boundariesRule.status).toBe('warn');
+      expect(boundariesRule.violationCount).toBe(1);
+      // Auto-enabled should still pass (warn only)
+      expect(data.passed).toBe(true);
+    } finally {
+      process.chdir(origCwd);
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test('boundaries with preset evaluates layer rules', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-manifesto-bpreset-'));
+    fs.mkdirSync(path.join(configDir, '.codegraph'));
+    const bDbPath = path.join(configDir, '.codegraph', 'graph.db');
+
+    const bDb = new Database(bDbPath);
+    bDb.pragma('journal_mode = WAL');
+    initSchema(bDb);
+
+    // domain imports from adapters — violation in hexagonal
+    const domFile = insertNode(bDb, 'src/domain/user.js', 'file', 'src/domain/user.js', 1);
+    const adapterFile = insertNode(bDb, 'src/api/handler.js', 'file', 'src/api/handler.js', 1);
+    insertEdge(bDb, domFile, adapterFile, 'imports');
+    bDb.close();
+
+    fs.writeFileSync(
+      path.join(configDir, '.codegraphrc.json'),
+      JSON.stringify({
+        manifesto: {
+          boundaries: {
+            modules: {
+              domain: { match: 'src/domain/**', layer: 'domain' },
+              api: { match: 'src/api/**', layer: 'adapters' },
+            },
+            preset: 'hexagonal',
+          },
+        },
+      }),
+    );
+
+    const origCwd = process.cwd();
+    try {
+      process.chdir(configDir);
+      const data = manifestoData(bDbPath);
+      const boundariesRule = data.rules.find((r) => r.name === 'boundaries');
+      expect(boundariesRule.violationCount).toBeGreaterThan(0);
+      expect(boundariesRule.status).toBe('warn');
+    } finally {
+      process.chdir(origCwd);
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
   test('noCycles rule with fail threshold sets passed=false', () => {
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-manifesto-fail-'));
     fs.mkdirSync(path.join(configDir, '.codegraph'));

--- a/tests/unit/boundaries.test.js
+++ b/tests/unit/boundaries.test.js
@@ -1,0 +1,429 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import {
+  evaluateBoundaries,
+  globToRegex,
+  PRESETS,
+  resolveModules,
+  validateBoundaryConfig,
+} from '../../src/boundaries.js';
+import { initSchema } from '../../src/db.js';
+
+// ─── globToRegex ─────────────────────────────────────────────────────
+
+describe('globToRegex', () => {
+  test('** matches any path depth', () => {
+    const re = globToRegex('src/**/*.js');
+    expect(re.test('src/foo.js')).toBe(true);
+    expect(re.test('src/a/b/c.js')).toBe(true);
+    expect(re.test('lib/foo.js')).toBe(false);
+  });
+
+  test('* matches non-slash characters', () => {
+    const re = globToRegex('src/*.js');
+    expect(re.test('src/foo.js')).toBe(true);
+    expect(re.test('src/a/foo.js')).toBe(false);
+  });
+
+  test('? matches single non-slash character', () => {
+    const re = globToRegex('src/?.js');
+    expect(re.test('src/a.js')).toBe(true);
+    expect(re.test('src/ab.js')).toBe(false);
+  });
+
+  test('escapes special regex characters', () => {
+    const re = globToRegex('src/file.name.js');
+    expect(re.test('src/file.name.js')).toBe(true);
+    expect(re.test('src/filexnamexjs')).toBe(false);
+  });
+
+  test('** at start matches any prefix', () => {
+    const re = globToRegex('**/*.test.js');
+    expect(re.test('src/foo.test.js')).toBe(true);
+    expect(re.test('a/b/c.test.js')).toBe(true);
+    expect(re.test('foo.test.js')).toBe(true);
+  });
+
+  test('exact path match', () => {
+    const re = globToRegex('src/controllers/main.js');
+    expect(re.test('src/controllers/main.js')).toBe(true);
+    expect(re.test('src/controllers/other.js')).toBe(false);
+  });
+});
+
+// ─── resolveModules ──────────────────────────────────────────────────
+
+describe('resolveModules', () => {
+  test('string shorthand form', () => {
+    const modules = resolveModules({ modules: { controllers: 'src/controllers/**' } });
+    expect(modules.size).toBe(1);
+    expect(modules.get('controllers').pattern).toBe('src/controllers/**');
+  });
+
+  test('object form with match', () => {
+    const modules = resolveModules({
+      modules: { services: { match: 'src/services/**' } },
+    });
+    expect(modules.size).toBe(1);
+    expect(modules.get('services').pattern).toBe('src/services/**');
+  });
+
+  test('object form with layer', () => {
+    const modules = resolveModules({
+      modules: { domain: { match: 'src/domain/**', layer: 'domain' } },
+    });
+    expect(modules.get('domain').layer).toBe('domain');
+  });
+
+  test('empty/null config returns empty map', () => {
+    expect(resolveModules(null).size).toBe(0);
+    expect(resolveModules({}).size).toBe(0);
+    expect(resolveModules({ modules: null }).size).toBe(0);
+  });
+});
+
+// ─── validateBoundaryConfig ──────────────────────────────────────────
+
+describe('validateBoundaryConfig', () => {
+  test('valid config with notTo rules', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: 'src/a/**', b: 'src/b/**' },
+      rules: [{ from: 'a', notTo: ['b'] }],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('valid config with onlyTo rules', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: 'src/a/**', b: 'src/b/**' },
+      rules: [{ from: 'a', onlyTo: ['b'] }],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects null config', () => {
+    const result = validateBoundaryConfig(null);
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects empty modules', () => {
+    const result = validateBoundaryConfig({ modules: {} });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/non-empty/);
+  });
+
+  test('rejects both notTo and onlyTo on same rule', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: 'src/a/**', b: 'src/b/**' },
+      rules: [{ from: 'a', notTo: ['b'], onlyTo: ['b'] }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('cannot have both'))).toBe(true);
+  });
+
+  test('rejects rule with neither notTo nor onlyTo', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: 'src/a/**' },
+      rules: [{ from: 'a' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('must have either'))).toBe(true);
+  });
+
+  test('rejects unknown module in from', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: 'src/a/**' },
+      rules: [{ from: 'unknown', notTo: ['a'] }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('unknown module "unknown"'))).toBe(true);
+  });
+
+  test('rejects unknown module in notTo', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: 'src/a/**' },
+      rules: [{ from: 'a', notTo: ['unknown'] }],
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects invalid preset name', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: 'src/a/**' },
+      preset: 'invalid',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('must be one of'))).toBe(true);
+  });
+
+  test('rejects layer not in preset', () => {
+    const result = validateBoundaryConfig({
+      modules: { a: { match: 'src/a/**', layer: 'nonexistent' } },
+      preset: 'hexagonal',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('not in preset'))).toBe(true);
+  });
+
+  test('valid preset with correct layers', () => {
+    const result = validateBoundaryConfig({
+      modules: {
+        core: { match: 'src/core/**', layer: 'domain' },
+        api: { match: 'src/api/**', layer: 'adapters' },
+      },
+      preset: 'hexagonal',
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ─── PRESETS ─────────────────────────────────────────────────────────
+
+describe('PRESETS', () => {
+  test('all three presets defined', () => {
+    expect(PRESETS.hexagonal).toBeDefined();
+    expect(PRESETS.layered).toBeDefined();
+    expect(PRESETS.clean).toBeDefined();
+  });
+
+  test('each preset has layers array', () => {
+    for (const preset of Object.values(PRESETS)) {
+      expect(Array.isArray(preset.layers)).toBe(true);
+      expect(preset.layers.length).toBeGreaterThan(1);
+    }
+  });
+});
+
+// ─── evaluateBoundaries ──────────────────────────────────────────────
+
+describe('evaluateBoundaries', () => {
+  let tmpDir, dbPath, db;
+
+  function insertNode(database, name, kind, file, line) {
+    return database
+      .prepare('INSERT INTO nodes (name, kind, file, line) VALUES (?, ?, ?, ?)')
+      .run(name, kind, file, line).lastInsertRowid;
+  }
+
+  function insertEdge(database, sourceId, targetId, kind) {
+    database
+      .prepare('INSERT INTO edges (source_id, target_id, kind, confidence) VALUES (?, ?, ?, 1.0)')
+      .run(sourceId, targetId, kind);
+  }
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-boundaries-'));
+    fs.mkdirSync(path.join(tmpDir, '.codegraph'));
+    dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+
+    db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    initSchema(db);
+
+    // Create file nodes in different "modules"
+    const ctrl1 = insertNode(
+      db,
+      'src/controllers/userCtrl.js',
+      'file',
+      'src/controllers/userCtrl.js',
+      1,
+    );
+    const ctrl2 = insertNode(
+      db,
+      'src/controllers/orderCtrl.js',
+      'file',
+      'src/controllers/orderCtrl.js',
+      1,
+    );
+    const svc1 = insertNode(db, 'src/services/userSvc.js', 'file', 'src/services/userSvc.js', 1);
+    const svc2 = insertNode(db, 'src/services/orderSvc.js', 'file', 'src/services/orderSvc.js', 1);
+    const dom1 = insertNode(db, 'src/domain/user.js', 'file', 'src/domain/user.js', 1);
+    const testFile = insertNode(db, 'tests/ctrl.test.js', 'file', 'tests/ctrl.test.js', 1);
+
+    // controller -> service (allowed)
+    insertEdge(db, ctrl1, svc1, 'imports');
+    // controller -> controller (violation for notTo rule)
+    insertEdge(db, ctrl1, ctrl2, 'imports');
+    // service -> domain (allowed)
+    insertEdge(db, svc1, dom1, 'imports');
+    // service -> controller (violation for preset rules)
+    insertEdge(db, svc2, ctrl1, 'imports');
+    // test -> controller (test file edge)
+    insertEdge(db, testFile, ctrl1, 'imports');
+
+    db.close();
+  });
+
+  afterAll(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function openDb() {
+    return new Database(dbPath, { readonly: true });
+  }
+
+  test('detects notTo violations', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(database, {
+        modules: {
+          controllers: 'src/controllers/**',
+          services: 'src/services/**',
+        },
+        rules: [{ from: 'controllers', notTo: ['controllers'] }],
+      });
+      expect(result.violationCount).toBe(1);
+      expect(result.violations[0].name).toBe('controllers -> controllers');
+      expect(result.violations[0].file).toBe('src/controllers/userCtrl.js');
+      expect(result.violations[0].targetFile).toBe('src/controllers/orderCtrl.js');
+    } finally {
+      database.close();
+    }
+  });
+
+  test('detects onlyTo violations', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(database, {
+        modules: {
+          controllers: 'src/controllers/**',
+          services: 'src/services/**',
+          domain: 'src/domain/**',
+        },
+        rules: [{ from: 'controllers', onlyTo: ['services'] }],
+      });
+      // controller -> controller violates onlyTo (controllers not in allowed list)
+      expect(result.violationCount).toBeGreaterThanOrEqual(1);
+      const names = result.violations.map((v) => v.name);
+      expect(names).toContain('controllers -> controllers');
+    } finally {
+      database.close();
+    }
+  });
+
+  test('scopeFiles limits checked edges', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(
+        database,
+        {
+          modules: {
+            controllers: 'src/controllers/**',
+            services: 'src/services/**',
+          },
+          rules: [
+            { from: 'controllers', notTo: ['controllers'] },
+            { from: 'services', notTo: ['controllers'] },
+          ],
+        },
+        { scopeFiles: ['src/services/orderSvc.js'] },
+      );
+      // Only service -> controller violation (scoped to orderSvc.js)
+      expect(result.violationCount).toBe(1);
+      expect(result.violations[0].file).toBe('src/services/orderSvc.js');
+    } finally {
+      database.close();
+    }
+  });
+
+  test('noTests excludes test files', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(
+        database,
+        {
+          modules: {
+            controllers: 'src/controllers/**',
+            tests: 'tests/**',
+          },
+          rules: [{ from: 'tests', notTo: ['controllers'] }],
+        },
+        { noTests: true },
+      );
+      expect(result.violationCount).toBe(0);
+    } finally {
+      database.close();
+    }
+  });
+
+  test('preset generates rules from layer assignments', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(database, {
+        modules: {
+          controllers: { match: 'src/controllers/**', layer: 'adapters' },
+          services: { match: 'src/services/**', layer: 'application' },
+          domain: { match: 'src/domain/**', layer: 'domain' },
+        },
+        preset: 'hexagonal',
+      });
+      // domain is innermost, cannot import from application/adapters
+      // application cannot import from adapters
+      // service -> controller = application -> adapters = violation
+      const svcToCtrl = result.violations.filter((v) => v.file === 'src/services/orderSvc.js');
+      expect(svcToCtrl.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      database.close();
+    }
+  });
+
+  test('returns empty on null config', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(database, null);
+      expect(result.violations).toHaveLength(0);
+      expect(result.violationCount).toBe(0);
+    } finally {
+      database.close();
+    }
+  });
+
+  test('returns empty on invalid config', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(database, { modules: {} });
+      expect(result.violations).toHaveLength(0);
+    } finally {
+      database.close();
+    }
+  });
+
+  test('files not in any module are skipped', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(database, {
+        modules: {
+          controllers: 'src/controllers/**',
+          // services NOT defined as a module
+        },
+        rules: [{ from: 'controllers', notTo: ['controllers'] }],
+      });
+      // Only the controller -> controller edge should be a violation
+      // controller -> service edges are skipped because services is not a module
+      expect(result.violationCount).toBe(1);
+    } finally {
+      database.close();
+    }
+  });
+
+  test('custom message appears in violation', () => {
+    const database = openDb();
+    try {
+      const result = evaluateBoundaries(database, {
+        modules: {
+          controllers: 'src/controllers/**',
+        },
+        rules: [
+          { from: 'controllers', notTo: ['controllers'], message: 'No cross-controller imports' },
+        ],
+      });
+      expect(result.violations[0].message).toBe('No cross-controller imports');
+    } finally {
+      database.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/boundaries.js` with core boundary enforcement logic: glob-to-regex matching, module resolution, config validation, preset support (hexagonal/layered/clean), and boundary evaluation against the dependency graph
- Wire `boundaries` as a new graph-level rule into the manifesto pipeline (`src/manifesto.js`), with auto-enable at warn level when boundary config is present
- Integrate boundary violation checks into `diff-impact` scoped to changed files via `scopeFiles` (`src/queries.js:1023-1039`)
- Add config defaults (`src/config.js`) and public API exports (`src/index.js`)
- 32 unit tests + 5 integration tests

## diff-impact integration

`diffImpactData()` now calls `evaluateBoundaries()` with `scopeFiles` set to the changed files, adds `boundaryViolations` and `boundaryViolationCount` to the return object, and the `diffImpact()` formatter prints them after ownership info.

## Configuration

```jsonc
{
  "manifesto": {
    "boundaries": {
      "modules": {
        "controllers": "src/controllers/**",
        "services": { "match": "src/services/**" },
        "domain": { "match": "src/domain/**", "layer": "domain" }
      },
      "rules": [
        { "from": "controllers", "notTo": ["controllers"] },
        { "from": "services", "notTo": ["controllers"] }
      ],
      "preset": null
    }
  }
}
```

## Test plan

- [x] `npx vitest run tests/unit/boundaries.test.js` — 32 tests pass
- [x] `npx vitest run tests/integration/manifesto.test.js` — 19 tests pass (5 new)
- [x] `npx biome check` on all changed files — 0 issues
- [x] `node src/cli.js manifesto -T` — boundaries rule shows in table output
- [x] `node src/cli.js manifesto -T -j` — boundaries rule in JSON output