### PR TITLE
chore: release v3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.1.4](https://github.com/optave/codegraph/compare/v3.1.3...v3.1.4) (2026-03-16)
+
+**Phase 3 architectural refactoring reaches near-completion.** This release delivers 11 of 14 roadmap tasks in Phase 3 (Vertical Slice Architecture), restructuring the codebase from a flat collection of large files into a modular subsystem layout. The 3,395-line `queries.js` is decomposed into `src/analysis/` and `src/shared/` modules. The MCP tool registry becomes composable. CLI commands are self-contained modules under `src/commands/`. A domain error hierarchy replaces ad-hoc throws. The build pipeline is decomposed into named stages. The embedder is extracted into `src/embeddings/` with pluggable stores and search strategies. A unified graph model (`src/graph/`) consolidates four parallel graph representations. Nodes gain qualified names, hierarchical scoping, and visibility metadata. An `InMemoryRepository` enables fast unit testing without SQLite. The presentation layer (`src/presentation/`) separates all output formatting from domain logic. `better-sqlite3` is bumped to 12.8.0.
+
+### Features
+
+* **graph-model:** unified in-memory `CodeGraph` model with 3 builders, 6 algorithms, and 2 classifiers — consolidates four parallel graph representations into `src/graph/` ([#435](https://github.com/optave/codegraph/pull/435), [#436](https://github.com/optave/codegraph/pull/436))
+* **qualified-names:** `qualified_name`, `scope`, and `visibility` columns on nodes (migration v15) — enables direct lookups like "all methods of class X" without edge traversal ([#437](https://github.com/optave/codegraph/pull/437))
+* **testing:** `InMemoryRepository` for unit tests without SQLite — repository pattern now supports in-memory and persistent backends ([#444](https://github.com/optave/codegraph/pull/444))
+
+### Refactors
+
+* **queries:** decompose `queries.js` (3,395 lines) into `src/analysis/` and `src/shared/` modules ([#425](https://github.com/optave/codegraph/pull/425))
+* **mcp:** composable MCP tool registry — tools defined alongside their implementations ([#426](https://github.com/optave/codegraph/pull/426))
+* **cli:** split `cli.js` into self-contained command modules under `src/commands/` ([#427](https://github.com/optave/codegraph/pull/427))
+* **api:** curate public API surface — explicit exports, remove internal leaks ([#430](https://github.com/optave/codegraph/pull/430))
+* **errors:** domain error hierarchy — typed errors replace ad-hoc throws ([#431](https://github.com/optave/codegraph/pull/431))
+* **embeddings:** extract embedder into `src/embeddings/` subsystem with pluggable stores and search strategies ([#433](https://github.com/optave/codegraph/pull/433))
+* **builder:** decompose `buildGraph()` into named pipeline stages ([#434](https://github.com/optave/codegraph/pull/434))
+* **presentation:** extract all output formatting into `src/presentation/` — viewer, export, table, sequence renderer, result formatter ([#443](https://github.com/optave/codegraph/pull/443))
+
+### Chores
+
+* **ci:** add backlog compliance phase to automated PR review ([#432](https://github.com/optave/codegraph/pull/432))
+* **deps:** bump better-sqlite3 from 12.6.2 to 12.8.0 ([#442](https://github.com/optave/codegraph/pull/442))
+* **deps-dev:** bump @biomejs/biome from 2.4.6 to 2.4.7 ([#441](https://github.com/optave/codegraph/pull/441))
+* **deps-dev:** bump @commitlint/cli from 20.4.3 to 20.4.4 ([#440](https://github.com/optave/codegraph/pull/440))
+* **deps-dev:** bump @commitlint/config-conventional from 20.4.3 to 20.4.4 ([#439](https://github.com/optave/codegraph/pull/439))
+* **deps-dev:** bump @vitest/coverage-v8 from 4.0.18 to 4.1.0 ([#438](https://github.com/optave/codegraph/pull/438))
+
 ## [3.1.3](https://github.com/optave/codegraph/compare/v3.1.2...v3.1.3) (2026-03-11)
 
 **Bug fixes and build instrumentation.** This patch fixes WASM builds silently producing zero complexity rows, resolves four dogfood-reported issues (benchmark crash resilience, WASM parser memory cleanup, native dynamic import tracking, stale native version reporting), and adds missing build phase timers so `setupMs` and `finalizeMs` now account for the previously untracked ~45% of total build time. Prepared statement caching is extracted into a reusable `cachedStmt` utility.

--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ See **[ROADMAP.md](docs/roadmap/ROADMAP.md)** for the full development roadmap a
 1. ~~**Rust Core**~~ — **Complete** (v1.3.0) — native tree-sitter parsing via napi-rs, parallel multi-core parsing, incremental re-parsing, import resolution & cycle detection in Rust
 2. ~~**Foundation Hardening**~~ — **Complete** (v1.4.0) — parser registry, 12-tool MCP server with multi-repo support, test coverage 62%→75%, `apiKeyCommand` secret resolution, global repo registry
 3. ~~**Deep Analysis**~~ — **Complete** (v3.0.0) — dataflow analysis (flows_to, returns, mutates), intraprocedural CFG for all 11 languages, stored AST nodes, expanded node/edge types (parameter, property, constant, contains, parameter_of, receiver), GraphML/GraphSON/Neo4j CSV export, interactive HTML viewer, CLI consolidation, stable JSON schema
-4. **Architectural Refactoring** — parser plugin system, repository pattern, pipeline builder, engine strategy, domain errors, curated API
+4. **Architectural Refactoring** — **In Progress** (v3.1.4) — unified AST analysis, composable MCP, domain errors, builder pipeline, embedder subsystem, graph model, qualified names, presentation layer, InMemoryRepository (11/14 tasks complete)
 5. **Natural Language Queries** — `codegraph ask` command, conversational sessions
 6. **Expanded Language Support** — 8 new languages (12 → 20)
 7. **GitHub Integration & CI** — reusable GitHub Action, PR review, SARIF output

--- a/docs/roadmap/BACKLOG.md
+++ b/docs/roadmap/BACKLOG.md
@@ -1,6 +1,6 @@
 # Codegraph Feature Backlog
 
-**Last updated:** 2026-03-12
+**Last updated:** 2026-03-16
 **Source:** Features derived from [COMPETITIVE_ANALYSIS.md](../../generated/competitive/COMPETITIVE_ANALYSIS.md) and internal roadmap discussions.
 
 ---

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,6 +1,6 @@
 # Codegraph Roadmap
 
-> **Current version:** 3.1.3 | **Status:** Active development | **Updated:** March 2026
+> **Current version:** 3.1.4 | **Status:** Active development | **Updated:** March 2026
 
 Codegraph is a strong local-first code graph CLI. This roadmap describes planned improvements across ten phases -- closing gaps with commercial code intelligence platforms while preserving codegraph's core strengths: fully local, open source, zero cloud dependency by default.
 
@@ -16,7 +16,7 @@ Codegraph is a strong local-first code graph CLI. This roadmap describes planned
 | [**2**](#phase-2--foundation-hardening) | Foundation Hardening | Parser registry, complete MCP, test coverage, enhanced config, multi-repo MCP | **Complete** (v1.4.0) |
 | [**2.5**](#phase-25--analysis-expansion) | Analysis Expansion | Complexity metrics, community detection, flow tracing, co-change, manifesto, boundary rules, check, triage, audit, batch, hybrid search | **Complete** (v2.6.0) |
 | [**2.7**](#phase-27--deep-analysis--graph-enrichment) | Deep Analysis & Graph Enrichment | Dataflow analysis, intraprocedural CFG, AST node storage, expanded node/edge types, extractors refactoring, CLI consolidation, interactive viewer, exports command, normalizeSymbol | **Complete** (v3.0.0) |
-| [**3**](#phase-3--architectural-refactoring) | Architectural Refactoring (Vertical Slice) | Unified AST analysis framework, command/query separation, repository pattern, queries.js decomposition, composable MCP, CLI commands, domain errors, builder pipeline, presentation layer, domain grouping, curated API, unified graph model, qualified names | **In Progress** (v3.1.3) |
+| [**3**](#phase-3--architectural-refactoring) | Architectural Refactoring (Vertical Slice) | Unified AST analysis framework, command/query separation, repository pattern, queries.js decomposition, composable MCP, CLI commands, domain errors, builder pipeline, presentation layer, domain grouping, curated API, unified graph model, qualified names | **In Progress** (v3.1.4) |
 | [**4**](#phase-4--typescript-migration) | TypeScript Migration | Project setup, core type definitions, leaf -> core -> orchestration module migration, test migration | Planned |
 | [**5**](#phase-5--intelligent-embeddings) | Intelligent Embeddings | LLM-generated descriptions, enhanced embeddings, build-time semantic metadata, module summaries | Planned |
 | [**6**](#phase-6--natural-language-queries) | Natural Language Queries | `ask` command, conversational sessions, LLM-narrated graph queries, onboarding tools | Planned |
@@ -828,9 +828,9 @@ src/
 
 **Affected files:** `src/builder.js` → split into `src/builder/`
 
-### 3.10 -- Embedder Subsystem Extraction
+### 3.10 -- Embedder Subsystem Extraction ✅
 
-Restructure `embedder.js` (1,113 lines) -- which now contains 3 search engines -- into a standalone subsystem.
+Restructured `embedder.js` (1,113 lines) into a standalone `src/embeddings/` subsystem with pluggable stores and search strategies.
 
 ```
 src/
@@ -851,6 +851,11 @@ src/
 ```
 
 The pluggable store interface enables future O(log n) ANN search (e.g., `hnswlib-node`) when symbol counts reach 50K+.
+
+- ✅ Extracted into `src/embeddings/` with `index.js`, `models.js`, `generator.js` (v3.1.4, [#433](https://github.com/optave/codegraph/pull/433))
+- ✅ Pluggable stores: `sqlite-blob.js`, `fts5.js`
+- ✅ Search engines: `semantic.js`, `keyword.js`, `hybrid.js`
+- ✅ Text preparation strategies: `structured.js`, `source.js`
 
 **Affected files:** `src/embedder.js` -> split into `src/embeddings/`
 
@@ -919,20 +924,18 @@ CREATE INDEX idx_nodes_scope ON nodes(scope);
 
 **Affected files:** `src/db/migrations.js`, `src/db/repository/nodes.js`, `src/builder/helpers.js`, `src/builder/stages/insert-nodes.js`, `src/extractors/*.js`, `src/extractors/helpers.js`, `src/analysis/symbol-lookup.js`
 
-### 3.13 -- Testing Pyramid with InMemoryRepository
+### 3.13 -- Testing Pyramid with InMemoryRepository ✅
 
-The repository pattern (3.3) enables true unit testing:
+The repository pattern (3.3) enables true unit testing. `InMemoryRepository` provides an in-memory backend that implements the same interface as `SqliteRepository`, enabling fast unit tests without SQLite.
 
-- Pure unit tests for graph algorithms (pass adjacency list, assert result)
-- Pure unit tests for risk/confidence scoring (pass parameters, assert score)
-- `InMemoryRepository` for query tests (no SQLite, instant setup)
-- Existing 70 test files continue as integration tests
+- ✅ `InMemoryRepository` at `src/db/repository/in-memory-repository.js` (v3.1.4, [#444](https://github.com/optave/codegraph/pull/444))
+- ✅ Pure unit tests for graph algorithms (pass adjacency list, assert result)
+- ✅ Pure unit tests for risk/confidence scoring (pass parameters, assert score)
+- 🔲 Migrate existing integration tests that only need query data to use `InMemoryRepository`
 
-**Current gap:** Many "unit" tests still hit SQLite because there's no repository abstraction.
+### 3.14 -- Presentation Layer Extraction ✅
 
-### 3.14 -- Presentation Layer Extraction
-
-Separate all output formatting from domain logic into a dedicated `src/presentation/` directory. Currently `viewer.js` (948 lines) and `export.js` (681 lines) mix graph traversal with rendering. `result-formatter.js` already exists in `infrastructure/` as a first step.
+Separated all output formatting from domain logic into `src/presentation/`. Domain functions return plain data objects; presentation functions are pure transforms: `data → formatted string`. Commands wire the two together.
 
 ```
 src/
@@ -942,15 +945,14 @@ src/
     table.js               # Tabular CLI output (used by complexity, stats, etc.)
     sequence-renderer.js   # Mermaid sequence diagram formatting (from sequence.js)
     result-formatter.js    # Structured result formatting (moved from infrastructure/)
+    colors.js              # Shared color/style utilities
 ```
 
-- ✅ Extract rendering logic from `viewer.js` — keep graph data loading in domain, move formatting to presentation
+- ✅ Extract rendering logic from `viewer.js` (v3.1.4, [#443](https://github.com/optave/codegraph/pull/443))
 - ✅ Extract serialization from `export.js` — DOT/Mermaid/JSON writers become pure data → string transforms
 - ✅ Extract table formatting helpers used across `queries-cli.js`, `complexity`, `stats`
-- ✅ Move `result-formatter.js` from `infrastructure/` to `presentation/` (it's output formatting, not infrastructure)
+- ✅ Move `result-formatter.js` from `infrastructure/` to `presentation/`
 - ✅ Extract Mermaid rendering from `sequence.js` into `sequence-renderer.js`
-
-**Principle:** Domain functions return plain data objects. Presentation functions are pure transforms: `data → formatted string`. Commands wire the two together.
 
 **Affected files:** `src/viewer.js`, `src/export.js`, `src/sequence.js`, `src/infrastructure/result-formatter.js`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@optave/codegraph",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Local code graph CLI — parse codebases with tree-sitter, build dependency graphs, query them",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 3.1.4
- Add CHANGELOG entry for all 20 commits since v3.1.3 (11 refactors, 3 features, 6 chores)
- Update ROADMAP: mark 3.10 (embedder extraction), 3.13 (InMemoryRepository), 3.14 (presentation layer) as complete — Phase 3 now at 11/14 tasks
- Update README roadmap section with Phase 3 progress
- Update BACKLOG last-updated date

## Test plan
- [ ] `npm install` succeeds with updated lock file
- [ ] CHANGELOG renders correctly on GitHub
- [ ] ROADMAP checklist items match actual codebase state (src/embeddings/, src/presentation/, src/db/repository/in-memory-repository.js all exist)