### PR TITLE
fix: update MCP server import path after src/ reorganization

### DIFF
--- a/src/cli/commands/mcp.js
+++ b/src/cli/commands/mcp.js
@@ -7,7 +7,7 @@ export const command = {
     ['--repos <names>', 'Comma-separated list of allowed repo names (restricts access)'],
   ],
   async execute(_args, opts) {
-    const { startMCPServer } = await import('../../mcp.js');
+    const { startMCPServer } = await import('../../mcp/index.js');
     const mcpOpts = {};
     mcpOpts.multiRepo = opts.multiRepo || !!opts.repos;
     if (opts.repos) {


### PR DESCRIPTION
## Summary
- Fix broken dynamic import in `src/cli/commands/mcp.js` — path `../../mcp.js` no longer exists after #458 moved it to `src/mcp/index.js`
- MCP server was failing with `ERR_MODULE_NOT_FOUND` on every Claude Code launch

Closes #465

## Test plan
- [ ] `node src/cli.js mcp` starts without `ERR_MODULE_NOT_FOUND`
- [ ] MCP tools respond correctly in Claude Code