### PR TITLE
fix: native no-op rebuild regression (~80x slower than WASM)

### DIFF
--- a/src/cfg.js
+++ b/src/cfg.js
@@ -1117,7 +1117,7 @@ export async function buildCFGData(db, fileSymbols, rootDir, _engineOpts) {
 
       // WASM fallback if no cached tree and not all native
       if (!tree && !allNative) {
-        if (!extToLang || !getParserFn) continue;
+        if (!getParserFn) continue;
         langId = extToLang.get(ext);
         if (!langId || !CFG_LANG_IDS.has(langId)) continue;
 
@@ -1140,7 +1140,7 @@ export async function buildCFGData(db, fileSymbols, rootDir, _engineOpts) {
       }
 
       if (!langId) {
-        langId = extToLang ? extToLang.get(ext) : null;
+        langId = extToLang.get(ext);
         if (!langId) continue;
       }
 

--- a/src/dataflow.js
+++ b/src/dataflow.js
@@ -1071,7 +1071,7 @@ export async function buildDataflowEdges(db, fileSymbols, rootDir, _engineOpts) 
 
         // WASM fallback if no cached tree
         if (!tree) {
-          if (!extToLang || !getParserFn) continue;
+          if (!getParserFn) continue;
           langId = extToLang.get(ext);
           if (!langId || !DATAFLOW_LANG_IDS.has(langId)) continue;
 
@@ -1094,7 +1094,7 @@ export async function buildDataflowEdges(db, fileSymbols, rootDir, _engineOpts) 
         }
 
         if (!langId) {
-          langId = extToLang ? extToLang.get(ext) : null;
+          langId = extToLang.get(ext);
           if (!langId) continue;
         }
 


### PR DESCRIPTION
## Summary

- **Root cause:** `buildCFGData` in `cfg.js` only built the `extToLang` map when WASM fallback was needed. When the native engine (3.0.4) provides pre-computed CFG for all functions, `extToLang` stayed `null`. Since native-parsed symbols lack `_langId`, the `langId` lookup fell through to `null` and every file was skipped — leaving `cfg_blocks` empty.
- On each subsequent incremental build, the empty-table guard in `builder.js:534` triggered a full `parseFilesAuto` re-parse of all files (~300ms), making native no-op rebuilds ~80× slower than WASM.
- **Fix:** Move `extToLang` construction before the `needsFallback` check so it is always available. Same defensive fix applied to `buildDataflowEdges`.

## Test plan

- [x] All 1453 tests pass (WASM-grammar-missing failures in worktree are pre-existing/unrelated)
- [x] Verified `cfg_blocks` is populated (13816 rows) after native full build
- [x] Native no-op rebuild: 6-7ms (was ~319ms before fix)
- [x] WASM no-op rebuild: 7-8ms (unchanged)
- [x] Full incremental benchmark shows no regression