### PR TITLE
chore: release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.0.2](https://github.com/optave/codegraph/compare/v3.0.1...v3.0.2) (2026-03-04)
+
+**Dataflow goes multi-language, build performance recovery, and native engine parity fixes.** This patch extends dataflow analysis from JS/TS-only to all 11 supported languages, recovers build performance lost after CFG/dataflow became default-on, fixes language-aware identifier collection in dataflow, and closes a native engine scoping bug for constants.
+
+### Features
+
+* **dataflow:** extend dataflow analysis to all supported languages (Python, Go, Rust, Java, C#, PHP, Ruby) with per-language `DATAFLOW_RULES` and `makeDataflowRules()` factory ([#318](https://github.com/optave/codegraph/pull/318))
+
+### Bug Fixes
+
+* **dataflow:** use `isIdent` in `collectIdentifiers` for language-aware `referencedNames` — fixes PHP `variable_name` and other non-`identifier` node types being missed in return statements ([#324](https://github.com/optave/codegraph/pull/324))
+* **native:** skip local constants inside function bodies — the native JS extractor incorrectly extracted function-scoped `const` as top-level constants ([#327](https://github.com/optave/codegraph/pull/327))
+* **native:** enable extended kinds (parameters, properties, constants, receivers) in parity tests and update native binary to v3.0.1 ([#327](https://github.com/optave/codegraph/pull/327))
+
+### Performance
+
+* **builder:** fix v3.0.1 build performance regression (14.1 → ~5.8 ms/file) — eliminate redundant WASM parsing via `ensureWasmTrees()`, memoize `createParsers()`, filter CFG/dataflow to changed files only ([#325](https://github.com/optave/codegraph/pull/325))
+
+### Documentation
+
+* update build performance, query, and incremental benchmarks for 3.0.1 ([#321](https://github.com/optave/codegraph/pull/321), [#322](https://github.com/optave/codegraph/pull/322), [#323](https://github.com/optave/codegraph/pull/323))
+
 ## [3.0.1](https://github.com/optave/codegraph/compare/v3.0.0...v3.0.1) (2026-03-03)
 
 **Post-release fixes and dataflow multi-language expansion.** This patch extends dataflow analysis (`flows_to`, `returns`, `mutates` edges) from JS/TS-only to all 11 supported languages, enables `--cfg` and `--dataflow` by default on builds, closes several native/WASM engine parity gaps, and fixes miscellaneous issues found during v3.0.0 dogfooding.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Local code graph CLI — parse codebases with tree-sitter, build dependency graphs, query them",
   "type": "module",
   "main": "src/index.js",
@@ -71,10 +71,10 @@
   },
   "optionalDependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@optave/codegraph-darwin-arm64": "3.0.1",
-    "@optave/codegraph-darwin-x64": "3.0.1",
-    "@optave/codegraph-linux-x64-gnu": "3.0.1",
-    "@optave/codegraph-win32-x64-msvc": "3.0.1"
+    "@optave/codegraph-darwin-arm64": "3.0.2",
+    "@optave/codegraph-darwin-x64": "3.0.2",
+    "@optave/codegraph-linux-x64-gnu": "3.0.2",
+    "@optave/codegraph-win32-x64-msvc": "3.0.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",


### PR DESCRIPTION
## Summary
- Add CHANGELOG entry for v3.0.2 covering all changes since v3.0.1
- Bump version to 3.0.2 in package.json (main version + 4 native binary optional deps)

## Changes included in 3.0.2
- **feat:** extend dataflow analysis to all supported languages (#318)
- **perf:** fix build performance regression 14.1 → ~5.8 ms/file (#325)
- **fix:** language-aware `collectIdentifiers` for dataflow (#324)
- **fix:** native engine local constant scoping + extended kinds parity (#327)
- **docs:** benchmark updates (#321, #322, #323)