### PR TITLE
ci: include Cargo.toml in publish version bump commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -432,10 +432,10 @@ jobs:
           BRANCH="release/v${VERSION}"
 
           # Check if there are version bump changes to push
-          if git diff --quiet HEAD -- package.json package-lock.json CHANGELOG.md generated/DEPENDENCIES.json; then
+          if git diff --quiet HEAD -- package.json package-lock.json CHANGELOG.md generated/DEPENDENCIES.json crates/codegraph-core/Cargo.toml; then
             echo "No version bump commit to push — skipping PR"
           else
-            git add -f package.json package-lock.json CHANGELOG.md generated/DEPENDENCIES.json
+            git add -f package.json package-lock.json CHANGELOG.md generated/DEPENDENCIES.json crates/codegraph-core/Cargo.toml
             git commit -m "chore: release v${VERSION}"
             git push origin "HEAD:refs/heads/${BRANCH}"
             gh pr create \


### PR DESCRIPTION
## Summary

- The publish workflow runs `sync-native-versions.js` which updates `crates/codegraph-core/Cargo.toml` with the release version, but the version bump commit only staged `package.json`, `package-lock.json`, `CHANGELOG.md`, and `DEPENDENCIES.json`
- This left `Cargo.toml` out of the commit, causing the native engine version to drift from the npm version after each release
- This is the root cause of #310 — the Cargo.toml version had to be manually bumped from `2.6.0` to `3.0.0`

Adds `crates/codegraph-core/Cargo.toml` to both the `git diff` check and `git add` in the "Push version bump via PR" step.

## Test plan

- [ ] Next stable release: verify the version bump PR includes `Cargo.toml` changes
- [ ] Verify `codegraph info` reports matching native/npm versions after release