### PR TITLE
fix: release config script validation and broken postbump

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -178,13 +178,21 @@ Verify that all script references in release-related config files point to files
 Check these files for script paths:
 
 ```bash
-# .versionrc.json — check any "scripts" entries
+# .versionrc.json — check any "scripts" entries (runner and forwarded args)
 grep -oP 'node \K[^ "]+' .versionrc.json 2>/dev/null | while read script; do
+  [ ! -f "$script" ] && echo "ERROR: .versionrc.json references '$script' but it does not exist"
+done
+grep -oP 'node [^ "]+ \K[^ "]+' .versionrc.json 2>/dev/null | while read script; do
   [ ! -f "$script" ] && echo "ERROR: .versionrc.json references '$script' but it does not exist"
 done
 
 # package.json — check version/preversion/postversion lifecycle hooks
 grep -E '"(pre)?version"|"postversion"' package.json | grep -oP 'node \K[^ "&]+' | while read script; do
+  [ ! -f "$script" ] && echo "ERROR: package.json lifecycle references '$script' but it does not exist"
+done
+
+# Also check forwarded script arguments (e.g. "node scripts/node-ts.js scripts/foo.ts")
+grep -E '"(pre)?version"|"postversion"' package.json | grep -oP 'node [^ "&]+ \K[^ "&]+' | while read script; do
   [ ! -f "$script" ] && echo "ERROR: package.json lifecycle references '$script' but it does not exist"
 done
 ```


### PR DESCRIPTION
## Summary
- Remove broken `postbump` script from `.versionrc.json` that referenced non-existent `sync-native-versions.js` (only `.ts` exists). The npm `version` lifecycle in `package.json` already handles native version syncing correctly via `node-ts.js`, making this entry both redundant and broken
- Add Step 7b to the `/release` skill that validates all script references in `.versionrc.json` and `package.json` lifecycle hooks point to files that actually exist, preventing this class of issue from recurring
- Fix `.js` → `.ts` reference in the release skill docs

Closes #823

## Test plan
- [ ] `npm run release:dry-run` succeeds without the removed postbump
- [ ] Verify `package.json` `version` lifecycle still syncs native versions correctly
- [ ] Step 7b validation catches broken script paths when running `/release`