### PR TITLE
fix: show all build phases in benchmark report

### DIFF
--- a/generated/benchmarks/BUILD-BENCHMARKS.md
+++ b/generated/benchmarks/BUILD-BENCHMARKS.md
@@ -132,6 +132,16 @@ calls, but the v2.3.0 CI benchmark confirms this was **insufficient** — WASM
 remains at 6.6 ms/file (vs 5.0 in v2.0.0). The WASM/Native ratio widened from
 2.0x to 3.5x. Further optimization of WASM boundary crossings in the JS
 extractor is needed to recover the regression.
+
+**Native build regression (v3.0.0 4.4 ms/file → v3.0.3 12.3 ms/file):** The regression is entirely
+from four new build phases added in v3.0.1 that are now default-on: AST node extraction (651ms),
+WASM pre-parse (388ms), dataflow analysis (367ms), and CFG construction (169ms) — totalling ~1,575ms
+of new work. The original seven phases (parse, insert, resolve, edges, structure, roles, complexity)
+actually got slightly faster (728ms → 542ms). The WASM pre-parse phase exists because CFG, dataflow,
+and complexity are implemented in JS and need tree-sitter AST trees to walk, but the native Rust engine
+only returns extracted symbols — not AST trees. So on native builds, all 172 files get parsed twice:
+once by Rust (85ms) and once by WASM (388ms). Eliminating this double-parse requires either implementing
+CFG/dataflow in Rust, or having the native engine expose tree-sitter trees to JS.
 <!-- NOTES_END -->
 
 <!-- BENCHMARK_DATA

--- a/scripts/update-benchmark-report.js
+++ b/scripts/update-benchmark-report.js
@@ -152,15 +152,19 @@ for (const engineKey of ['native', 'wasm']) {
 const hasPhases = latest.native?.phases || latest.wasm?.phases;
 if (hasPhases) {
 	md += '### Build Phase Breakdown (latest)\n\n';
-	const phaseKeys = ['parseMs', 'insertMs', 'resolveMs', 'edgesMs', 'structureMs', 'rolesMs', 'complexityMs'];
+	const phaseKeys = ['parseMs', 'wasmPreMs', 'insertMs', 'resolveMs', 'edgesMs', 'structureMs', 'rolesMs', 'astMs', 'complexityMs', 'cfgMs', 'dataflowMs'];
 	const phaseLabels = {
 		parseMs: 'Parse',
+		wasmPreMs: 'WASM pre-parse',
 		insertMs: 'Insert nodes',
 		resolveMs: 'Resolve imports',
 		edgesMs: 'Build edges',
 		structureMs: 'Structure',
 		rolesMs: 'Roles',
+		astMs: 'AST nodes',
 		complexityMs: 'Complexity',
+		cfgMs: 'CFG',
+		dataflowMs: 'Dataflow',
 	};
 
 	md += '| Phase | Native | WASM |\n';


### PR DESCRIPTION
## Summary

- Add 4 missing phases to the benchmark phase breakdown table: `astMs`, `cfgMs`, `dataflowMs`, `wasmPreMs`
- These phases account for ~75% of native build time since v3.0.1 but were invisible in the report
- Add explanatory note documenting the v3.0.0 (4.4 ms/file) → v3.0.3 (12.3 ms/file) native regression cause: four new default-on phases totalling ~1,575ms, plus WASM double-parse on native builds

## Root cause of regression

The native build time tripled not because existing phases got slower, but because four new phases became default-on in v3.0.1:

| Phase | Time (CI) | Existed in 3.0.0? |
|-------|----------:|---|
| AST nodes | 651ms | No |
| WASM pre-parse | 388ms | No |
| Dataflow | 367ms | No |
| CFG | 169ms | No |
| **Total** | **1,575ms** | |

The WASM pre-parse is particularly wasteful: on native builds, all files get parsed twice (Rust 85ms + WASM 388ms) because CFG/dataflow/complexity are JS code that needs tree-sitter AST trees the native engine doesn't expose.

## Test plan

- [x] Script change is display-only — adds phase keys to markdown table
- [x] Notes section uses preserved `NOTES_START`/`NOTES_END` markers