### PR TITLE
chore: add pre-commit diff-impact hook

### DIFF
--- a/.claude/hooks/show-diff-impact.sh
+++ b/.claude/hooks/show-diff-impact.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# show-diff-impact.sh — PreToolUse hook for Bash (git commit)
+# Runs `codegraph diff-impact --staged -T` before commits and injects
+# the impact summary as additionalContext. Informational only — never blocks.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Extract the command from tool_input JSON
+COMMAND=$(echo "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>{
+    const p=JSON.parse(d).tool_input?.command||'';
+    if(p)process.stdout.write(p);
+  });
+" 2>/dev/null) || true
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Only trigger on git commit commands
+if ! echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+commit\b'; then
+  exit 0
+fi
+
+# Guard: codegraph DB must exist
+WORK_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || WORK_ROOT="${CLAUDE_PROJECT_DIR:-.}"
+if [ ! -f "$WORK_ROOT/.codegraph/graph.db" ]; then
+  exit 0
+fi
+
+# Guard: must have staged changes
+STAGED=$(git diff --cached --name-only 2>/dev/null) || true
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Run diff-impact and capture output
+IMPACT=$(node "$WORK_ROOT/src/cli.js" diff-impact --staged -T 2>/dev/null) || true
+
+if [ -z "$IMPACT" ]; then
+  exit 0
+fi
+
+# Escape for JSON embedding
+ESCAPED=$(printf '%s' "$IMPACT" | node -e "
+  let d='';
+  process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d)));
+" 2>/dev/null) || true
+
+if [ -z "$ESCAPED" ]; then
+  exit 0
+fi
+
+# Inject as additionalContext — never block
+node -e "
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      additionalContext: '[codegraph diff-impact] Pre-commit blast radius:\\n' + JSON.parse(process.argv[1])
+    }
+  }));
+" "$ESCAPED" 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-git.sh\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/show-diff-impact.sh\"",
+            "timeout": 15
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Adds `show-diff-impact.sh` hook that automatically runs `codegraph diff-impact --staged -T` before `git commit` commands
- Injects blast radius summary as `additionalContext` — informational only, never blocks commits
- Registers hook in `.claude/settings.json` after `guard-git.sh` with 15s timeout

## Details

The hook:
- Triggers on PreToolUse for Bash when the command matches `git commit`
- Guards: skips silently if no `.codegraph/graph.db` exists, no staged changes, or empty output
- JSON-escapes the diff-impact output and injects it with `[codegraph diff-impact]` prefix
- Every failure path exits 0 gracefully — never interferes with commits

## Test plan
- [ ] Stage a file and run `git commit` via Claude Code — hook output should appear as context
- [ ] Verify hook doesn't block — commit proceeds normally
- [ ] Verify graceful skip when no graph DB exists
- [ ] Verify graceful skip when no staged changes