### PR TITLE
fix: bump native engine version to 3.0.0

### DIFF
--- a/crates/codegraph-core/Cargo.toml
+++ b/crates/codegraph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codegraph-core"
-version = "2.6.0"
+version = "3.0.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Bumps `crates/codegraph-core/Cargo.toml` version from `2.6.0` to `3.0.0` to match `package.json`
- Fixes `codegraph info` reporting stale native version and potential unnecessary full rebuilds from version mismatch detection in `buildGraph()`

Closes #305

## Test plan
- [ ] After native binary rebuild, verify `codegraph info` shows `Native version: 3.0.0`
- [ ] Verify no version mismatch warning in `codegraph build` output