### PR TITLE
ci: replace npm ci with npm install in benchmark and license workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,7 +37,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: npm install --prefer-offline --no-audit --no-fund
 
       - name: Determine benchmark mode
         id: mode
@@ -175,7 +175,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: npm install --prefer-offline --no-audit --no-fund
 
       - name: Determine benchmark mode
         id: mode
@@ -326,7 +326,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: npm install --prefer-offline --no-audit --no-fund
 
       - name: Determine benchmark mode
         id: mode
@@ -463,7 +463,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: npm install --prefer-offline --no-audit --no-fund
 
       - name: Determine benchmark mode
         id: mode

--- a/.github/workflows/shield-license-compliance.yml
+++ b/.github/workflows/shield-license-compliance.yml
@@ -32,12 +32,12 @@ jobs:
         shell: bash
         run: |
           for attempt in 1 2 3; do
-            npm ci --prefer-offline --no-audit --no-fund --ignore-scripts && break
+            npm install --prefer-offline --no-audit --no-fund --ignore-scripts && break
             if [ "$attempt" -lt 3 ]; then
-              echo "::warning::npm ci attempt $attempt failed, retrying in 15s..."
+              echo "::warning::npm install attempt $attempt failed, retrying in 15s..."
               sleep 15
             else
-              echo "::error::npm ci failed after 3 attempts"
+              echo "::error::npm install failed after 3 attempts"
               exit 1
             fi
           done


### PR DESCRIPTION
## Summary
- Replace `npm ci` with `npm install` in the license compliance scan and benchmark workflows
- `npm ci` fails when `package-lock.json` is out of sync with `package.json` for the `@optave/codegraph-*` native binary optional deps (only published during release)
- `npm install` tolerates missing optional deps gracefully, matching the main CI workflow

Fixes the "License Compliance Scan" failure on PRs #298, #300, #307.

## Test plan
- [ ] Verify license compliance scan passes on this PR
- [ ] Verify benchmark workflow can still run successfully