### PR TITLE
fix(publish): build native addon from source in preflight

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,31 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
+
+      # Build the native addon from the current Rust source so build-parity
+      # tests compare WASM and native engines built from the same commit.
+      # Without this, npm install pulls the last-published binary, which lags
+      # behind PR changes that touch both the TS and Rust extractors.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates/codegraph-core
+
+      - name: Install napi-rs CLI
+        run: npm install -g @napi-rs/cli@3
+
       - run: npm install
+
+      - name: Build native addon from current source
+        working-directory: crates/codegraph-core
+        run: napi build --release
+
+      - name: Install native addon over published binary
+        run: node scripts/ci-install-native.mjs
+
       - run: npm test
 
   compute-version:


### PR DESCRIPTION
## Summary

The publish workflow's preflight job ran `npm install && npm test` against the last-published native binary, while the WASM engine used the current TypeScript source. When a PR updated both the TS and Rust extractors in lockstep (e.g. #947), the `build-parity` test passed on CI — which rebuilds native from source via the `parity` job — but failed on every subsequent `publish.yml` run until the next release caught up.

This is what blocked the v3.9.4 release ([run 24588894845](https://github.com/optave/ops-codegraph-tool/actions/runs/24588894845/job/71905131580)): the preflight loaded the v3.9.3 native binary (21 nodes, 37 edges) while WASM produced 26 nodes, 41 edges from PR #947's extractor additions.

## Fix

Mirror the `ci.yml` `parity` job pattern inline in preflight:
- Setup Rust toolchain + cache
- `npm install` (pulls the stale published binary into `node_modules/@optave/codegraph-linux-x64-gnu`)
- `napi build --release` from `crates/codegraph-core`
- `node scripts/ci-install-native.mjs` copies the freshly-built `.node` over the published binary
- `npm test` — both engines now run from the same commit

## Test plan

- [ ] Preflight runs on this PR (dev publish on push-to-main won't trigger until merge, but the `preflight` job runs on `workflow_dispatch` and `release` events; CI's own parity job already validates the native build step works)
- [ ] After merge, re-run the v3.9.4 release workflow and confirm preflight passes