### PR TITLE
docs: plan to centralize hardcoded configuration

### DIFF
--- a/docs/tasks/PLAN_centralize_config.md
+++ b/docs/tasks/PLAN_centralize_config.md
@@ -210,7 +210,7 @@ export const DEFAULTS = {
 
 **Files to change:**
 - `src/domain/search/search/hybrid.js` → read `config.search.rrfK`, `config.search.topK`
-- `src/domain/search/search/semantic.js` → read `config.search.defaultMinScore` and `config.search.similarityWarnThreshold` (C5, replaces hardcoded `SIMILARITY_WARN_THRESHOLD`)
+- `src/domain/search/search/semantic.js` → read `config.search.defaultMinScore`, `config.search.topK` (C3), and `config.search.similarityWarnThreshold` (C5, replaces hardcoded `SIMILARITY_WARN_THRESHOLD`)
 - `src/domain/search/models.js` → batch sizes stay hardcoded (moved to Category F — model-specific implementation details)
 
 **Note:** `config.search` already exists with `defaultMinScore`, `rrfK`, `topK`. The modules just don't read from it — they duplicate the values. This phase wires the existing config keys.
@@ -232,7 +232,7 @@ export const DEFAULTS = {
 4. Add a JSON Schema file (`.codegraphrc.schema.json`) for IDE autocomplete
 5. Add a **Configuration** section to `CLAUDE.md` that documents:
    - The `.codegraphrc.json` config file and its location
-   - The full list of configurable sections (`analysis`, `community`, `risk`, `display`, `mcp`, `search`, `check`, `coChange`, `manifesto`)
+   - The full list of configurable sections (`analysis`, `community`, `structure`, `risk`, `display`, `mcp`, `search`, `check`, `coChange`, `manifesto`)
    - Key tunable parameters and their defaults (depth limits, risk weights, thresholds)
    - How `mergeConfig` works (partial overrides deep-merge with defaults)
    - Env var overrides (`CODEGRAPH_LLM_*`)


### PR DESCRIPTION
## Summary
- Inventoried ~70 individual hardcoded constants (34 inventory entries, expanding to ~70 discrete values when counting sub-keys) scattered across the codebase (thresholds, depths, weights, limits)
- Designed a 6-phase plan to route them through the existing `.codegraphrc.json` config system
- Includes PR #480 `brief` command thresholds (risk tiers, BFS depths)
- Zero breaking changes — all defaults match current hardcoded values

### Categories found
| Category | Count | Examples |
|----------|-------|---------|
| Analysis params | 12 | BFS depths, risk tier thresholds, false-positive filter |
| Risk weights | 3 groups | Metric weights, role weights, default weight |
| Search | 6 | Already in DEFAULTS but modules duplicate locally |
| Display | 5 | Column widths, truncation limits |
| MCP pagination | 22 | Per-tool default page sizes (hard cap stays hardcoded) |
| Infrastructure | 7 | Kept hardcoded (standard formulas, security, MCP_MAX_LIMIT) |

### Implementation phases
1. Extend `DEFAULTS` schema + fix `mergeConfig` for recursive deep merge (hard prerequisite)
2. Wire analysis parameters (impact, audit, check, sequence, module-map, brief)
3. Wire risk & community parameters (classifiers, Louvain, structure)
4. Wire search parameters (connect existing config keys)
5. Wire display & MCP parameters
6. Documentation + CLAUDE.md configuration guidance

## Test plan
- [ ] Plan review — verify inventory completeness against codebase
- [ ] Validate proposed schema against existing `.codegraphrc.json` usage