### PR TITLE
fix(bench): use dist/ for npm benchmark installs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -236,9 +236,7 @@ jobs:
 
       - name: Build graph
         if: steps.existing.outputs.skip != 'true'
-        run: |
-          STRIP_FLAG=$(node -e "const [M]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
-          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js src/cli.ts build .
+        run: npx codegraph build .
 
       - name: Run embedding benchmark
         if: steps.existing.outputs.skip != 'true'

--- a/scripts/lib/bench-config.ts
+++ b/scripts/lib/bench-config.ts
@@ -155,11 +155,14 @@ export async function resolveBenchmarkSource() {
 		console.error(`Warning: failed to install @huggingface/transformers: ${err.message}`);
 	}
 
-	const srcDir = path.join(pkgDir, 'src');
+	// v3.4.0+ publishes compiled JS in dist/ alongside raw TS in src/.
+	// Node cannot strip types from node_modules, so prefer dist/ when available.
+	const distDir = path.join(pkgDir, 'dist');
+	const srcDir = fs.existsSync(distDir) ? distDir : path.join(pkgDir, 'src');
 
 	if (!fs.existsSync(srcDir)) {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
-		throw new Error(`Installed package does not contain src/ at ${srcDir}`);
+		throw new Error(`Installed package does not contain dist/ or src/ at ${pkgDir}`);
 	}
 
 	const resolvedVersion = cliVersion || installedPkg.version;


### PR DESCRIPTION
## Summary

- **bench-config.ts**: When installing codegraph from npm, use `dist/` (compiled JS) instead of `src/` (raw TS) as the import root. Node 22 throws `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` when importing `.ts` files from `node_modules`, which caused all 4 benchmark jobs to fail on v3.4.0.
- **benchmark.yml**: Replace `node src/cli.ts build .` with `npx codegraph build .` in the embedding benchmark's "Build graph" step — uses the package's bin entry point instead of a hardcoded source path.

The prior fix (#612) resolved `.js`→`.ts` in `srcImport()`, but that still fails because Node refuses type stripping inside `node_modules`. Using `dist/` sidesteps this entirely since it contains pre-compiled `.js` files. Falls back to `src/` for older packages without `dist/`.

## Test plan

- [ ] Re-run benchmark workflow with `version: 3.4.0` via `workflow_dispatch` — all 4 jobs should pass and create PRs
- [ ] Run benchmarks in `dev` mode (local) — should still work via `src/` + ts-resolve-loader