### PR TITLE
chore: release v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.5.0](https://github.com/optave/codegraph/compare/v3.4.0...v3.5.0) (2026-03-26)
+
+**Post-migration stabilization and native engine accuracy.** This release fixes a Rust `findCaller` bug that misattributed 68 call edges, adds compound database indexes to restore query performance after the TypeScript migration, and delivers a 96% speedup to incremental role classification (255ms → 9ms). WASM builds are more resilient, incremental rebuilds handle JSONC and version changes correctly, and error handling is safer across the board.
+
+### Features
+
+* **titan:** first full Titan Paradigm pipeline run — audit report generation and skill improvements ([#623](https://github.com/optave/codegraph/pull/623))
+
+### Bug Fixes
+
+* **native:** remove spurious else-if in Rust `findCaller` that misattributed 68 call edges ([#637](https://github.com/optave/codegraph/pull/637))
+* **native:** recurse into `await_expression` children in `walk_ast_nodes` ([#618](https://github.com/optave/codegraph/pull/618))
+* **build:** JSONC parse and version-aware incremental rebuilds ([#631](https://github.com/optave/codegraph/pull/631))
+* WASM build resilience and lint cleanup from TypeScript migration ([#629](https://github.com/optave/codegraph/pull/629))
+* dogfood fixes 9.1–9.4 — version warning, barrel exports, quieter tsconfig, Set compatibility ([#634](https://github.com/optave/codegraph/pull/634))
+* use safe error coercion in debug catch blocks ([#630](https://github.com/optave/codegraph/pull/630))
+* add debug logging to empty catch blocks across infrastructure and domain layers ([#616](https://github.com/optave/codegraph/pull/616))
+* **bench:** use `dist/` for npm benchmark installs to avoid Node type-stripping error ([#624](https://github.com/optave/codegraph/pull/624))
+* **bench:** repair benchmark workflow broken by TypeScript migration ([#612](https://github.com/optave/codegraph/pull/612))
+* **skills:** prevent `/review` from spamming `@greptileai` when already approved ([#628](https://github.com/optave/codegraph/pull/628))
+
+### Performance
+
+* **db:** add compound indexes to fix query regression from TypeScript migration ([#632](https://github.com/optave/codegraph/pull/632))
+* **build:** incremental rebuild optimizations — roles 255ms → 9ms ([#622](https://github.com/optave/codegraph/pull/622))
+
+### Refactors
+
+* **errors:** extract shared `toErrorMessage` helper ([#633](https://github.com/optave/codegraph/pull/633))
+* extract `MAX_WALK_DEPTH` constant to extractors helpers ([#620](https://github.com/optave/codegraph/pull/620))
+* address SLOC warnings in domain and features layers ([#621](https://github.com/optave/codegraph/pull/621))
+* split `cfg-visitor.ts` by control-flow construct ([#619](https://github.com/optave/codegraph/pull/619))
+
 ## [3.4.0](https://github.com/optave/codegraph/compare/v3.3.1...v3.4.0) (2026-03-25)
 
 **TypeScript migration complete, Leiden community detection, and native engine hardening.** The entire codebase — all 271 source files — is now TypeScript with zero `.js` files remaining. Community detection upgrades from Louvain to a vendored Leiden algorithm with true probabilistic refinement, removing the `graphology` dependency. Go gains structural interface matching and C# gets proper `implements` disambiguation. The native Rust engine now extracts call-site AST nodes and bypasses the JS CFG visitor entirely on native builds. MCP server shutdown is graceful, and several edge-attribution and WASM fallback bugs are fixed.

--- a/crates/codegraph-core/Cargo.toml
+++ b/crates/codegraph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codegraph-core"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/docs/roadmap/BACKLOG.md
+++ b/docs/roadmap/BACKLOG.md
@@ -1,6 +1,6 @@
 # Codegraph Feature Backlog
 
-**Last updated:** 2026-03-25
+**Last updated:** 2026-03-26
 **Source:** Features derived from [COMPETITIVE_ANALYSIS.md](../../generated/competitive/COMPETITIVE_ANALYSIS.md) and internal roadmap discussions.
 
 ---

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,6 +1,6 @@
 # Codegraph Roadmap
 
-> **Current version:** 3.4.0 | **Status:** Active development | **Updated:** 2026-03-25
+> **Current version:** 3.5.0 | **Status:** Active development | **Updated:** 2026-03-26
 
 Codegraph is a strong local-first code graph CLI. This roadmap describes planned improvements across twelve phases -- closing gaps with commercial code intelligence platforms while preserving codegraph's core strengths: fully local, open source, zero cloud dependency by default.
 
@@ -1207,11 +1207,13 @@ Structure building is unchanged — at 22ms it's already fast.
 
 ### 6.8 -- Incremental Rebuild Performance
 
-**Not started.** Current native 1-file rebuild is ~802ms. Structure (~18ms) and roles (~255ms) still run full graph-wide recomputation on every 1-file change. Finalize (~80ms) is also significant.
+**In progress.** Roles optimization shipped in v3.5.0 — batch UPDATE by role reduced roles from 255ms → 9ms ([#622](https://github.com/optave/codegraph/pull/622)). Compound DB indexes restored query performance after TS migration ([#632](https://github.com/optave/codegraph/pull/632)).
 
-- **Skip unchanged phases:** Structure and roles should skip full reclassification when only 1 file changes and cross-file degree is unchanged
-- **Incremental edge rebuild:** Only rebuild edges involving the changed file's symbols
-- **Benchmark target:** Sub-100ms native 1-file rebuilds (from current 802ms)
+- ✅ **Roles optimization:** Batch UPDATE grouped by role (255ms → 9ms, −96%) — v3.5.0, [#622](https://github.com/optave/codegraph/pull/622)
+- ✅ **DB index regression:** Compound indexes on nodes/edges tables — v3.5.0, [#632](https://github.com/optave/codegraph/pull/632)
+- 🔲 **Skip unchanged phases:** Structure and roles should skip full reclassification when only 1 file changes and cross-file degree is unchanged
+- 🔲 **Incremental edge rebuild:** Only rebuild edges involving the changed file's symbols
+- 🔲 **Benchmark target:** Sub-100ms native 1-file rebuilds
 
 **Affected files:** `src/domain/graph/builder/stages/build-structure.ts`, `src/domain/graph/builder/stages/build-edges.ts`, `src/domain/graph/builder/pipeline.ts`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@optave/codegraph",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Local code graph CLI — parse codebases with tree-sitter, build dependency graphs, query them",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 3.5.0
- Add CHANGELOG entry for all 23 commits since v3.4.0
- Update ROADMAP Phase 6.8 with incremental rebuild progress (roles 255ms → 9ms)
- Restore missing `libc` fields in package-lock.json Linux entries

## Test plan
- [ ] `npm install` succeeds with updated lock file
- [ ] CHANGELOG renders correctly on GitHub
- [ ] ROADMAP checklist items match actual codebase state