### PR TITLE
ci: allow benchmark/ branch name prefix

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Check branch name
         run: |
           BRANCH="${{ github.head_ref }}"
-          PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|release|dependabot|revert)/"
+          PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|release|dependabot|revert|benchmark)/"
           if [[ ! "$BRANCH" =~ $PATTERN ]]; then
             echo "::error::Branch name '$BRANCH' does not match the required pattern."
-            echo "Branch names must start with one of: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, dependabot/, revert/"
+            echo "Branch names must start with one of: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, dependabot/, revert/, benchmark/"
             exit 1
           fi
           echo "Branch name '$BRANCH' is valid."


### PR DESCRIPTION
## Summary
- Add `benchmark/` to the allowed branch name prefixes in the commitlint workflow
- Fixes failing "Validate branch name" check on PRs #247, #248, #250 which use `benchmark/` prefixed branches

## Test plan
- [x] Verify PRs #247, #248, #250 pass branch name validation after merge