### PR TITLE
fix: only trigger Claude review on PR open, not every push

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,7 +2,7 @@ name: Claude Code
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:


### PR DESCRIPTION
## Summary

- Remove `synchronize` from the `pull_request` trigger types in `claude.yml` so the automated review job only runs when a PR is **first opened**, not on every subsequent push
- After the initial review, re-reviews require an explicit `@claude` comment — same pattern as Greptile's `@greptileai` trigger

## Test plan

- [ ] Open a new PR — Claude automated review should run
- [ ] Push a commit to an existing PR — Claude should NOT run automatically
- [ ] Comment `@claude` on a PR — interactive Claude should respond
