### PR TITLE
fix: remove unused rolesData import

### DIFF
--- a/tests/integration/queries.test.js
+++ b/tests/integration/queries.test.js
@@ -37,7 +37,6 @@ import {
   moduleMapData,
   pathData,
   queryNameData,
-  rolesData,
   statsData,
   whereData,
 } from '../../src/queries.js';


### PR DESCRIPTION
## Summary
- Remove unused `rolesData` import in `tests/integration/queries.test.js` flagged by Biome (`lint/correctness/noUnusedImports`)

## Test plan
- [x] `npx biome check tests/integration/queries.test.js` — clean, no warnings
- [x] `npx vitest run tests/integration/queries.test.js` — 73/73 pass