### PR TITLE
docs: update architecture audit and roadmap for v2.7.0

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -439,8 +439,8 @@ Persist and query selected AST node types for pattern-based codebase exploration
 
 Split per-language extractors from monolithic `parser.js` into dedicated modules.
 
-- ✅ New `src/extractors/` directory with 11 files (2,299 lines total)
-- ✅ One file per language: `javascript.js` (750), `csharp.js` (248), `php.js` (243), `java.js` (230), `rust.js` (225), `ruby.js` (188), `go.js` (172), `python.js` (150), `hcl.js` (73)
+- ✅ New `src/extractors/` directory with 11 files (3,023 lines total)
+- ✅ One file per language: `javascript.js` (892), `csharp.js` (311), `php.js` (322), `java.js` (290), `rust.js` (295), `ruby.js` (277), `go.js` (237), `python.js` (284), `hcl.js` (95)
 - ✅ Shared utilities in `helpers.js` (`nodeEndLine()`, `findChild()`)
 - ✅ Barrel export via `index.js`
 - ✅ Consistent return schema: `{ definitions, calls, imports, classes, exports }`
@@ -705,9 +705,7 @@ Export only `*Data()` functions (the command execute functions). Never export CL
 
 **Affected files:** `src/index.js`, `package.json`
 
-### ~~3.8~~ -- ~~Decompose complexity.js~~ Subsumed by 3.1
-
-> The standalone complexity decomposition from the previous revision is now part of the unified AST analysis framework (3.1). The `complexity.js` per-language rules become `ast-analysis/rules/complexity/{lang}.js` alongside CFG and dataflow rules.
+> **Removed: Decompose complexity.js** — Subsumed by 3.1. The standalone complexity decomposition from the previous revision is now part of the unified AST analysis framework (3.1). The `complexity.js` per-language rules become `ast-analysis/rules/complexity/{lang}.js` alongside CFG and dataflow rules.
 
 ### 3.8 -- Domain Error Hierarchy
 

--- a/generated/architecture.md
+++ b/generated/architecture.md
@@ -30,7 +30,7 @@
 | Test files | 59 | 70 | +11 |
 | Node kinds | 10 | 13 | +3 (parameter, property, constant) |
 | Edge kinds | 6 | 9 | +3 (contains, parameter_of, receiver) |
-| Extractor modules | 0 (inline in parser.js) | 11 files, 2,299 lines | New directory |
+| Extractor modules | 0 (inline in parser.js) | 11 files, 3,023 lines | New directory |
 
 **Key patterns observed in this burst:**
 
@@ -209,19 +209,19 @@ Both complexity and CFG analysis walk the same AST trees with language-specific 
 
 **Previous state:** parser.js at 404 lines with inline extractors.
 
-**Current state:** `src/extractors/` directory with 11 files totaling 2,299 lines:
+**Current state:** `src/extractors/` directory with 11 files totaling 3,023 lines:
 
 | File | Lines | Language |
 |------|-------|----------|
-| `javascript.js` | 750 | JS/TS/TSX |
-| `csharp.js` | 248 | C# |
-| `php.js` | 243 | PHP |
-| `java.js` | 230 | Java |
-| `rust.js` | 225 | Rust |
-| `ruby.js` | 188 | Ruby |
-| `go.js` | 172 | Go |
-| `python.js` | 150 | Python |
-| `hcl.js` | 73 | Terraform/HCL |
+| `javascript.js` | 892 | JS/TS/TSX |
+| `csharp.js` | 311 | C# |
+| `php.js` | 322 | PHP |
+| `java.js` | 290 | Java |
+| `rust.js` | 295 | Rust |
+| `ruby.js` | 277 | Ruby |
+| `go.js` | 237 | Go |
+| `python.js` | 284 | Python |
+| `hcl.js` | 95 | Terraform/HCL |
 | `helpers.js` | 11 | Shared utilities |
 | `index.js` | 9 | Barrel export |
 


### PR DESCRIPTION
## Summary

- Add **Phase 2.7** (Deep Analysis & Graph Enrichment) to the roadmap with 12 subsections covering all features shipped since the last review: dataflow analysis, intraprocedural CFG, AST node storage, expanded node/edge types (13 kinds, 9 edge kinds), extractors refactoring, CLI consolidation, interactive viewer, exports command, normalizeSymbol utility, export format expansion, and MCP tool expansion (25→34)
- Update **architecture.md** with current metrics (50 modules, 26,277 lines, 13 tables, 34 MCP tools, 47 CLI commands, 70 test files) and add new critical concern: three independent AST analysis engines (complexity + CFG + dataflow = 4,801 lines) sharing no infrastructure
- Update **Phase 3** priorities: new #1 is unified AST analysis framework; renumber all items; update all metrics; mark qualified names as partially addressed; subsume complexity decomposition into AST framework
- Update **Phase 4** type definitions with new kind/edge type hierarchies (`CoreSymbolKind`/`ExtendedSymbolKind`, `CoreEdgeKind`/`StructuralEdgeKind`, `ASTNodeKind`, `ASTVisitor`)
- Mark **Phase 9.1** visualization as partially complete (plot command covers static HTML viewer)

## Test plan

- [ ] Verify all internal anchor links resolve correctly in both files
- [ ] Verify Phase 3 section numbering is sequential (3.1–3.14)
- [ ] Spot-check metrics against actual codebase (`wc -l src/*.js`, `git show origin/main:src/mcp.js | grep "name: '" | wc -l`, etc.)