### PR TITLE
fix(native): extract export name for destructured dynamic imports

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1535,4 +1535,22 @@ mod tests {
         assert!(dyn_imports[0].names.contains(&"c".to_string()));
         assert!(!dyn_imports[0].names.contains(&"fromBarrel".to_string()));
     }
+
+    #[test]
+    fn finds_dynamic_import_with_aliased_default_destructuring() {
+        let s = parse_js("const { buildGraph: local = null } = await import('./builder.js');");
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        assert_eq!(dyn_imports.len(), 1);
+        assert!(dyn_imports[0].names.contains(&"buildGraph".to_string()));
+        assert!(!dyn_imports[0].names.contains(&"local".to_string()));
+    }
+
+    #[test]
+    fn finds_dynamic_import_with_nested_object_destructuring() {
+        let s = parse_js("const { foo: { nested } } = await import('./mod.js');");
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        assert_eq!(dyn_imports.len(), 1);
+        assert!(dyn_imports[0].names.contains(&"foo".to_string()));
+        assert!(!dyn_imports[0].names.contains(&"nested".to_string()));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix Rust parser extracting local alias instead of export name for destructured dynamic imports (`const { buildGraph: fromBarrel } = await import(...)`)
- Changed `pair_pattern`/`pair` handling in `extract_dynamic_import_names()` to read the `key` field (export name) instead of `value` field (local alias), matching WASM behavior
- Added tests for aliased and mixed destructured dynamic imports

## Test plan
- [ ] CI passes Rust tests (`finds_dynamic_import_with_aliased_destructuring`, `finds_dynamic_import_with_mixed_destructuring`)
- [ ] Existing `finds_dynamic_import_with_destructuring` test still passes (shorthand case unaffected)
- [ ] Native/WASM parity test shows no remaining edge difference for dynamic imports

Closes #812