### PR TITLE
feat(benchmark): add 1-file rebuild phase breakdown

### DIFF
--- a/generated/benchmarks/BUILD-BENCHMARKS.md
+++ b/generated/benchmarks/BUILD-BENCHMARKS.md
@@ -150,14 +150,11 @@ remains at 6.6 ms/file (vs 5.0 in v2.0.0). The WASM/Native ratio widened from
 extractor is needed to recover the regression.
 
 **Native build regression (v3.0.0 4.4 ms/file → v3.0.3 12.3 ms/file):** The regression is entirely
-from four new build phases added in v3.0.1 that are now default-on: AST node extraction (651ms),
-WASM pre-parse (388ms), dataflow analysis (367ms), and CFG construction (169ms) — totalling ~1,575ms
-of new work. The original seven phases (parse, insert, resolve, edges, structure, roles, complexity)
-actually got slightly faster (728ms → 542ms). The WASM pre-parse phase exists because CFG, dataflow,
-and complexity are implemented in JS and need tree-sitter AST trees to walk, but the native Rust engine
-only returns extracted symbols — not AST trees. So on native builds, all 172 files get parsed twice:
-once by Rust (85ms) and once by WASM (388ms). Eliminating this double-parse requires either implementing
-CFG/dataflow in Rust, or having the native engine expose tree-sitter trees to JS.
+from new build phases added in v3.0.1 that are now default-on: AST node extraction (651ms),
+dataflow analysis (367ms), and CFG construction (169ms) — totalling ~1,187ms of new work. The original
+seven phases (parse, insert, resolve, edges, structure, roles, complexity) actually got slightly faster
+(728ms → 542ms). As of v3.1.0, CFG and dataflow run natively in Rust, eliminating the redundant WASM
+pre-parse that previously added ~388ms on native builds.
 <!-- NOTES_END -->
 
 <!-- BENCHMARK_DATA

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -106,15 +106,19 @@ async function benchmarkEngine(engine) {
 	console.error(`  [${engine}] Benchmarking 1-file rebuild...`);
 	const original = fs.readFileSync(PROBE_FILE, 'utf8');
 	let oneFileRebuildMs;
+	let oneFilePhases = null;
 	try {
-		const oneFileTimings = [];
+		const oneFileRuns = [];
 		for (let i = 0; i < INCREMENTAL_RUNS; i++) {
 			fs.writeFileSync(PROBE_FILE, original + `\n// probe-${i}\n`);
 			const start = performance.now();
-			await buildGraph(root, { engine, incremental: true });
-			oneFileTimings.push(performance.now() - start);
+			const res = await buildGraph(root, { engine, incremental: true });
+			oneFileRuns.push({ ms: performance.now() - start, phases: res?.phases || null });
 		}
-		oneFileRebuildMs = Math.round(median(oneFileTimings));
+		oneFileRuns.sort((a, b) => a.ms - b.ms);
+		const medianRun = oneFileRuns[Math.floor(oneFileRuns.length / 2)];
+		oneFileRebuildMs = Math.round(medianRun.ms);
+		oneFilePhases = medianRun.phases;
 	} finally {
 		fs.writeFileSync(PROBE_FILE, original);
 		await buildGraph(root, { engine, incremental: true });
@@ -157,6 +161,7 @@ async function benchmarkEngine(engine) {
 		},
 		noopRebuildMs,
 		oneFileRebuildMs,
+		oneFilePhases,
 		queries,
 		phases: buildResult?.phases || null,
 	};
@@ -204,6 +209,7 @@ const result = {
 				perFile: wasm.perFile,
 				noopRebuildMs: wasm.noopRebuildMs,
 				oneFileRebuildMs: wasm.oneFileRebuildMs,
+				oneFilePhases: wasm.oneFilePhases,
 				queries: wasm.queries,
 				phases: wasm.phases,
 			}
@@ -218,6 +224,7 @@ const result = {
 				perFile: native.perFile,
 				noopRebuildMs: native.noopRebuildMs,
 				oneFileRebuildMs: native.oneFileRebuildMs,
+				oneFilePhases: native.oneFilePhases,
 				queries: native.queries,
 				phases: native.phases,
 			}

--- a/scripts/incremental-benchmark.js
+++ b/scripts/incremental-benchmark.js
@@ -77,22 +77,26 @@ async function benchmarkBuildTiers(engine) {
 	// 1-file change rebuild
 	const original = fs.readFileSync(PROBE_FILE, 'utf8');
 	let oneFileRebuildMs;
+	let oneFilePhases = null;
 	try {
-		const oneFileTimings = [];
+		const oneFileRuns = [];
 		for (let i = 0; i < RUNS; i++) {
 			fs.writeFileSync(PROBE_FILE, original + `\n// probe-${i}\n`);
 			const start = performance.now();
-			await buildGraph(root, { engine, incremental: true });
-			oneFileTimings.push(performance.now() - start);
+			const res = await buildGraph(root, { engine, incremental: true });
+			oneFileRuns.push({ ms: performance.now() - start, phases: res?.phases || null });
 		}
-		oneFileRebuildMs = Math.round(median(oneFileTimings));
+		oneFileRuns.sort((a, b) => a.ms - b.ms);
+		const medianRun = oneFileRuns[Math.floor(oneFileRuns.length / 2)];
+		oneFileRebuildMs = Math.round(medianRun.ms);
+		oneFilePhases = medianRun.phases;
 	} finally {
 		fs.writeFileSync(PROBE_FILE, original);
 		// One final incremental build to restore DB state
 		await buildGraph(root, { engine, incremental: true });
 	}
 
-	return { fullBuildMs, noopRebuildMs, oneFileRebuildMs };
+	return { fullBuildMs, noopRebuildMs, oneFileRebuildMs, oneFilePhases };
 }
 
 /**
@@ -207,6 +211,7 @@ const result = {
 				fullBuildMs: wasm.fullBuildMs,
 				noopRebuildMs: wasm.noopRebuildMs,
 				oneFileRebuildMs: wasm.oneFileRebuildMs,
+				oneFilePhases: wasm.oneFilePhases,
 			}
 		: null,
 	native: native
@@ -214,6 +219,7 @@ const result = {
 				fullBuildMs: native.fullBuildMs,
 				noopRebuildMs: native.noopRebuildMs,
 				oneFileRebuildMs: native.oneFileRebuildMs,
+				oneFilePhases: native.oneFilePhases,
 			}
 		: null,
 	resolve,

--- a/scripts/update-benchmark-report.js
+++ b/scripts/update-benchmark-report.js
@@ -148,31 +148,46 @@ for (const engineKey of ['native', 'wasm']) {
 	md += `| Files | ${latest.files} |\n\n`;
 }
 
+// ── Shared phase definitions ──────────────────────────────────────────
+const PHASE_KEYS = ['parseMs', 'insertMs', 'resolveMs', 'edgesMs', 'structureMs', 'rolesMs', 'astMs', 'complexityMs', 'cfgMs', 'dataflowMs'];
+const PHASE_LABELS = {
+	parseMs: 'Parse',
+	insertMs: 'Insert nodes',
+	resolveMs: 'Resolve imports',
+	edgesMs: 'Build edges',
+	structureMs: 'Structure',
+	rolesMs: 'Roles',
+	astMs: 'AST nodes',
+	complexityMs: 'Complexity',
+	cfgMs: 'CFG',
+	dataflowMs: 'Dataflow',
+};
+
+function fmtPhase(val) {
+	return val != null ? val + ' ms' : 'n/a';
+}
+
 // ── Build Phase Breakdown (latest) ────────────────────────────────────
 const hasPhases = latest.native?.phases || latest.wasm?.phases;
+const hasOneFilePhases = latest.native?.oneFilePhases || latest.wasm?.oneFilePhases;
 if (hasPhases) {
 	md += '### Build Phase Breakdown (latest)\n\n';
-	const phaseKeys = ['parseMs', 'wasmPreMs', 'insertMs', 'resolveMs', 'edgesMs', 'structureMs', 'rolesMs', 'astMs', 'complexityMs', 'cfgMs', 'dataflowMs'];
-	const phaseLabels = {
-		parseMs: 'Parse',
-		wasmPreMs: 'WASM pre-parse',
-		insertMs: 'Insert nodes',
-		resolveMs: 'Resolve imports',
-		edgesMs: 'Build edges',
-		structureMs: 'Structure',
-		rolesMs: 'Roles',
-		astMs: 'AST nodes',
-		complexityMs: 'Complexity',
-		cfgMs: 'CFG',
-		dataflowMs: 'Dataflow',
-	};
-
-	md += '| Phase | Native | WASM |\n';
-	md += '|-------|-------:|-----:|\n';
-	for (const key of phaseKeys) {
-		const nVal = latest.native?.phases?.[key];
-		const wVal = latest.wasm?.phases?.[key];
-		md += `| ${phaseLabels[key]} | ${nVal != null ? nVal + ' ms' : 'n/a'} | ${wVal != null ? wVal + ' ms' : 'n/a'} |\n`;
+	if (hasOneFilePhases) {
+		md += '| Phase | Native (build) | WASM (build) | Native (1-file) | WASM (1-file) |\n';
+		md += '|-------|---------------:|-------------:|----------------:|--------------:|\n';
+		for (const key of PHASE_KEYS) {
+			const nb = fmtPhase(latest.native?.phases?.[key]);
+			const wb = fmtPhase(latest.wasm?.phases?.[key]);
+			const nr = fmtPhase(latest.native?.oneFilePhases?.[key]);
+			const wr = fmtPhase(latest.wasm?.oneFilePhases?.[key]);
+			md += `| ${PHASE_LABELS[key]} | ${nb} | ${wb} | ${nr} | ${wr} |\n`;
+		}
+	} else {
+		md += '| Phase | Native | WASM |\n';
+		md += '|-------|-------:|-----:|\n';
+		for (const key of PHASE_KEYS) {
+			md += `| ${PHASE_LABELS[key]} | ${fmtPhase(latest.native?.phases?.[key])} | ${fmtPhase(latest.wasm?.phases?.[key])} |\n`;
+		}
 	}
 	md += '\n';
 }

--- a/src/builder.js
+++ b/src/builder.js
@@ -1448,16 +1448,12 @@ export async function buildGraph(rootDir, opts = {}) {
     }
 
     if (needsWasmTrees) {
-      _t.wasmPre0 = performance.now();
       try {
         const { ensureWasmTrees } = await import('./parser.js');
         await ensureWasmTrees(astComplexitySymbols, rootDir);
       } catch (err) {
         debug(`WASM pre-parse failed: ${err.message}`);
       }
-      _t.wasmPreMs = performance.now() - _t.wasmPre0;
-    } else {
-      _t.wasmPreMs = 0;
     }
   }
 
@@ -1601,7 +1597,6 @@ export async function buildGraph(rootDir, opts = {}) {
       rolesMs: +_t.rolesMs.toFixed(1),
       astMs: +_t.astMs.toFixed(1),
       complexityMs: +_t.complexityMs.toFixed(1),
-      ...(_t.wasmPreMs != null && { wasmPreMs: +_t.wasmPreMs.toFixed(1) }),
       ...(_t.cfgMs != null && { cfgMs: +_t.cfgMs.toFixed(1) }),
       ...(_t.dataflowMs != null && { dataflowMs: +_t.dataflowMs.toFixed(1) }),
     },


### PR DESCRIPTION
## Summary
- Capture per-phase timing from incremental 1-file rebuilds (median run) in both `benchmark.js` and `incremental-benchmark.js`
- Render build and 1-file rebuild phases side-by-side in a single combined table: `Native (build) | WASM (build) | Native (1-file) | WASM (1-file)`
- Remove obsolete `wasmPreMs` phase tracking from builder and report generator — always 0ms now that CFG/dataflow run natively

## Test plan
- [ ] Run `node scripts/benchmark.js` and verify `oneFilePhases` appears in JSON output for both engines
- [ ] Pipe output to `node scripts/update-benchmark-report.js` and verify the combined 4-column phase table renders correctly
- [ ] Verify older benchmark data (without `oneFilePhases`) falls back to the 2-column layout