### PR TITLE
chore: release v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.4.0](https://github.com/optave/codegraph/compare/v3.3.1...v3.4.0) (2026-03-25)
+
+**TypeScript migration complete, Leiden community detection, and native engine hardening.** The entire codebase — all 271 source files — is now TypeScript with zero `.js` files remaining. Community detection upgrades from Louvain to a vendored Leiden algorithm with true probabilistic refinement, removing the `graphology` dependency. Go gains structural interface matching and C# gets proper `implements` disambiguation. The native Rust engine now extracts call-site AST nodes and bypasses the JS CFG visitor entirely on native builds. MCP server shutdown is graceful, and several edge-attribution and WASM fallback bugs are fixed.
+
+### Features
+
+* **types:** complete TypeScript migration — all 271 source files migrated from JavaScript, zero `.js` files remaining. Covers leaf modules, core domain, graph algorithms, builder stages, search, CLI layer (48 command handlers), AST analysis, features, presentation, MCP tools, and test suite ([#553](https://github.com/optave/codegraph/pull/553), [#554](https://github.com/optave/codegraph/pull/554), [#555](https://github.com/optave/codegraph/pull/555), [#558](https://github.com/optave/codegraph/pull/558), [#566](https://github.com/optave/codegraph/pull/566), [#570](https://github.com/optave/codegraph/pull/570), [#579](https://github.com/optave/codegraph/pull/579), [#580](https://github.com/optave/codegraph/pull/580), [#581](https://github.com/optave/codegraph/pull/581), [#588](https://github.com/optave/codegraph/pull/588))
+* **communities:** vendor Leiden community detection algorithm, replacing `graphology-communities-louvain` — full control over resolution, quality functions, and probabilistic refinement ([#545](https://github.com/optave/codegraph/pull/545), [#552](https://github.com/optave/codegraph/pull/552), [#556](https://github.com/optave/codegraph/pull/556))
+* **resolution:** Go structural interface matching — post-extraction pass matches struct method sets against interface method sets; C# `implements` disambiguation via post-walk reclassification of `extends` entries targeting known interfaces ([#522](https://github.com/optave/codegraph/pull/522))
+* **native:** extract call-site AST nodes in Rust during native parse, fixing WASM fallback path for incomplete extraction ([#591](https://github.com/optave/codegraph/pull/591))
+* **native:** extract `base_list` for C# classes in the Rust engine ([#577](https://github.com/optave/codegraph/pull/577))
+* **cfg:** bypass JS CFG visitor entirely on native builds; fix Go `for-range` CFG parity between engines ([#595](https://github.com/optave/codegraph/pull/595))
+
+### Bug Fixes
+
+* **edges:** remove `findCaller` fallback that misattributed file-scope calls to unrelated functions ([#607](https://github.com/optave/codegraph/pull/607))
+* **mcp:** add graceful shutdown to prevent "MCP Failed" errors on session clear ([#598](https://github.com/optave/codegraph/pull/598))
+* **resolver:** apply JS-side `.js` → `.ts` extension remap after native resolution ([#594](https://github.com/optave/codegraph/pull/594))
+* **resolver:** normalize paths in native resolver for `.js` → `.ts` remap ([#600](https://github.com/optave/codegraph/pull/600))
+* **deps:** patch 5 high-severity transitive vulnerabilities ([#583](https://github.com/optave/codegraph/pull/583))
+* **types:** narrow parser return types, `cachedStmt` in `buildTestFileIds`, WASM parser path, and triage query results ([#569](https://github.com/optave/codegraph/pull/569), [#576](https://github.com/optave/codegraph/pull/576), [#578](https://github.com/optave/codegraph/pull/578))
+* **scripts:** use version-aware `strip-types` flag in `package.json` scripts ([#599](https://github.com/optave/codegraph/pull/599))
+* **tests:** use `fs.cpSync` for fixture copy to handle subdirectories ([#584](https://github.com/optave/codegraph/pull/584))
+
+### Performance
+
+* **native:** fix WASM fallback bypass so native builds skip redundant JS analysis passes; batch SQL inserts for node/edge operations ([#606](https://github.com/optave/codegraph/pull/606))
+* **queries:** apply `cachedStmt` to `buildTestFileIds` static SQL for faster test filtering ([#575](https://github.com/optave/codegraph/pull/575))
+
+### Tests
+
+* strengthen weak assertions and add presentation layer coverage ([#586](https://github.com/optave/codegraph/pull/586))
+
+### Chores
+
+* add `npm run bench` script and stale embeddings warning ([#604](https://github.com/optave/codegraph/pull/604))
+* bump `commit-and-tag-version`, `tree-sitter-cli`, `web-tree-sitter`, `@commitlint/cli`, `@commitlint/config-conventional` ([#560](https://github.com/optave/codegraph/pull/560), [#561](https://github.com/optave/codegraph/pull/561), [#562](https://github.com/optave/codegraph/pull/562), [#563](https://github.com/optave/codegraph/pull/563), [#564](https://github.com/optave/codegraph/pull/564))
+
 ## [3.3.1](https://github.com/optave/codegraph/compare/v3.3.0...v3.3.1) (2026-03-20)
 
 **Incremental rebuild accuracy and post-3.3.0 stabilization.** This patch fixes a critical edge gap in the file watcher's single-file rebuild path where call edges were silently dropped during incremental rebuilds, aligns the native Rust engine's edge builder kind filters with the JS engine for parity, plugs a WASM tree memory leak in native engine typeMap backfill, and restores query performance to pre-3.1.4 levels. Several post-reorganization import path issues are also corrected.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ cd codegraph && npm install && npm link
 | ⚡ | **Always fresh** | Three-tier incremental detection — sub-second rebuilds even on large codebases |
 | 🔬 | **Data flow analysis** | Intraprocedural parameter tracking, return consumers, argument flows, and mutation detection — all 11 languages |
 | 🧮 | **Complexity metrics** | Cognitive, cyclomatic, nesting depth, Halstead, and Maintainability Index per function |
-| 🏘️ | **Community detection** | Louvain clustering to discover natural module boundaries and architectural drift |
+| 🏘️ | **Community detection** | Leiden clustering to discover natural module boundaries and architectural drift |
 | 📜 | **Manifesto rule engine** | Configurable pass/fail rules with warn/fail thresholds for CI gates via `check` (exit code 1 on fail) |
 | 👥 | **CODEOWNERS integration** | Map graph nodes to CODEOWNERS entries — see who owns each function, ownership boundaries in `diff-impact` |
 | 💾 | **Graph snapshots** | `snapshot save`/`restore` for instant DB backup and rollback — checkpoint before refactoring, restore without rebuilding |
@@ -299,7 +299,7 @@ codegraph complexity              # Per-function cognitive, cyclomatic, nesting,
 codegraph complexity --health -T  # Full Halstead health view (volume, effort, bugs, MI)
 codegraph complexity --sort mi -T # Sort by worst maintainability index
 codegraph complexity --above-threshold -T  # Only functions exceeding warn thresholds
-codegraph communities             # Louvain community detection — natural module boundaries
+codegraph communities             # Leiden community detection — natural module boundaries
 codegraph communities --drift -T  # Drift analysis only — split/merge candidates
 codegraph communities --functions # Function-level community detection
 codegraph check                   # Pass/fail rule engine (exit code 1 on fail)
@@ -770,9 +770,9 @@ See **[ROADMAP.md](docs/roadmap/ROADMAP.md)** for the full development roadmap a
 3. ~~**Analysis Expansion**~~ — **Complete** (v2.7.0) — complexity metrics, community detection, flow tracing, co-change, manifesto, boundary rules, check, triage, audit, batch, hybrid search
 4. ~~**Deep Analysis & Graph Enrichment**~~ — **Complete** (v3.0.0) — dataflow analysis, intraprocedural CFG, AST node storage, expanded node/edge types, interactive viewer, exports command
 5. ~~**Architectural Refactoring**~~ — **Complete** (v3.1.5) — unified AST analysis, composable MCP, domain errors, builder pipeline, graph model, qualified names, presentation layer, CLI composability
-6. **Resolution Accuracy** — **In Progress** (5 of 6 complete) — type inference, receiver type tracking, dead role sub-categories, resolution benchmarks, `package.json` exports, monorepo workspace resolution
-7. **TypeScript Migration** — **In Progress** (2 of 7 complete) — project setup, core type definitions, leaf → core → orchestration migration
-8. **Native Analysis Acceleration** — move JS-only build phases to Rust, sub-100ms 1-file rebuilds
+6. ~~**Resolution Accuracy**~~ — **Complete** (v3.3.1) — type inference, receiver type tracking, dead role sub-categories, resolution benchmarks, `package.json` exports, monorepo workspace resolution
+7. ~~**TypeScript Migration**~~ — **Complete** (v3.4.0) — all 271 source files migrated from JS to TS, zero `.js` remaining
+8. **Native Analysis Acceleration** — **In Progress** (7 of 8 complete) — JS-only build phases moved to Rust, sub-100ms 1-file rebuilds remaining
 9. **Runtime & Extensibility** — event-driven pipeline, plugin system, query caching, pagination
 10. **Intelligent Embeddings** — LLM-generated descriptions, enhanced embeddings, module summaries
 11. **Natural Language Queries** — `codegraph ask` command, conversational sessions

--- a/crates/codegraph-core/Cargo.toml
+++ b/crates/codegraph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codegraph-core"
-version = "3.3.1"
+version = "3.4.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/docs/roadmap/BACKLOG.md
+++ b/docs/roadmap/BACKLOG.md
@@ -1,6 +1,6 @@
 # Codegraph Feature Backlog
 
-**Last updated:** 2026-03-20
+**Last updated:** 2026-03-25
 **Source:** Features derived from [COMPETITIVE_ANALYSIS.md](../../generated/competitive/COMPETITIVE_ANALYSIS.md) and internal roadmap discussions.
 
 ---
@@ -114,7 +114,7 @@ Co-change data captures historical coupling from git history. Currently only use
 
 ### Tier 1e.1 — Community leverage (build on vendored Leiden algorithm)
 
-Community detection will use a vendored Leiden optimiser (PR #545) with full control over resolution, quality functions, and refinement. Currently consumed by `communities` command and HTML viewer enrichment via `graphology-communities-louvain`. These features deepen community awareness across the analysis pipeline once the Leiden vendoring lands.
+Community detection now uses a vendored Leiden optimiser (PRs #545, #552, #556) with full control over resolution, quality functions, and true probabilistic refinement (Algorithm 3). The `graphology` dependency has been removed. Items in this tier are now **unblocked**.
 
 | ID | Title | Description | Category | Benefit | Zero-dep | Foundation-aligned | Problem-fit (1-5) | Breaking | Depends on |
 |----|-------|-------------|----------|---------|----------|-------------------|-------------------|----------|------------|

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,6 +1,6 @@
 # Codegraph Roadmap
 
-> **Current version:** 3.3.1 | **Status:** Active development | **Updated:** 2026-03-25
+> **Current version:** 3.4.0 | **Status:** Active development | **Updated:** 2026-03-25
 
 Codegraph is a strong local-first code graph CLI. This roadmap describes planned improvements across twelve phases -- closing gaps with commercial code intelligence platforms while preserving codegraph's core strengths: fully local, open source, zero cloud dependency by default.
 
@@ -18,7 +18,7 @@ Codegraph is a strong local-first code graph CLI. This roadmap describes planned
 | [**2.7**](#phase-27--deep-analysis--graph-enrichment) | Deep Analysis & Graph Enrichment | Dataflow analysis, intraprocedural CFG, AST node storage, expanded node/edge types, extractors refactoring, CLI consolidation, interactive viewer, exports command, normalizeSymbol | **Complete** (v3.0.0) |
 | [**3**](#phase-3--architectural-refactoring) | Architectural Refactoring (Vertical Slice) | Unified AST analysis framework, command/query separation, repository pattern, queries.js decomposition, composable MCP, CLI commands, domain errors, builder pipeline, presentation layer, domain grouping, curated API, unified graph model, qualified names, CLI composability | **Complete** (v3.1.5) |
 | [**4**](#phase-4--resolution-accuracy) | Resolution Accuracy | Dead role sub-categories, receiver type tracking, interface/trait implementation edges, resolution precision/recall benchmarks, `package.json` exports field, monorepo workspace resolution | **Complete** (v3.3.1) |
-| [**5**](#phase-5--typescript-migration) | TypeScript Migration | Project setup, core type definitions, leaf -> core -> orchestration module migration, test migration | **Complete** (v3.3.1) |
+| [**5**](#phase-5--typescript-migration) | TypeScript Migration | Project setup, core type definitions, leaf -> core -> orchestration module migration, test migration | **Complete** (v3.4.0) |
 | [**6**](#phase-6--native-analysis-acceleration) | Native Analysis Acceleration | Move JS-only build phases (AST nodes, CFG, dataflow, insert nodes, structure, roles, complexity) to Rust; fix incremental rebuild data loss on native; sub-100ms 1-file rebuilds | **In Progress** (7 of 8 items complete) |
 | [**7**](#phase-7--runtime--extensibility) | Runtime & Extensibility | Event-driven pipeline, unified engine strategy, subgraph export filtering, transitive confidence, query caching, configuration profiles, pagination, plugin system, DX & onboarding, confidence annotations, shell completion | Planned |
 | [**8**](#phase-8--intelligent-embeddings) | Intelligent Embeddings | LLM-generated descriptions, enhanced embeddings, build-time semantic metadata, module summaries | Planned |
@@ -1080,13 +1080,13 @@ npm workspaces (`package.json` `workspaces`), `pnpm-workspace.yaml`, and `lerna.
 
 ## Phase 5 -- TypeScript Migration
 
-> **Status:** In Progress — 178 of 283 source files migrated (~63%), 105 `.js` files remaining
+> **Status:** Complete — all 271 source files migrated to TypeScript, 0 `.js` files remaining (v3.4.0)
 
 **Goal:** Migrate the codebase from plain JavaScript to TypeScript, leveraging the clean module boundaries established in Phase 3. Incremental module-by-module migration starting from leaf modules inward.
 
 **Why after Phase 4:** The resolution accuracy work (Phase 4) operates on the existing JS codebase and produces immediate accuracy gains. TypeScript migration builds on Phase 3's clean module boundaries to add type safety across the entire codebase. Every subsequent phase benefits from types: MCP schema auto-generation, API contracts, refactoring safety. The Phase 4 resolution improvements (receiver tracking, interface edges) establish the resolution model that TypeScript types will formalize.
 
-**Note:** `.js` and `.ts` coexist during migration (`allowJs: true` in tsconfig). PRs #553, #554, #555, #566 migrated a first wave of files across steps 5.3–5.5. Step 5.3 is complete; substantial work remains in steps 5.4–5.5. 13 stale `.js` files have `.ts` counterparts and need deletion.
+**Note:** Migration is complete as of v3.4.0. All 271 source files are TypeScript. The migration proceeded leaf-inward: shared utilities → core domain → graph algorithms → builder stages → search → CLI layer → AST analysis → features → presentation → MCP tools → tests.
 
 ### ~~5.1 -- Project Setup~~ ✅
 
@@ -1116,48 +1116,27 @@ Migrate modules with no or minimal internal dependencies. All 29 modules migrate
 
 **Migrated (29):** `shared/errors`, `shared/kinds`, `shared/normalize`, `shared/paginate`, `shared/constants`, `shared/file-utils`, `shared/generators`, `shared/hierarchy`, `infrastructure/logger`, `infrastructure/config`, `infrastructure/native`, `infrastructure/registry`, `infrastructure/update-check`, `infrastructure/result-formatter`, `infrastructure/test-filter`, `db/repository/*` (14 files), `db/connection`, `db/index`, `db/migrations`, `db/query-builder`, `domain/analysis/*` (9 files), `presentation/colors`, `presentation/table` — via [#553](https://github.com/optave/codegraph/pull/553), [#566](https://github.com/optave/codegraph/pull/566)
 
-### 5.4 -- Core Module Migration (In Progress)
+### ~~5.4 -- Core Module Migration~~ ✅
 
-Migrate modules that implement domain logic and Phase 3 interfaces. Some migrated via [#554](https://github.com/optave/codegraph/pull/554), 22 files remaining.
+All core domain modules migrated: builder stages, search subsystem, graph utilities, incremental rebuild logic.
 
-**Migrated:** `db/repository/*.ts` (14 files), `domain/parser.ts`, `domain/graph/resolve.ts`, `extractors/*.ts` (11 files), `domain/graph/builder.ts` + `context.ts` + `helpers.ts` + `pipeline.ts`, `domain/graph/watcher.ts`, `domain/search/{generator,index,models}.ts`, `graph/model.ts`, `graph/algorithms/{bfs,centrality,shortest-path,tarjan}.ts`, `graph/algorithms/leiden/*.ts` (7 files), `graph/algorithms/{louvain,index}.ts`, `graph/builders/{dependency,structure,temporal,index}.ts`, `graph/classifiers/{risk,roles,index}.ts`, `graph/index.ts`, `domain/queries.ts`
+**Migrated:** `db/repository/*.ts` (14 files), `domain/parser.ts`, `domain/graph/resolve.ts`, `extractors/*.ts` (11 files), `domain/graph/builder.ts` + `context.ts` + `helpers.ts` + `pipeline.ts`, `domain/graph/watcher.ts`, `domain/search/` (all files), `graph/` (all files), `domain/queries.ts`, `domain/graph/builder/stages/` (all 9 stages), `domain/graph/{cycles,journal,change-journal}.ts`
 
-**Remaining (22):**
+**Key PRs:** [#554](https://github.com/optave/codegraph/pull/554), [#570](https://github.com/optave/codegraph/pull/570), [#579](https://github.com/optave/codegraph/pull/579)
 
-| Module | Files | Notes |
-|--------|-------|-------|
-| `domain/graph/builder/stages/` | 9 | All 9 build pipeline stages (collect-files, parse-files, resolve-imports, build-edges, etc.) |
-| `domain/graph/builder/incremental.js` | 1 | Incremental rebuild logic |
-| `domain/graph/{cycles,journal,change-journal}.js` | 3 | Graph utilities |
-| `domain/search/search/` | 6 | Search subsystem (hybrid, semantic, keyword, filters, cli-formatter, prepare) |
-| `domain/search/stores/` | 2 | FTS5, SQLite blob stores |
-| `domain/search/strategies/` | 3 | Source, structured, text-utils strategies |
+### ~~5.5 -- Orchestration & Public API Migration~~ ✅
 
-### 5.5 -- Orchestration & Public API Migration (In Progress)
+All orchestration, features, presentation, MCP, and CLI modules migrated — including 48 CLI command handlers.
 
-Migrate top-level orchestration, features, and entry points. Some migrated via [#555](https://github.com/optave/codegraph/pull/555), 141 files remaining.
+**Migrated:** `cli.ts` + `cli/` (all 55 files), `index.ts`, `ast-analysis/` (all 18 files), `features/` (all 20 files), `presentation/` (all 28 files), `mcp/` + `mcp/tools/` (all files). All stale `.js` counterparts deleted.
 
-**Migrated:** `domain/graph/builder.ts` + `context.ts` + `helpers.ts` + `pipeline.ts`, `domain/graph/watcher.ts`, `domain/search/{generator,index,models}.ts`, `mcp/{index,middleware,server,tool-registry}.ts`, `features/export.ts`, `index.ts`, `ast-analysis/` (all 18 files), `features/` (all 20 files), `presentation/` (all 28 files), `mcp/tools/` (all 36 files)
+**Key PRs:** [#555](https://github.com/optave/codegraph/pull/555), [#558](https://github.com/optave/codegraph/pull/558), [#580](https://github.com/optave/codegraph/pull/580), [#581](https://github.com/optave/codegraph/pull/581)
 
-**Remaining (57):**
+### ~~5.6 -- Test Migration~~ ✅
 
-| Module | Files | Notes |
-|--------|-------|-------|
-| `cli.js` + `cli/` | 55 | Commander entry point, 43 command handlers (`commands/`), barrel, shared CLI utilities |
-| `index.js` | 1 | Public API exports (stale — `.ts` exists) |
+All test files migrated from `.js` to `.ts`. Vitest TypeScript integration verified. `tsc --noEmit` succeeds with zero errors. No `any` escape hatches except at FFI boundaries (napi-rs addon, tree-sitter WASM).
 
-**Stale `.js` counterparts to delete (13 files):** `domain/graph/builder.js`, `domain/graph/builder/{context,helpers,pipeline}.js`, `domain/graph/watcher.js`, `domain/search/{generator,index,models}.js`, `features/export.js`, `mcp/{index,middleware,server,tool-registry}.js` — these have `.ts` counterparts already
-
-### 5.6 -- Test Migration
-
-- Migrate test files from `.js` to `.ts`
-- Add type-safe test utilities and fixture builders
-- Verify vitest TypeScript integration with path aliases
-- Maintain `InMemoryRepository` (from Phase 3.2) as a typed test double
-
-**Verification:** All existing tests pass. `tsc --noEmit` succeeds with zero errors. No `any` escape hatches except at FFI boundaries (napi-rs addon, tree-sitter WASM).
-
-**Affected files:** All remaining `src/**/*.js` → `src/**/*.ts`, all `tests/**/*.js` → `tests/**/*.ts`, `package.json`, `biome.json`
+**Key PRs:** [#588](https://github.com/optave/codegraph/pull/588)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@optave/codegraph",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
@@ -39,7 +39,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.6"
       },
       "optionalDependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -1275,6 +1275,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1288,6 +1291,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1300,6 +1306,9 @@
       "integrity": "sha512-EnsiznqZ+sVE8dLie04EV6sEaX8SRguF4xf/2DzAoAlXBB4t6yIGWmq4My6eIZ2Cn3NS/Jzdpdpf4SS8SZoF0w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Local code graph CLI — parse codebases with tree-sitter, build dependency graphs, query them",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 3.4.0
- Add CHANGELOG entry for all 51 commits since v3.3.1
- Update ROADMAP: Phase 5 (TypeScript Migration) marked complete, Phase 6 status updated
- Update BACKLOG: Leiden vendoring unblocks community leverage features
- Update README: Phase 4/5 marked complete, Phase 6 in progress, Louvain → Leiden
- Restore missing `libc` fields in `package-lock.json` for Linux platform binaries

## Test plan
- [ ] `npm install` succeeds with updated lock file
- [ ] CHANGELOG renders correctly on GitHub
- [ ] ROADMAP checklist items match actual codebase state