### PR TITLE
feat: add onion architecture preset to boundary rules

### DIFF
--- a/src/boundaries.js
+++ b/src/boundaries.js
@@ -58,6 +58,10 @@ export const PRESETS = {
     layers: ['entities', 'usecases', 'interfaces', 'frameworks'],
     description: 'Inward-only dependency direction',
   },
+  onion: {
+    layers: ['domain-model', 'domain-services', 'application', 'infrastructure'],
+    description: 'Inward-only dependency direction',
+  },
 };
 
 // ─── Module Resolution ───────────────────────────────────────────────

--- a/tests/unit/boundaries.test.js
+++ b/tests/unit/boundaries.test.js
@@ -184,10 +184,11 @@ describe('validateBoundaryConfig', () => {
 // ─── PRESETS ─────────────────────────────────────────────────────────
 
 describe('PRESETS', () => {
-  test('all three presets defined', () => {
+  test('all four presets defined', () => {
     expect(PRESETS.hexagonal).toBeDefined();
     expect(PRESETS.layered).toBeDefined();
     expect(PRESETS.clean).toBeDefined();
+    expect(PRESETS.onion).toBeDefined();
   });
 
   test('each preset has layers array', () => {


### PR DESCRIPTION
## Summary

- Add `onion` preset with layers: `domain-model` → `domain-services` → `application` → `infrastructure`
- Enforces inward-only dependency direction, same as the other presets
- Completes the four most popular layered architecture patterns: hexagonal, layered, clean, onion

## Test plan

- [x] Unit test updated to verify all four presets
- [x] All 32 boundary tests pass