### PR TITLE
fix(parser): add explicit continue for self_parameter skip (#649)

### DIFF
--- a/src/extractors/rust.ts
+++ b/src/extractors/rust.ts
@@ -228,6 +228,7 @@ function extractRustParameters(paramListNode: TreeSitterNode | null): SubDeclara
     if (!param) continue;
     if (param.type === 'self_parameter') {
       // Skip self parameters — matches native engine behaviour
+      continue;
     } else if (param.type === 'parameter') {
       const pattern = param.childForFieldName('pattern');
       if (pattern) {


### PR DESCRIPTION
## Summary

- Adds explicit `continue` in `extractRustParameters` when skipping `self_parameter` nodes, matching native engine behavior

The original parity fix (commit c898a4a on `fix/wasm-engine-parity-649`) contained 5 fixes. Four of the five already reached main through other PRs (#618, #637, #651, etc.). This PR lands the one remaining change: an explicit `continue` statement in the WASM Rust extractor's `self_parameter` guard.

While the empty `if` block was functionally equivalent (the `else if` prevented fall-through), the explicit `continue` is clearer and matches the pattern used elsewhere in the codebase.

Closes #649

## Test plan

- [ ] CI passes (no behavioral change — the `else if` already prevented `self_parameter` from being extracted)
- [ ] Engine parity tests continue to pass