### PR TITLE
fix: reconcile dogfood report data inconsistencies

### DIFF
--- a/generated/dogfood/DOGFOOD_REPORT_v3.1.0.md
+++ b/generated/dogfood/DOGFOOD_REPORT_v3.1.0.md
@@ -28,7 +28,7 @@ All 34 commands tested without a graph database present.
 
 | Command | Status | Message |
 |---------|--------|---------|
-| `query`, `map`, `stats`, `deps`, `fn-impact`, `context`, `where`, `impact`, `cycles`, `export`, `structure`, `roles`, `complexity`, `communities`, `triage`, `audit`, `search`, `diff-impact`, `check`, `path`, `exports`, `children`, `owners`, `co-change`, `dataflow`, `cfg`, `ast`, `sequence`, `batch` | PASS | "No codegraph database found. Run `codegraph build` first." |
+| `query`, `map`, `stats`, `deps`, `fn-impact`, `context`, `where`, `impact`, `cycles`, `export`, `structure`, `roles`, `complexity`, `communities`, `triage`, `audit`, `search`, `diff-impact`, `check`, `path`, `exports`, `children`, `owners`, `co-change`, `dataflow`, `cfg`, `ast`, `sequence`, `batch`, `branch-compare` | PASS | "No codegraph database found. Run `codegraph build` first." |
 | `flow` (no args) | PASS | "Provide a function/entry point name or use --list" |
 | `info` | PASS | Shows diagnostics without needing DB |
 | `models` | PASS | Lists 7 embedding models |
@@ -349,7 +349,7 @@ Note: Package is ESM-only (`"type": "module"`). CJS `require()` fails with `ERR_
 | No-op rebuild (ms) | 6 | 8 |
 | 1-file rebuild (ms) | 1111 | 1267 |
 | Nodes | 3673 | 3682 |
-| Edges | 7937 | 7978 |
+| Edges | 7930 | 7978 |
 | DB size | 14.4 MB | 13.8 MB |
 
 ### Incremental Benchmark


### PR DESCRIPTION
## Summary

Follow-up to #374. Fixes two data inconsistencies in the v3.1.0 dogfood report:

- **Edge count (Section 5 vs 8 mismatch):** The native engine edge count in the full-build benchmark table (line 352) read 7937, but Section 8 reported 7930. Changed to 7930 to match the authoritative graph-quality section.
- **Cold-start command count (33 to 34):** The grouped command list in Section 2 was missing `branch-compare`. Added it after `batch` so the list matches the "34/34 commands" claim on line 37.

## Test plan

- [x] Verify edge count row now reads `| Edges | 7930 | 7978 |`
- [x] Verify `branch-compare` appears in the cold-start command list
- [x] Confirm "34/34 commands" text is consistent with the listed commands