### PR TITLE
fix(structure): reconcile import_count semantics between fast path and full path

### DIFF
--- a/crates/codegraph-core/src/structure.rs
+++ b/crates/codegraph-core/src/structure.rs
@@ -589,6 +589,25 @@ fn compute_file_metrics(
         }
     }
 
+    // Batch-load import counts per file from DB (distinct imported files,
+    // matching the fast-path semantics in update_changed_file_metrics)
+    let mut import_counts: HashMap<String, i64> = HashMap::new();
+    if let Ok(mut stmt) = tx.prepare(
+        "SELECT n1.file, COUNT(DISTINCT n2.file) FROM edges e \
+         JOIN nodes n1 ON e.source_id = n1.id \
+         JOIN nodes n2 ON e.target_id = n2.id \
+         WHERE e.kind = 'imports' \
+         GROUP BY n1.file",
+    ) {
+        if let Ok(rows) = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        }) {
+            for row in rows.flatten() {
+                import_counts.insert(row.0, row.1);
+            }
+        }
+    }
+
     {
         let mut upsert = match tx.prepare(
             "INSERT OR REPLACE INTO node_metrics \
@@ -607,7 +626,7 @@ fn compute_file_metrics(
 
             let line_count = line_count_map.get(rel_path).copied().unwrap_or(0);
             let symbol_count = symbol_counts.get(rel_path).copied().unwrap_or(0);
-            let import_count = symbols.imports.len() as i64;
+            let import_count = import_counts.get(rel_path).copied().unwrap_or(0);
             let export_count = symbols.exports.len() as i64;
             let fan_in = fan_in_map.get(rel_path).copied().unwrap_or(0);
             let fan_out = fan_out_map.get(rel_path).copied().unwrap_or(0);

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -165,22 +165,23 @@ function computeFileMetrics(
   fanInMap: Map<string, number>,
   fanOutMap: Map<string, number>,
 ): void {
-  // Batch-load import counts per file (distinct imported files,
-  // matching the fast-path semantics in updateChangedFileMetrics)
-  const importCountMap = new Map<string, number>();
-  for (const row of db
-    .prepare(
-      `SELECT n1.file AS src, COUNT(DISTINCT n2.file) AS cnt FROM edges e
-       JOIN nodes n1 ON e.source_id = n1.id
-       JOIN nodes n2 ON e.target_id = n2.id
-       WHERE e.kind = 'imports'
-       GROUP BY n1.file`,
-    )
-    .all() as { src: string; cnt: number }[]) {
-    importCountMap.set(row.src, row.cnt);
-  }
-
   db.transaction(() => {
+    // Batch-load import counts per file (distinct imported files,
+    // matching the fast-path semantics in updateChangedFileMetrics).
+    // Runs inside the transaction for parity with the Rust path.
+    const importCountMap = new Map<string, number>();
+    for (const row of db
+      .prepare(
+        `SELECT n1.file AS src, COUNT(DISTINCT n2.file) AS cnt FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'imports'
+         GROUP BY n1.file`,
+      )
+      .all() as { src: string; cnt: number }[]) {
+      importCountMap.set(row.src, row.cnt);
+    }
+
     for (const [relPath, symbols] of fileSymbols) {
       const fileRow = getNodeIdStmt.get(relPath, 'file', relPath, 0);
       if (!fileRow) continue;

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -165,6 +165,21 @@ function computeFileMetrics(
   fanInMap: Map<string, number>,
   fanOutMap: Map<string, number>,
 ): void {
+  // Batch-load import counts per file (distinct imported files,
+  // matching the fast-path semantics in updateChangedFileMetrics)
+  const importCountMap = new Map<string, number>();
+  for (const row of db
+    .prepare(
+      `SELECT n1.file AS src, COUNT(DISTINCT n2.file) AS cnt FROM edges e
+       JOIN nodes n1 ON e.source_id = n1.id
+       JOIN nodes n2 ON e.target_id = n2.id
+       WHERE e.kind = 'imports'
+       GROUP BY n1.file`,
+    )
+    .all() as { src: string; cnt: number }[]) {
+    importCountMap.set(row.src, row.cnt);
+  }
+
   db.transaction(() => {
     for (const [relPath, symbols] of fileSymbols) {
       const fileRow = getNodeIdStmt.get(relPath, 'file', relPath, 0);
@@ -180,7 +195,7 @@ function computeFileMetrics(
           symbolCount++;
         }
       }
-      const importCount = symbols.imports.length;
+      const importCount = importCountMap.get(relPath) || 0;
       const exportCount = symbols.exports.length;
       const fanIn = fanInMap.get(relPath) || 0;
       const fanOut = fanOutMap.get(relPath) || 0;


### PR DESCRIPTION
## Summary
- **Bug:** `import_count` in `compute_file_metrics` (full-build path) counted raw import *statements* (`symbols.imports.len()`), while `update_changed_file_metrics` (incremental fast path) counted distinct imported *files* (`COUNT(DISTINCT n2.file)`). A file importing two symbols from the same module would get `import_count=2` in full builds but `import_count=1` in incremental rebuilds.
- **Fix:** Both paths now consistently count distinct imported files by querying the DB edges table. The full path batch-loads all counts upfront (one query) to avoid N+1 queries.
- **Scope:** Fixed in both the Rust native engine (`crates/codegraph-core/src/structure.rs`) and the JS/TS WASM engine (`src/features/structure.ts`).

Closes #941

## Test plan
- [x] `cargo check` passes (Rust)
- [x] `tsc --noEmit` passes (TypeScript)
- [x] All 31 structure tests pass (`vitest run -t "structure"`)
- [ ] Verify with a project that has multiple imports from the same file — `import_count` should now be consistent between full and incremental builds