### PR TITLE
docs: add Claude Code MCP registration to recommended practices

### DIFF
--- a/docs/guides/recommended-practices.md
+++ b/docs/guides/recommended-practices.md
@@ -177,7 +177,7 @@ claude mcp add --transport stdio codegraph -- codegraph mcp
 claude mcp add --transport stdio codegraph -- cmd /c codegraph mcp
 ```
 
-This saves the server to your local Claude Code config. Once registered, Claude can call codegraph tools (`where`, `explain`, `fn_impact`, `diff_impact`, etc.) natively — including from custom subagents like a [planner agent](#custom-planner-agent).
+This saves the server to your local Claude Code config. Once registered, Claude can call codegraph tools (`where`, `explain`, `fn_impact`, `diff_impact`, etc.) natively — including from custom subagents.
 
 Use `--scope project` to check it into `.mcp.json` so the whole team gets it:
 


### PR DESCRIPTION
## Summary
- Add `claude mcp add` registration instructions to the MCP server section in recommended practices
- Include platform-specific commands (Linux/macOS and Windows)
- Document `--scope project` for team-wide `.mcp.json` sharing
- Add as step 10 in the setup checklist

## Test plan
- [ ] Verify `claude mcp add --transport stdio codegraph -- codegraph mcp` works on Linux/macOS
- [ ] Verify `claude mcp add --transport stdio codegraph -- cmd /c codegraph mcp` works on Windows
- [ ] Confirm `claude mcp list` shows the registered server after setup