### PR TITLE
chore(deps): upgrade TypeScript from 5.9 to 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.28.0",
         "better-sqlite3": "^12.6.2",
         "commander": "^14.0.3",
         "web-tree-sitter": "^0.26.5"
@@ -37,7 +36,7 @@
         "tree-sitter-ruby": "^0.23.1",
         "tree-sitter-rust": "^0.24.0",
         "tree-sitter-typescript": "^0.23.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -7262,9 +7261,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "^0.24.0",
     "tree-sitter-typescript": "^0.23.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vitest": "^4.0.18"
   },
   "license": "Apache-2.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,18 +9,6 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "rootDir": "./src",
-    "baseUrl": "./src",
-    "paths": {
-      "#shared/*": ["./shared/*"],
-      "#infrastructure/*": ["./infrastructure/*"],
-      "#db/*": ["./db/*"],
-      "#domain/*": ["./domain/*"],
-      "#features/*": ["./features/*"],
-      "#presentation/*": ["./presentation/*"],
-      "#graph/*": ["./graph/*"],
-      "#mcp/*": ["./mcp/*"],
-      "#ast-analysis/*": ["./ast-analysis/*"]
-    },
 
     /* Emit */
     "outDir": "./dist",


### PR DESCRIPTION
## Summary
- Upgrade `typescript` devDependency from `^5.9.3` to `^6.0.2`
- Remove unused `baseUrl` and `paths` from `tsconfig.json` — zero imports in the codebase reference path aliases (all 849+ imports use relative paths with `.js` extensions), so these were dead config
- This fixes the TS5101 error (`baseUrl` deprecated in TS 6.x) that blocked Dependabot PR #663

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm run build` produces `dist/` successfully
- [x] `npm run lint` passes (no new warnings)
- [x] `npm test` — 2129/2129 tests pass
- [x] `npx codegraph --help` works
- [ ] CI passes on this PR

Closes #663