### PR TITLE
fix(native): strip pre-release suffix in semverCompare

### DIFF
--- a/src/infrastructure/update-check.ts
+++ b/src/infrastructure/update-check.ts
@@ -18,11 +18,11 @@ interface UpdateCache {
 
 /**
  * Minimal semver comparison. Returns -1, 0, or 1.
- * Only handles numeric x.y.z (no pre-release tags).
+ * Strips pre-release suffixes (e.g. "3.9.3-dev.6" → "3.9.3") before comparing.
  */
 export function semverCompare(a: string, b: string): -1 | 0 | 1 {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
+  const pa = a.replace(/-.*$/, '').split('.').map(Number);
+  const pb = b.replace(/-.*$/, '').split('.').map(Number);
   for (let i = 0; i < 3; i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;

--- a/tests/unit/update-check.test.ts
+++ b/tests/unit/update-check.test.ts
@@ -51,6 +51,15 @@ describe('semverCompare', () => {
   it('major takes priority over minor and patch', () => {
     expect(semverCompare('1.9.9', '2.0.0')).toBe(-1);
   });
+
+  it('strips pre-release suffixes before comparing', () => {
+    // 3.9.3-dev.6 should be treated as 3.9.3, which is > 3.9.1
+    expect(semverCompare('3.9.3-dev.6', '3.9.1')).toBe(1);
+    expect(semverCompare('3.9.3-dev.6', '3.9.3')).toBe(0);
+    expect(semverCompare('3.9.3-dev.6', '3.9.4')).toBe(-1);
+    // Both sides with pre-release
+    expect(semverCompare('2.0.0-beta.1', '1.9.9-alpha.3')).toBe(1);
+  });
 });
 
 // ─── checkForUpdates ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `semverCompare('3.9.3-dev.6', '3.9.1')` incorrectly returned `-1` because `Number('3-dev')` is `NaN`, and `NaN || 0` collapsed to `0`, making the patch comparison `0 < 1`
- This caused `shouldSkipNativeOrchestrator` to flag **all pre-release builds** as "buggy addon", disabling the native orchestrator fast path from #897
- Fix: strip `-<prerelease>` suffix before splitting on `.` so `3.9.3-dev.6` correctly compares as `3.9.3`

## Impact

Every dev build (e.g. `3.9.3-dev.6`) was silently falling back to the JS pipeline instead of using the Rust orchestrator. Benchmarking confirmed the native orchestrator was skipped:
```
[codegraph DEBUG] Skipping native orchestrator: buggy addon 3.9.3-dev.6
```

## Test plan

- [x] Existing `semverCompare` tests pass (equal, less-than, greater-than across major/minor/patch)
- [x] New test: pre-release suffixes stripped correctly (`3.9.3-dev.6 > 3.9.1`, `3.9.3-dev.6 == 3.9.3`, `2.0.0-beta.1 > 1.9.9-alpha.3`)
- [x] All 23 tests in `update-check.test.ts` pass