### PR TITLE
fix(builder): purge function_complexity on full rebuild

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -435,7 +435,7 @@ export async function buildGraph(rootDir, opts = {}) {
 
   if (isFullBuild) {
     const deletions =
-      'PRAGMA foreign_keys = OFF; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM nodes; PRAGMA foreign_keys = ON;';
+      'PRAGMA foreign_keys = OFF; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM nodes; PRAGMA foreign_keys = ON;';
     db.exec(
       hasEmbeddings
         ? `${deletions.replace('PRAGMA foreign_keys = ON;', '')} DELETE FROM embeddings; PRAGMA foreign_keys = ON;`


### PR DESCRIPTION
## Summary
- **Fixes #173** — `--no-incremental` full rebuilds now clear the `function_complexity` table before inserting new data
- Without this fix, old complexity rows became orphaned on each full rebuild (node IDs are reassigned), causing unbounded table growth (2160→2879→3599 rows observed across 3 rebuilds, while only ~720 are valid)
- One-line addition of `DELETE FROM function_complexity;` to the full-rebuild purge sequence in `builder.js`

## Test plan
- [x] `npm test` — all integration/unit tests pass (no regressions)
- [x] `npm run lint` — clean
- [ ] Manual: `node src/cli.js build . --no-incremental` twice, verify `SELECT COUNT(*) FROM function_complexity` stays constant