### PR TITLE
docs: add 'never ignore lint warnings' working principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,5 +195,5 @@ Requires Node >= 20.
 
 * Never silently skip or dismiss linting/formatting warnings — always check whether they are relevant to the current change
 * If a warning fires on code you touched, fix it
-* If a warning fires on code you didn't touch, mention it to the user but don't fix it (per the "don't clean up other sessions' files" rule)
+* If a warning fires on code you didn't touch, mention it to the user but don't fix it (per the "Do not clean up lint/format issues in files you aren't working on" rule in Parallel Sessions)
 * Run `npm run lint` after editing code and review the output — do not assume warnings are spurious


### PR DESCRIPTION
## Summary
- Adds working principle #2 to CLAUDE.md: "Never Ignore Lint Warnings"
- Requires always checking lint output for relevance, fixing warnings on touched code, and surfacing warnings on untouched code

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm new principle doesn't conflict with existing rules