### PR TITLE
fix(rust): fix test compilation errors and add verification rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 > **Never document bugs as expected behavior.** If two engines (native vs WASM) produce different results, that is a bug in the less-accurate engine — not an acceptable "parity gap." Adding comments or tests that frame wrong output as "expected" blocks future agents from ever fixing it. Instead: identify the root cause, file an issue, and fix the extraction/resolution layer that produces incorrect results. The correct response to "engine A reports 8 cycles, engine B reports 11" is to fix the 3 false cycles in engine B, not to document why the difference is okay.
 
+> **Never silently skip verification.** If tests, builds, or any verification step cannot run or fails for any reason (compilation errors, platform issues, missing dependencies), STOP and report the issue to the user immediately. Never silently proceed with unverified changes. Let the user decide whether to proceed — do not make that decision yourself.
+
 ## Codegraph Workflow
 
 Hooks handle: file-level deps on reads, graph rebuild after edits, commit-time checks (cycles, dead exports, diff-impact, lint). **Use these for function-level understanding when modifying source code:**

--- a/crates/codegraph-core/src/edge_builder.rs
+++ b/crates/codegraph-core/src/edge_builder.rs
@@ -709,7 +709,7 @@ mod import_edge_tests {
         let resolved = vec![make_resolved("/root/src/app.ts", "./utils", "src/utils.ts")];
         let node_ids = vec![make_node_entry("src/app.ts", 1), make_node_entry("src/utils.ts", 2)];
 
-        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string());
+        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string(), None);
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].source_id, 1);
         assert_eq!(edges[0].target_id, 2);
@@ -725,7 +725,7 @@ mod import_edge_tests {
         let resolved = vec![make_resolved("/root/src/index.ts", "./utils", "src/utils.ts")];
         let node_ids = vec![make_node_entry("src/index.ts", 1), make_node_entry("src/utils.ts", 2)];
 
-        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string());
+        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string(), None);
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].kind, "reexports");
     }
@@ -738,7 +738,7 @@ mod import_edge_tests {
         let resolved = vec![make_resolved("/root/src/app.ts", "./types", "src/types.ts")];
         let node_ids = vec![make_node_entry("src/app.ts", 1), make_node_entry("src/types.ts", 2)];
 
-        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string());
+        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string(), None);
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].kind, "imports-type");
     }
@@ -751,7 +751,7 @@ mod import_edge_tests {
         let resolved = vec![make_resolved("/root/src/app.ts", "./lazy", "src/lazy.ts")];
         let node_ids = vec![make_node_entry("src/app.ts", 1), make_node_entry("src/lazy.ts", 2)];
 
-        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string());
+        let edges = build_import_edges(files, resolved, vec![], node_ids, vec![], "/root".to_string(), None);
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].kind, "dynamic-imports");
     }
@@ -773,7 +773,7 @@ mod import_edge_tests {
             make_node_entry("src/b.ts", 3),
         ];
 
-        let edges = build_import_edges(vec![file], resolved, vec![], node_ids, vec![], "/root".to_string());
+        let edges = build_import_edges(vec![file], resolved, vec![], node_ids, vec![], "/root".to_string(), None);
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].kind, "reexports");
         assert_eq!(edges[0].target_id, 3);
@@ -804,7 +804,7 @@ mod import_edge_tests {
         ];
         let barrels = vec!["src/index.ts".to_string()];
 
-        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string());
+        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string(), None);
         assert_eq!(edges.len(), 2);
         // First: direct import to barrel
         assert_eq!(edges[0].target_id, 10);
@@ -851,7 +851,7 @@ mod import_edge_tests {
         ];
         let barrels = vec!["src/index.ts".to_string()];
 
-        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string());
+        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string(), None);
         assert_eq!(edges.len(), 2);
         assert_eq!(edges[1].target_id, 30);
         assert_eq!(edges[1].confidence, 0.9);
@@ -891,7 +891,7 @@ mod import_edge_tests {
         ];
         let barrels = vec!["src/a.ts".to_string()];
 
-        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string());
+        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string(), None);
         // Only the direct import edge, no barrel-through (cycle prevents resolution)
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].target_id, 10);
@@ -922,7 +922,7 @@ mod import_edge_tests {
         ];
         let barrels = vec!["src/barrel.ts".to_string()];
 
-        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string());
+        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string(), None);
         assert_eq!(edges.len(), 2);
         assert_eq!(edges[1].target_id, 20);
         assert_eq!(edges[1].confidence, 0.9);
@@ -954,7 +954,7 @@ mod import_edge_tests {
         ];
         let barrels = vec!["src/barrel.ts".to_string()];
 
-        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string());
+        let edges = build_import_edges(files, resolved, reexports, node_ids, barrels, "/root".to_string(), None);
         // 1 direct import + 1 barrel-through (deduped, not 2)
         assert_eq!(edges.len(), 2);
     }

--- a/crates/codegraph-core/src/extractors/bash.rs
+++ b/crates/codegraph-core/src/extractors/bash.rs
@@ -106,7 +106,7 @@ mod tests {
     fn extracts_source_import() {
         let s = parse_bash("source ./utils.sh");
         assert_eq!(s.imports.len(), 1);
-        assert_eq!(s.imports[0].path, "./utils.sh");
+        assert_eq!(s.imports[0].source, "./utils.sh");
         assert!(s.imports[0].bash_source.unwrap());
     }
 

--- a/crates/codegraph-core/src/extractors/c.rs
+++ b/crates/codegraph-core/src/extractors/c.rs
@@ -372,7 +372,7 @@ mod tests {
     fn extracts_include() {
         let s = parse_c("#include <stdio.h>\n#include \"mylib.h\"");
         assert_eq!(s.imports.len(), 2);
-        assert_eq!(s.imports[0].path, "stdio.h");
+        assert_eq!(s.imports[0].source, "stdio.h");
         assert!(s.imports[0].c_include.unwrap());
     }
 

--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -387,7 +387,7 @@ mod tests {
     fn extracts_import() {
         let s = parse_kotlin("import com.example.Foo");
         assert_eq!(s.imports.len(), 1);
-        assert_eq!(s.imports[0].path, "com.example.Foo");
+        assert_eq!(s.imports[0].source, "com.example.Foo");
         assert!(s.imports[0].kotlin_import.unwrap());
     }
 

--- a/crates/codegraph-core/src/extractors/swift.rs
+++ b/crates/codegraph-core/src/extractors/swift.rs
@@ -372,7 +372,7 @@ mod tests {
     fn extracts_import() {
         let s = parse_swift("import Foundation");
         assert_eq!(s.imports.len(), 1);
-        assert_eq!(s.imports[0].path, "Foundation");
+        assert_eq!(s.imports[0].source, "Foundation");
         assert!(s.imports[0].swift_import.unwrap());
     }
 }


### PR DESCRIPTION
## Summary

- Fix pre-existing Rust test compilation errors that prevented `cargo test` from building:
  - `Import.path` → `Import.source` in bash, c, kotlin, swift extractor tests (field was renamed but tests weren't updated)
  - Add missing 7th argument (`symbol_nodes: None`) to all `build_import_edges` test call sites
- Add CLAUDE.md rule: never silently skip verification — report test/build failures to the user immediately

## Test plan

- [x] `cargo test -p codegraph-core --lib` compiles (was broken before — 14 errors)
- [x] 152 tests pass, 11 pre-existing failures (Swift/Scala grammar version, config deserialization — unrelated)
- [x] `cargo check -p codegraph-core` clean