### PR TITLE
docs: add conflict resolution guidance to /review skill

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -60,11 +60,13 @@ If `CONFLICTING`:
    ```bash
    git merge origin/<base-branch>
    ```
-2. **Do not assume which side to keep.** Before resolving any conflict:
-   - Check the PR's commit history (`git log --oneline origin/<base-branch>..HEAD -- <file>`) to understand *why* the conflicting line was changed on each side.
+2. **Do not assume which side to keep.** You must fully understand the context of both sides before resolving. If you don't know why a line was added — what feature it supports, what bug it fixes, what reviewer requested it — you cannot resolve the conflict correctly. Before touching any conflict:
+   - Read the PR description and any linked issues (`gh pr view <number>`) to understand the PR's purpose and scope.
+   - Check the PR's commit history (`git log --oneline origin/<base-branch>..HEAD -- <file>`) to understand *why* the conflicting line was changed on the PR side. Also check the base branch history (`git log --oneline HEAD..origin/<base-branch> -- <file>`) to understand *why* the base version exists.
    - Read Greptile and Claude review comments on the PR (`gh api repos/optave/codegraph/pulls/<number>/comments`, `gh api repos/optave/codegraph/issues/<number>/comments`) — a reviewer may have requested the change that caused the conflict.
+   - Check what landed on main that introduced the other side (`git log --oneline HEAD..origin/<base-branch> -- <file>`) and read those PR descriptions too if needed.
    - Compare the PR's diff against its merge base (`git diff $(git merge-base origin/<base-branch> HEAD) HEAD -- <file>`) to see which side introduced an intentional change vs. which side carried stale code.
-   - Only then choose the correct resolution. If the PR deliberately changed a line and main still has the old version, keep the PR's version. If main introduced a fix the PR doesn't have, keep main's version.
+   - Only then choose the correct resolution. If the PR deliberately changed a line and main still has the old version, keep the PR's version. If main introduced a fix or new feature the PR doesn't have, keep main's version. If both sides made intentional changes, merge them together manually.
 3. After resolving, stage the resolved files by name (not `git add .`), commit with: `fix: resolve merge conflicts with <base-branch>`
 4. Push the updated branch.
 


### PR DESCRIPTION
## Summary
- Adds explicit instructions to the `/review` skill's conflict resolution step (2b) to check PR commit history and reviewer comments before choosing which side of a conflict to keep
- Prevents incorrect resolutions where the review agent blindly picks a side without understanding why each version exists

## Context
During conflict resolution on #475, the template-literal syntax was the PR's intentional change but was nearly discarded in favor of main's stale concatenation. The review skill lacked guidance to check *why* each side differs before resolving.

## Test plan
- [ ] Run `/review` on a PR with conflicts and verify it checks commit history before resolving