### PR TITLE
fix(ci): add resilience to Claude Code workflow for fork branch races

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -186,8 +186,8 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO_FULL_NAME: ${{ github.repository }}
         run: |
-          PR_DATA=$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" --json headRefName,headRepository)
-          HEAD_REPO=$(echo "${PR_DATA}" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')
+          PR_DATA=$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" --json headRefName,headRepository,headRepositoryOwner)
+          HEAD_REPO=$(echo "${PR_DATA}" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
           HEAD_REF=$(echo "${PR_DATA}" | jq -r '.headRefName')
           for i in 1 2 3; do
             if git ls-remote --exit-code "https://github.com/${HEAD_REPO}.git" "refs/heads/${HEAD_REF}" >/dev/null 2>&1; then

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,12 +16,32 @@ jobs:
   automated-review:
     if: github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
     steps:
+      - name: Verify PR branch is fetchable
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          for i in 1 2 3; do
+            if git ls-remote --exit-code "https://github.com/${HEAD_REPO}.git" "refs/heads/${HEAD_REF}" >/dev/null 2>&1; then
+              echo "Branch ${HEAD_REPO}:${HEAD_REF} verified on attempt ${i}"
+              exit 0
+            fi
+            echo "::warning::Branch not reachable (attempt ${i}/3), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::PR branch ${HEAD_REPO}:${HEAD_REF} not reachable after 3 attempts — fork may be deleted or branch in transient state"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -149,6 +169,9 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    concurrency:
+      group: claude-interactive-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: read
@@ -156,6 +179,26 @@ jobs:
       id-token: write
       actions: read
     steps:
+      - name: Verify PR branch is fetchable
+        if: github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          PR_DATA=$(gh pr view "${PR_NUMBER}" --repo "${{ github.repository }}" --json headRefName,headRepository)
+          HEAD_REPO=$(echo "${PR_DATA}" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')
+          HEAD_REF=$(echo "${PR_DATA}" | jq -r '.headRefName')
+          for i in 1 2 3; do
+            if git ls-remote --exit-code "https://github.com/${HEAD_REPO}.git" "refs/heads/${HEAD_REF}" >/dev/null 2>&1; then
+              echo "Branch ${HEAD_REPO}:${HEAD_REF} verified on attempt ${i}"
+              exit 0
+            fi
+            echo "::warning::Branch not reachable (attempt ${i}/3), retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::PR branch ${HEAD_REPO}:${HEAD_REF} not reachable after 3 attempts — fork may be deleted or branch in transient state"
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,16 +28,16 @@ jobs:
       - name: Verify PR branch is fetchable
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
-          HEAD_REF="${{ github.event.pull_request.head.ref }}"
           for i in 1 2 3; do
             if git ls-remote --exit-code "https://github.com/${HEAD_REPO}.git" "refs/heads/${HEAD_REF}" >/dev/null 2>&1; then
               echo "Branch ${HEAD_REPO}:${HEAD_REF} verified on attempt ${i}"
               exit 0
             fi
             echo "::warning::Branch not reachable (attempt ${i}/3), retrying in 10s..."
-            sleep 10
+            if [ "${i}" -lt 3 ]; then sleep 10; fi
           done
           echo "::error::PR branch ${HEAD_REPO}:${HEAD_REF} not reachable after 3 attempts — fork may be deleted or branch in transient state"
           exit 1
@@ -183,9 +183,10 @@ jobs:
         if: github.event.issue.pull_request
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO_FULL_NAME: ${{ github.repository }}
         run: |
-          PR_NUMBER="${{ github.event.issue.number }}"
-          PR_DATA=$(gh pr view "${PR_NUMBER}" --repo "${{ github.repository }}" --json headRefName,headRepository)
+          PR_DATA=$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL_NAME}" --json headRefName,headRepository)
           HEAD_REPO=$(echo "${PR_DATA}" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')
           HEAD_REF=$(echo "${PR_DATA}" | jq -r '.headRefName')
           for i in 1 2 3; do
@@ -194,7 +195,7 @@ jobs:
               exit 0
             fi
             echo "::warning::Branch not reachable (attempt ${i}/3), retrying in 10s..."
-            sleep 10
+            if [ "${i}" -lt 3 ]; then sleep 10; fi
           done
           echo "::error::PR branch ${HEAD_REPO}:${HEAD_REF} not reachable after 3 attempts — fork may be deleted or branch in transient state"
           exit 1


### PR DESCRIPTION
## Summary

- Add **concurrency groups** (cancel-in-progress) to both `automated-review` and `interactive-claude` jobs, keyed on PR number. If "Update branch" triggers a new push event while `@claude` is running, the stale run is cancelled instead of racing
- Add **pre-flight branch verification** with 3 retries at 10s intervals before `claude-code-action` runs. Catches transient fork ref states (concurrent "Update branch" operations, GitHub propagation delays, deleted forks) with a clear error message instead of a cryptic `exit code 128`

## Context

PR #947 triggered this: `@claude` and "Update branch" were clicked within seconds. GitHub's server-side merge temporarily made the fork branch ref unreachable. The `claude-code-action` hit that ~1s window and failed with `fatal: couldn't find remote ref`. See [failed run](https://github.com/optave/ops-codegraph-tool/actions/runs/24525861910/job/71695797882).

## Test plan

- [ ] Trigger `@claude` on a fork PR — verify the pre-flight step logs "Branch verified on attempt 1"
- [ ] Click "Update branch" and `@claude` simultaneously — verify concurrency group cancels the stale run
- [ ] Trigger `@claude` on a PR whose fork branch was deleted — verify clear error after 3 retries