### PR TITLE
fix(skill): support dev build installs in dogfood skill

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -45,7 +45,7 @@ Your goal is to install the published package, exercise every feature, compare e
 
    > **Tip:** To find the latest dev version, run:
    > ```bash
-   > gh release list --repo optave/codegraph --json tagName,isPrerelease --jq '[.[] | select(.isPrerelease)][0].tagName' | sed 's/^dev-v//'
+   > gh release list --repo optave/codegraph --json tagName --jq '.[] | select(.tagName | startswith("dev-v")) | .tagName' | head -1 | sed 's/^dev-v//'
    > ```
 
 3. Verify the install: `npx codegraph --version` should print `$ARGUMENTS`.


### PR DESCRIPTION
## Summary

- The dogfood skill's Phase 0 (install) only supported `npm install @optave/codegraph@<version>`, which fails for dev builds since they're not published to npm
- Dev builds are attached as tarballs to GitHub pre-releases (`dev-v<version>` tags)
- Phase 0 now branches: stable versions install from npm, dev versions install from GitHub release tarballs (main package + platform-specific native binary)
- Phase 4b pre-flight (native binary version check for benchmarks) gets the same treatment
- Added a tip showing how to find the latest dev version via `gh release list`

## Test plan

- [ ] Run `/dogfood 2.5.1` (stable) — should install from npm as before
- [ ] Run `/dogfood 2.5.33-dev.3c36ef7` (dev) — should install from GitHub release tarballs