### PR TITLE
perf(native): raise native edge-building threshold to smallFilesThreshold

### DIFF
--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -798,10 +798,11 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
       }
     }
 
-    // Skip native import-edge path for small incremental builds (≤3 files):
-    // napi-rs marshaling overhead exceeds computation savings.
+    // Skip native import-edge path for small incremental builds: napi-rs
+    // marshaling overhead (~13ms) exceeds Rust computation savings at this scale.
     const useNativeImportEdges =
-      native?.buildImportEdges && (ctx.isFullBuild || ctx.fileSymbols.size > 3);
+      native?.buildImportEdges &&
+      (ctx.isFullBuild || ctx.fileSymbols.size > ctx.config.build.smallFilesThreshold);
     if (useNativeImportEdges) {
       const beforeLen = allEdgeRows.length;
       buildImportEdgesNative(ctx, getNodeIdStmt, allEdgeRows, native!);
@@ -821,10 +822,11 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
       buildImportEdges(ctx, getNodeIdStmt, allEdgeRows);
     }
 
-    // Skip native call-edge path for small incremental builds (≤3 files):
-    // napi-rs marshaling overhead for allNodes exceeds computation savings.
+    // Skip native call-edge path for small incremental builds: napi-rs
+    // marshaling overhead for allNodes exceeds Rust computation savings.
     const useNativeCallEdges =
-      native?.buildCallEdges && (ctx.isFullBuild || ctx.fileSymbols.size > 3);
+      native?.buildCallEdges &&
+      (ctx.isFullBuild || ctx.fileSymbols.size > ctx.config.build.smallFilesThreshold);
     if (useNativeCallEdges) {
       buildCallEdgesNative(ctx, getNodeIdStmt, allEdgeRows, allNodesBefore, native!);
     } else {


### PR DESCRIPTION
## Summary

- Raise the native import/call edge-building threshold from hardcoded `> 3` to `ctx.config.build.smallFilesThreshold` (default 5)
- Small incremental builds (≤5 files) now use the JS edge path, avoiding ~13ms of napi-rs marshaling overhead
- Aligns with the same threshold used for insertNodes, structure, and other pipeline stages

Closes #936

## Test plan

- [x] Integration tests pass (564/564)
- [ ] Verify with `codegraph build --engine native --timing` on a 5-file incremental — edges phase should drop from ~42ms to ~29ms
- [ ] Verify full builds and large incrementals still use the native edge path