### PR TITLE
chore: release v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.5.0](https://github.com/optave/codegraph/compare/v3.4.1...v3.5.0) (2026-03-29)
+
+**Full rusqlite database migration and sub-100ms incremental rebuilds.** This release completes the migration of all SQLite operations from better-sqlite3 to native Rust/rusqlite via napi-rs, delivering major performance gains across the entire build pipeline. Incremental rebuilds drop from 466ms to 67–80ms, and bulk inserts for nodes, edges, roles, AST nodes, CFG, and dataflow all run through the native engine. better-sqlite3 is now lazy-loaded only as a fallback. Path aliases are restored with TS 6.x-compatible subpath imports, and several WASM/native parity bugs are fixed.
+
+### Features
+
+* **config:** restore path aliases with TS 6.x-compatible subpath imports ([#672](https://github.com/optave/codegraph/pull/672))
+
+### Bug Fixes
+
+* **db:** fold reverse-dep edge deletion into NativeDatabase.purgeFilesData ([#670](https://github.com/optave/codegraph/pull/670), [#679](https://github.com/optave/codegraph/pull/679))
+* **wasm:** extract call-site AST nodes in ast-store-visitor ([#678](https://github.com/optave/codegraph/pull/678))
+* **parser:** close WASM–native engine parity gap ([#649](https://github.com/optave/codegraph/pull/649), [#657](https://github.com/optave/codegraph/pull/657))
+* **test:** remove constant-kind exclusion from parity test ([#676](https://github.com/optave/codegraph/pull/676), [#680](https://github.com/optave/codegraph/pull/680))
+
+### Performance
+
+* **db:** NativeDatabase napi-rs class for rusqlite connection lifecycle (6.13) ([#666](https://github.com/optave/codegraph/pull/666))
+* **db:** migrate Repository read queries to NativeDatabase rusqlite (6.14) ([#671](https://github.com/optave/codegraph/pull/671))
+* **db:** migrate build pipeline writes to NativeDatabase (6.15) ([#669](https://github.com/optave/codegraph/pull/669))
+* **db:** generic query execution on NativeDatabase (6.16) ([#677](https://github.com/optave/codegraph/pull/677))
+* **db:** bulk CFG and dataflow DB writes via rusqlite ([#653](https://github.com/optave/codegraph/pull/653))
+* **build:** native Rust/rusqlite for roles & edge insertion (6.12) ([#658](https://github.com/optave/codegraph/pull/658))
+* **insert-nodes:** native Rust/rusqlite pipeline for node insertion ([#654](https://github.com/optave/codegraph/pull/654))
+* **ast:** bulk-insert AST nodes via native Rust/rusqlite ([#651](https://github.com/optave/codegraph/pull/651))
+* sub-100ms incremental rebuilds (466ms → 67–80ms) ([#644](https://github.com/optave/codegraph/pull/644))
+* **hooks:** narrow Bash hook matchers to git commands only ([#655](https://github.com/optave/codegraph/pull/655))
+
+### Refactors
+
+* **db:** lazy-load better-sqlite3 and remove standalone napi functions (6.17) ([#673](https://github.com/optave/codegraph/pull/673))
+
+### Chores
+
+* **deps:** upgrade TypeScript from 5.9 to 6.0 ([#667](https://github.com/optave/codegraph/pull/667))
+* **deps:** bump @modelcontextprotocol/sdk from 1.27.1 to 1.28.0 ([#664](https://github.com/optave/codegraph/pull/664))
+* **deps-dev:** bump @vitest/coverage-v8 from 4.1.1 to 4.1.2 ([#662](https://github.com/optave/codegraph/pull/662))
+* **deps-dev:** bump @biomejs/biome from 2.4.8 to 2.4.9 ([#661](https://github.com/optave/codegraph/pull/661))
+
 ## [3.4.1](https://github.com/optave/codegraph/compare/v3.4.0...v3.4.1) (2026-03-26)
 
 **Post-migration stabilization and native engine accuracy.** This release fixes a Rust `findCaller` bug that misattributed 68 call edges, adds compound database indexes to restore query performance after the TypeScript migration, and delivers a 96% speedup to incremental role classification (255ms → 9ms). WASM builds are more resilient, incremental rebuilds handle JSONC and version changes correctly, and error handling is safer across the board.

--- a/README.md
+++ b/README.md
@@ -772,8 +772,8 @@ See **[ROADMAP.md](docs/roadmap/ROADMAP.md)** for the full development roadmap a
 5. ~~**Architectural Refactoring**~~ — **Complete** (v3.1.5) — unified AST analysis, composable MCP, domain errors, builder pipeline, graph model, qualified names, presentation layer, CLI composability
 6. ~~**Resolution Accuracy**~~ — **Complete** (v3.3.1) — type inference, receiver type tracking, dead role sub-categories, resolution benchmarks, `package.json` exports, monorepo workspace resolution
 7. ~~**TypeScript Migration**~~ — **Complete** (v3.4.0) — all 271 source files migrated from JS to TS, zero `.js` remaining
-8. **Native Analysis Acceleration** — **In Progress** (7 of 8 complete) — JS-only build phases moved to Rust, sub-100ms 1-file rebuilds remaining
-9. **Expanded Language Support** — 8 new languages (11 → 19)
+8. ~~**Native Analysis Acceleration**~~ — **Complete** (v3.5.0) — all build phases in Rust/rusqlite, sub-100ms incremental rebuilds, better-sqlite3 lazy-loaded as fallback only
+9. **Expanded Language Support** — 23 new languages in 4 batches (11 → 34)
 10. **Runtime & Extensibility** — event-driven pipeline, plugin system, query caching, pagination
 11. **Quality, Security & Technical Debt** — supply-chain security (SBOM, SLSA), CI coverage gates, timer cleanup, tech debt kill list
 12. **Intelligent Embeddings** — LLM-generated descriptions, enhanced embeddings, module summaries

--- a/crates/codegraph-core/Cargo.toml
+++ b/crates/codegraph-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codegraph-core"
-version = "3.4.1"
+version = "3.5.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/docs/roadmap/BACKLOG.md
+++ b/docs/roadmap/BACKLOG.md
@@ -1,6 +1,6 @@
 # Codegraph Feature Backlog
 
-**Last updated:** 2026-03-26
+**Last updated:** 2026-03-29
 **Source:** Features derived from [COMPETITIVE_ANALYSIS.md](../../generated/competitive/COMPETITIVE_ANALYSIS.md) and internal roadmap discussions.
 
 ---

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,6 +1,6 @@
 # Codegraph Roadmap
 
-> **Current version:** 3.4.1 | **Status:** Active development | **Updated:** 2026-03-26
+> **Current version:** 3.5.0 | **Status:** Active development | **Updated:** 2026-03-29
 
 Codegraph is a strong local-first code graph CLI. This roadmap describes planned improvements across thirteen phases -- closing gaps with commercial code intelligence platforms while preserving codegraph's core strengths: fully local, open source, zero cloud dependency by default.
 
@@ -19,7 +19,7 @@ Codegraph is a strong local-first code graph CLI. This roadmap describes planned
 | [**3**](#phase-3--architectural-refactoring) | Architectural Refactoring (Vertical Slice) | Unified AST analysis framework, command/query separation, repository pattern, queries.js decomposition, composable MCP, CLI commands, domain errors, builder pipeline, presentation layer, domain grouping, curated API, unified graph model, qualified names, CLI composability | **Complete** (v3.1.5) |
 | [**4**](#phase-4--resolution-accuracy) | Resolution Accuracy | Dead role sub-categories, receiver type tracking, interface/trait implementation edges, resolution precision/recall benchmarks, `package.json` exports field, monorepo workspace resolution | **Complete** (v3.3.1) |
 | [**5**](#phase-5--typescript-migration) | TypeScript Migration | Project setup, core type definitions, leaf -> core -> orchestration module migration, test migration | **Complete** (v3.4.0) |
-| [**6**](#phase-6--native-analysis-acceleration) | Native Analysis Acceleration | Rust extraction for AST/CFG/dataflow/complexity; batch SQLite inserts; incremental rebuilds; native DB write pipeline; full rusqlite migration so native engine never touches better-sqlite3 | **In Progress** (7 of 17 done, 1 partial) |
+| [**6**](#phase-6--native-analysis-acceleration) | Native Analysis Acceleration | Rust extraction for AST/CFG/dataflow/complexity; batch SQLite inserts; incremental rebuilds; native DB write pipeline; full rusqlite migration so native engine never touches better-sqlite3 | **Complete** (v3.5.0) |
 | [**7**](#phase-7--expanded-language-support) | Expanded Language Support | Parser abstraction layer, 23 new languages in 4 batches (11 → 34), dual-engine support | Planned |
 | [**8**](#phase-8--runtime--extensibility) | Runtime & Extensibility | Event-driven pipeline, unified engine strategy, subgraph export filtering, transitive confidence, query caching, configuration profiles, pagination, plugin system | Planned |
 | [**9**](#phase-9--quality-security--technical-debt) | Quality, Security & Technical Debt | Supply-chain security, test quality gates, architectural debt cleanup | Planned |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@optave/codegraph",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
@@ -1276,6 +1276,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1289,6 +1292,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1301,6 +1307,9 @@
       "integrity": "sha512-JVYjOpesDThFbWFguX4JjXjBkwNlebwSOnGEX4NTtgcGkpZv2s+/TjBd8uks+SLEjPdtDGzZQNTlHFA+h40sPw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optave/codegraph",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Local code graph CLI — parse codebases with tree-sitter, build dependency graphs, query them",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 3.5.0
- Add CHANGELOG entry for all commits since v3.4.1
- Update ROADMAP — Phase 6 (Native Analysis Acceleration) marked Complete
- Update README roadmap — Phase 6 complete, fix Phase 7 language count (11 → 34)
- Restore missing `libc` fields in package-lock.json for Linux platform binaries

## Test plan
- [ ] `npm install` succeeds with updated lock file
- [ ] CHANGELOG renders correctly on GitHub
- [ ] ROADMAP checklist items match actual codebase state