### PR TITLE
docs: add /titan-forge skill (Titan Paradigm execution phase)

### DIFF
--- a/.claude/skills/titan-forge/SKILL.md
+++ b/.claude/skills/titan-forge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: titan-forge
 description: Execute the sync.json plan — refactor code, validate with /titan-gate, commit, and advance state (Titan Paradigm Phase 4)
-argument-hint: <--phase N> <--target name> <--dry-run>
+argument-hint: <--phase N> <--target name> <--dry-run> <--yes>
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Agent
 ---
 
@@ -18,6 +18,7 @@ Your goal: read `sync.json`, find the next incomplete execution phase, make the 
 - `--phase N` → jump to specific phase
 - `--target <name>` → run single target only (for retrying failures)
 - `--dry-run` → show what would be done without changing code
+- `--yes` → skip confirmation prompt
 
 ---
 
@@ -52,7 +53,9 @@ Your goal: read `sync.json`, find the next incomplete execution phase, make the 
        "currentTarget": null,
        "completedTargets": [],
        "failedTargets": [],
-       "commits": []
+       "commits": [],
+       "currentSubphase": null,
+       "completedSubphases": []
      }
    }
    ```
@@ -136,10 +139,10 @@ For each target in the current phase:
    ```bash
    npm test 2>&1
    ```
-   If tests fail → go to rollback (step 10).
+   If tests fail → go to rollback (step 11).
 
 9. **Run /titan-gate:**
-   Use the Skill tool to invoke `titan-gate`. If FAIL → go to rollback (step 10).
+   Use the Skill tool to invoke `titan-gate`. If FAIL → go to rollback (step 11).
 
 10. **On success:**
     ```bash

--- a/docs/examples/claude-code-skills/README.md
+++ b/docs/examples/claude-code-skills/README.md
@@ -107,7 +107,7 @@ All artifacts are written to `.codegraph/titan/` (6 files, no redundancy):
 | `GLOBAL_ARCH.md` | Markdown | RECON | GAUNTLET, SYNC |
 | `gauntlet.ndjson` | NDJSON | GAUNTLET | SYNC |
 | `gauntlet-summary.json` | JSON | GAUNTLET | SYNC, GATE |
-| `sync.json` | JSON | SYNC | GATE |
+| `sync.json` | JSON | SYNC | FORGE, GATE |
 | `gate-log.ndjson` | NDJSON | GATE | Audit trail |
 
 NDJSON format (one JSON object per line) means partial results survive crashes mid-batch.

--- a/docs/examples/claude-code-skills/titan-forge/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-forge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: titan-forge
 description: Execute the sync.json plan — refactor code, validate with /titan-gate, commit, and advance state (Titan Paradigm Phase 4)
-argument-hint: <--phase N> <--target name> <--dry-run>
+argument-hint: <--phase N> <--target name> <--dry-run> <--yes>
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Agent
 ---
 
@@ -18,6 +18,7 @@ Your goal: read `sync.json`, find the next incomplete execution phase, make the 
 - `--phase N` → jump to specific phase
 - `--target <name>` → run single target only (for retrying failures)
 - `--dry-run` → show what would be done without changing code
+- `--yes` → skip confirmation prompt
 
 ---
 
@@ -52,7 +53,9 @@ Your goal: read `sync.json`, find the next incomplete execution phase, make the 
        "currentTarget": null,
        "completedTargets": [],
        "failedTargets": [],
-       "commits": []
+       "commits": [],
+       "currentSubphase": null,
+       "completedSubphases": []
      }
    }
    ```
@@ -136,10 +139,10 @@ For each target in the current phase:
    ```bash
    npm test 2>&1
    ```
-   If tests fail → go to rollback (step 10).
+   If tests fail → go to rollback (step 11).
 
 9. **Run /titan-gate:**
-   Use the Skill tool to invoke `titan-gate`. If FAIL → go to rollback (step 10).
+   Use the Skill tool to invoke `titan-gate`. If FAIL → go to rollback (step 11).
 
 10. **On success:**
     ```bash


### PR DESCRIPTION
## Summary

- Adds `/titan-forge` skill — the missing execution phase of the Titan Paradigm that reads `sync.json` and makes the actual code changes
- One phase per invocation, resumable across sessions, validates each commit with `/titan-gate`
- Phase-specific strategies for dead code removal, shared abstractions, error handling, decomposition, and general fixes
- Updates `docs/examples/claude-code-skills/README.md` with FORGE in pipeline diagram, skills table, usage examples, and command reference

## Test plan
- [ ] Verify `/titan-forge` is recognized as a skill by Claude Code
- [ ] Run `/titan-forge --dry-run` after a `/titan-sync` to confirm plan parsing
- [ ] Run a full phase execution on a test worktree