### PR TITLE
chore: disable adaptive thinking via env var

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/
 .env
 grammars/*.wasm
 .claude/session-edits.log
+.claude/worktrees/
 generated/DEPENDENCIES.md
 generated/DEPENDENCIES.json
 artifacts/


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` env var to `.claude/settings.json` to disable adaptive thinking in Claude Code sessions.

## Test plan
- [x] Verify settings.json is valid JSON
- [ ] Confirm env var is picked up in new Claude Code sessions