### PR TITLE
fix: prevent duplicate benchmark PRs on stable releases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event != 'push')
     permissions:
       actions: read
       contents: write
@@ -139,17 +140,23 @@ jobs:
           git commit -m "docs: update build performance benchmarks (${VERSION})"
           git push origin "$BRANCH"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "docs: update build performance benchmarks (${VERSION})" \
-            --body "Automated build benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          TITLE="docs: update build performance benchmarks (${VERSION})"
+          if gh pr list --state open --json title --jq ".[].title" | grep -qF "$TITLE"; then
+            echo "::notice::PR already open for '$TITLE' — skipping"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "Automated build benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
 
   embedding-benchmark:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event != 'push')
     permissions:
       actions: read
       contents: write
@@ -284,17 +291,23 @@ jobs:
           git commit -m "docs: update embedding benchmarks (${VERSION})"
           git push origin "$BRANCH"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "docs: update embedding benchmarks (${VERSION})" \
-            --body "Automated embedding benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          TITLE="docs: update embedding benchmarks (${VERSION})"
+          if gh pr list --state open --json title --jq ".[].title" | grep -qF "$TITLE"; then
+            echo "::notice::PR already open for '$TITLE' — skipping"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "Automated embedding benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
 
   query-benchmark:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event != 'push')
     permissions:
       actions: read
       contents: write
@@ -415,17 +428,23 @@ jobs:
           git commit -m "docs: update query benchmarks (${VERSION})"
           git push origin "$BRANCH"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "docs: update query benchmarks (${VERSION})" \
-            --body "Automated query benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          TITLE="docs: update query benchmarks (${VERSION})"
+          if gh pr list --state open --json title --jq ".[].title" | grep -qF "$TITLE"; then
+            echo "::notice::PR already open for '$TITLE' — skipping"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "Automated query benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
 
   incremental-benchmark:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event != 'push')
     permissions:
       actions: read
       contents: write
@@ -546,8 +565,13 @@ jobs:
           git commit -m "docs: update incremental benchmarks (${VERSION})"
           git push origin "$BRANCH"
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "docs: update incremental benchmarks (${VERSION})" \
-            --body "Automated incremental benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          TITLE="docs: update incremental benchmarks (${VERSION})"
+          if gh pr list --state open --json title --jq ".[].title" | grep -qF "$TITLE"; then
+            echo "::notice::PR already open for '$TITLE' — skipping"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "Automated incremental benchmark update for **${VERSION}** from workflow run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi


### PR DESCRIPTION
## Summary

- Filter benchmark `workflow_run` triggers to exclude push-initiated Publish completions — dev builds should not benchmark the latest stable tag
- Add duplicate-PR guard before `gh pr create` in all 4 benchmark jobs as a safety net

## Root cause

During the 3.0.0 release, two Publish workflow runs completed successfully within minutes of each other:
1. A **push** event (dev build from merging a PR to main) at 10:05
2. The **release** event (actual v3.0.0 publish) at 10:07

Both triggered separate Benchmark workflow runs. Each resolved to version `3.0.0` via `git tag --sort=-version:refname`, creating duplicate PRs (#298-#300 and #301-#303).

## Test plan

- [ ] Verify next stable release creates only one set of benchmark PRs
- [ ] Verify dev pushes to main no longer trigger benchmark runs
- [ ] Verify `workflow_dispatch` benchmarks still work as expected

Closes duplicate PRs: #301, #302, #303 (already closed)