### PR TITLE
docs: add Contributor License Agreement (CLA)

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,41 @@
+# Contributor License Agreement (CLA)
+
+In order to clarify the intellectual property license granted with Contributions from any person or entity, Optave AI Solutions Inc. ("Optave") must have a Contributor License Agreement ("CLA") on file that has been signed by each Contributor, indicating agreement to the license terms below. This license is for your protection as a Contributor as well as the protection of Optave; it does not change your rights to use your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your present and future Contributions submitted to Optave. Except for the license granted herein to Optave and recipients of software distributed by Optave, You reserve all right, title, and interest in and to Your Contributions.
+
+## Definitions
+
+**"You" (or "Your")** shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Optave. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, "control" means:
+
+i. the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or
+ii. ownership of fifty percent (50%) or more of the outstanding shares, or
+iii. beneficial ownership of such entity.
+
+**"Contribution"** shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Optave for inclusion in, or documentation of, any of the products owned or managed by Optave (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to Optave or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Optave for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Optave and to recipients of software distributed by Optave a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Optave and to recipients of software distributed by Optave a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+## Representations
+
+You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to Optave, or that your employer has executed a separate Corporate CLA with Optave.
+
+You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
+
+## Support
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## Third-Party Submissions
+
+Should You wish to submit work that is not Your original creation, You may submit it to Optave separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third party: [named here]".
+
+## Notifications
+
+You agree to notify Optave of any facts or circumstances of which you become aware that would make these representations inaccurate in any respect.


### PR DESCRIPTION
## Summary
- Add `CLA.md` — Contributor License Agreement for Optave AI Solutions Inc.
- Covers copyright and patent license grants, contributor representations, third-party submissions, and notifications
- Modeled after the Zep CLA format

## Test plan
- [ ] Review legal text for accuracy
- [ ] Verify company name and jurisdiction are correct