### PR TITLE
fix: use safe error coercion in debug catch blocks

### DIFF
--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -67,7 +67,7 @@ function getPackageExports(packageDir: string): any {
     return exports;
   } catch (e) {
     debug(
-      `readPackageExports: failed to read package.json in ${packageDir}: ${(e as Error).message}`,
+      `readPackageExports: failed to read package.json in ${packageDir}: ${e instanceof Error ? e.message : String(e)}`,
     );
     _exportsCache.set(packageDir, null);
     return null;
@@ -521,7 +521,7 @@ export function resolveImportPath(
       return remapJsToTs(normalized, rootDir);
     } catch (e) {
       debug(
-        `resolveImportPath: native resolution failed, falling back to JS: ${(e as Error).message}`,
+        `resolveImportPath: native resolution failed, falling back to JS: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
   }
@@ -543,7 +543,7 @@ export function computeConfidence(
       return native.computeConfidence(callerFile, targetFile, importedFrom || null);
     } catch (e) {
       debug(
-        `computeConfidence: native computation failed, falling back to JS: ${(e as Error).message}`,
+        `computeConfidence: native computation failed, falling back to JS: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
   }
@@ -584,7 +584,9 @@ export function resolveImportsBatch(
     }
     return map;
   } catch (e) {
-    debug(`batchResolve: native batch resolution failed: ${(e as Error).message}`);
+    debug(
+      `batchResolve: native batch resolution failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
     return null;
   }
 }

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -443,7 +443,9 @@ async function backfillTypeMap(
     try {
       code = fs.readFileSync(filePath, 'utf-8');
     } catch (e) {
-      debug(`backfillTypeMap: failed to read ${filePath}: ${(e as Error).message}`);
+      debug(
+        `backfillTypeMap: failed to read ${filePath}: ${e instanceof Error ? e.message : String(e)}`,
+      );
       return { typeMap: new Map(), backfilled: false };
     }
   }
@@ -460,7 +462,9 @@ async function backfillTypeMap(
       try {
         extracted.tree.delete();
       } catch (e) {
-        debug(`backfillTypeMap: WASM tree cleanup failed: ${(e as Error).message}`);
+        debug(
+          `backfillTypeMap: WASM tree cleanup failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
     }
   }
@@ -575,14 +579,18 @@ export async function parseFilesAuto(
               symbols._typeMapBackfilled = true;
             }
           } catch (e) {
-            debug(`batchExtract: typeMap backfill failed: ${(e as Error).message}`);
+            debug(
+              `batchExtract: typeMap backfill failed: ${e instanceof Error ? e.message : String(e)}`,
+            );
           } finally {
             // Free the WASM tree to prevent memory accumulation across repeated builds
             if (extracted?.tree && typeof extracted.tree.delete === 'function') {
               try {
                 extracted.tree.delete();
               } catch (e) {
-                debug(`batchExtract: WASM tree cleanup failed: ${(e as Error).message}`);
+                debug(
+                  `batchExtract: WASM tree cleanup failed: ${e instanceof Error ? e.message : String(e)}`,
+                );
               }
             }
           }

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -312,7 +312,7 @@ function resolveWorkspaceEntry(pkgDir: string): string | null {
     }
   } catch (e) {
     debug(
-      `resolveWorkspaceEntry: package.json probe failed for ${pkgDir}: ${(e as Error).message}`,
+      `resolveWorkspaceEntry: package.json probe failed for ${pkgDir}: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
   return null;
@@ -347,7 +347,9 @@ export function detectWorkspaces(rootDir: string): Map<string, WorkspaceEntry> {
         }
       }
     } catch (e) {
-      debug(`detectWorkspaces: failed to parse pnpm-workspace.yaml: ${(e as Error).message}`);
+      debug(
+        `detectWorkspaces: failed to parse pnpm-workspace.yaml: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
 
@@ -366,7 +368,9 @@ export function detectWorkspaces(rootDir: string): Map<string, WorkspaceEntry> {
           patterns.push(...ws.packages);
         }
       } catch (e) {
-        debug(`detectWorkspaces: failed to parse package.json workspaces: ${(e as Error).message}`);
+        debug(
+          `detectWorkspaces: failed to parse package.json workspaces: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
     }
   }
@@ -382,7 +386,9 @@ export function detectWorkspaces(rootDir: string): Map<string, WorkspaceEntry> {
           patterns.push(...lerna.packages);
         }
       } catch (e) {
-        debug(`detectWorkspaces: failed to parse lerna.json: ${(e as Error).message}`);
+        debug(
+          `detectWorkspaces: failed to parse lerna.json: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
     }
   }

--- a/src/infrastructure/native.ts
+++ b/src/infrastructure/native.ts
@@ -28,7 +28,7 @@ function detectLibc(): 'gnu' | 'musl' {
       return 'musl';
     }
   } catch (e) {
-    debug(`detectLibc: failed to read /lib: ${(e as Error).message}`);
+    debug(`detectLibc: failed to read /lib: ${e instanceof Error ? e.message : String(e)}`);
   }
   return 'gnu';
 }
@@ -97,7 +97,7 @@ export function getNativePackageVersion(): string | null {
     return pkgJson.version || null;
   } catch (e) {
     debug(
-      `getNativePackageVersion: failed to read package.json for ${pkg}: ${(e as Error).message}`,
+      `getNativePackageVersion: failed to read package.json for ${pkg}: ${e instanceof Error ? e.message : String(e)}`,
     );
     return null;
   }


### PR DESCRIPTION
## Summary

- Addresses Greptile review feedback on #616 (merged): replaces `(e as Error).message` with `e instanceof Error ? e.message : String(e)` in all 14 catch blocks introduced by that PR
- Prevents `undefined` in debug output when non-`Error` values are thrown (e.g. from WASM layer)
- Affects `config.ts` (4), `native.ts` (2), `parser.ts` (4), `resolve.ts` (4)

## Test plan

- [x] All 2128 tests pass locally
- [x] Lint clean on all 4 changed files
- [ ] CI green