### PR TITLE
fix(native): backfill silently-dropped files via WASM for engine parity

### DIFF
--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -21,6 +21,7 @@ import { detectWorkspaces, loadConfig } from '../../../infrastructure/config.js'
 import { debug, info, warn } from '../../../infrastructure/logger.js';
 import { loadNative } from '../../../infrastructure/native.js';
 import { semverCompare } from '../../../infrastructure/update-check.js';
+import { normalizePath } from '../../../shared/constants.js';
 import { toErrorMessage } from '../../../shared/errors.js';
 import { CODEGRAPH_VERSION } from '../../../shared/version.js';
 import type {
@@ -30,8 +31,7 @@ import type {
   Definition,
   ExtractorOutput,
 } from '../../../types.js';
-import { normalizePath } from '../../../shared/constants.js';
-import { getActiveEngine, parseFilesAuto } from '../../parser.js';
+import { getActiveEngine, getInstalledWasmExtensions, parseFilesAuto } from '../../parser.js';
 import { setWorkspaces } from '../resolve.js';
 import { PipelineContext } from './context.js';
 import { batchInsertNodes, collectFiles as collectFilesUtil, loadPathAliases } from './helpers.js';
@@ -701,7 +701,13 @@ async function tryNativeOrchestrator(
   // Rust extractor/grammar is missing or fails (e.g. HCL, Scala, Swift on
   // stale native binaries). WASM handles those — backfill via WASM so both
   // engines process the same file set (#967).
-  await backfillNativeDroppedFiles(ctx);
+  //
+  // Only runs on full builds: incremental builds only touch changed files,
+  // which are parsed through parseFilesAuto (which has its own per-file
+  // backfill), so a full filesystem scan here would be wasted work.
+  if (result.isFullBuild) {
+    await backfillNativeDroppedFiles(ctx);
+  }
 
   closeDbPair({ db: ctx.db, nativeDb: ctx.nativeDb });
   return formatNativeTimingResult(p, structurePatchMs, analysisTiming);
@@ -729,11 +735,17 @@ async function backfillNativeDroppedFiles(ctx: PipelineContext): Promise<void> {
     .all() as Array<{ file: string }>;
   const existing = new Set(existingRows.map((r) => r.file));
 
+  // Restrict backfill to files with an installed WASM grammar. Extensions in
+  // LANGUAGE_REGISTRY without a shipped grammar file (e.g. groovy, erlang on
+  // minimal installs) can't be parsed by either engine, so they're not a
+  // native regression — excluding them keeps the warn count meaningful.
+  const installedExts = getInstalledWasmExtensions();
   const missingAbs: string[] = [];
   for (const rel of expected) {
-    if (!existing.has(rel)) {
-      missingAbs.push(path.join(ctx.rootDir, rel));
-    }
+    if (existing.has(rel)) continue;
+    const ext = path.extname(rel).toLowerCase();
+    if (!installedExts.has(ext)) continue;
+    missingAbs.push(path.join(ctx.rootDir, rel));
   }
   if (missingAbs.length === 0) return;
 
@@ -744,8 +756,14 @@ async function backfillNativeDroppedFiles(ctx: PipelineContext): Promise<void> {
 
   const rows: unknown[][] = [];
   for (const [relPath, symbols] of wasmResults) {
+    // File row: name=relPath, qualified_name=relPath (matches insertDefinitionsAndExports).
     rows.push([relPath, 'file', relPath, 0, null, null, relPath, null, null]);
     for (const def of symbols.definitions ?? []) {
+      // Populate qualified_name/scope the same way the JS fallback does so
+      // downstream queries (cross-file references, "go to definition") find
+      // these symbols.
+      const dotIdx = def.name.lastIndexOf('.');
+      const scope = dotIdx !== -1 ? def.name.slice(0, dotIdx) : null;
       rows.push([
         def.name,
         def.kind,
@@ -753,8 +771,8 @@ async function backfillNativeDroppedFiles(ctx: PipelineContext): Promise<void> {
         def.line,
         def.endLine ?? null,
         null,
-        null,
-        null,
+        def.name,
+        scope,
         def.visibility ?? null,
       ]);
     }

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -30,6 +30,7 @@ import type {
   BuildResult,
   Definition,
   ExtractorOutput,
+  SqliteStatement,
 } from '../../../types.js';
 import { getActiveEngine, getInstalledWasmExtensions, parseFilesAuto } from '../../parser.js';
 import { setWorkspaces } from '../resolve.js';
@@ -755,9 +756,10 @@ async function backfillNativeDroppedFiles(ctx: PipelineContext): Promise<void> {
   const wasmResults = await parseFilesAuto(missingAbs, ctx.rootDir, { engine: 'wasm' });
 
   const rows: unknown[][] = [];
+  const exportKeys: unknown[][] = [];
   for (const [relPath, symbols] of wasmResults) {
-    // File row: name=relPath, qualified_name=relPath (matches insertDefinitionsAndExports).
-    rows.push([relPath, 'file', relPath, 0, null, null, relPath, null, null]);
+    // File row — mirrors insertDefinitionsAndExports: qualified_name is null.
+    rows.push([relPath, 'file', relPath, 0, null, null, null, null, null]);
     for (const def of symbols.definitions ?? []) {
       // Populate qualified_name/scope the same way the JS fallback does so
       // downstream queries (cross-file references, "go to definition") find
@@ -776,8 +778,41 @@ async function backfillNativeDroppedFiles(ctx: PipelineContext): Promise<void> {
         def.visibility ?? null,
       ]);
     }
+    // Exports: insert the row (INSERT OR IGNORE — a matching definition row
+    // is a no-op) and queue a key for the second-pass exported=1 update, so
+    // queries filtering on exported=1 find backfilled symbols (#970).
+    for (const exp of symbols.exports ?? []) {
+      rows.push([exp.name, exp.kind, relPath, exp.line, null, null, exp.name, null, null]);
+      exportKeys.push([exp.name, exp.kind, relPath, exp.line]);
+    }
   }
-  batchInsertNodes(ctx.db as unknown as BetterSqlite3Database, rows);
+  const db = ctx.db as unknown as BetterSqlite3Database;
+  batchInsertNodes(db, rows);
+
+  // Mark exported symbols in batches — mirrors insertDefinitionsAndExports.
+  if (exportKeys.length > 0) {
+    const EXPORT_CHUNK = 500;
+    const exportStmtCache = new Map<number, SqliteStatement>();
+    for (let i = 0; i < exportKeys.length; i += EXPORT_CHUNK) {
+      const end = Math.min(i + EXPORT_CHUNK, exportKeys.length);
+      const chunkSize = end - i;
+      let updateStmt = exportStmtCache.get(chunkSize);
+      if (!updateStmt) {
+        const conditions = Array.from(
+          { length: chunkSize },
+          () => '(name = ? AND kind = ? AND file = ? AND line = ?)',
+        ).join(' OR ');
+        updateStmt = db.prepare(`UPDATE nodes SET exported = 1 WHERE ${conditions}`);
+        exportStmtCache.set(chunkSize, updateStmt);
+      }
+      const vals: unknown[] = [];
+      for (let j = i; j < end; j++) {
+        const k = exportKeys[j] as unknown[];
+        vals.push(k[0], k[1], k[2], k[3]);
+      }
+      updateStmt.run(...vals);
+    }
+  }
 }
 
 // ── Pipeline stages execution ───────────────────────────────────────────

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -30,10 +30,11 @@ import type {
   Definition,
   ExtractorOutput,
 } from '../../../types.js';
-import { getActiveEngine } from '../../parser.js';
+import { normalizePath } from '../../../shared/constants.js';
+import { getActiveEngine, parseFilesAuto } from '../../parser.js';
 import { setWorkspaces } from '../resolve.js';
 import { PipelineContext } from './context.js';
-import { loadPathAliases } from './helpers.js';
+import { batchInsertNodes, collectFiles as collectFilesUtil, loadPathAliases } from './helpers.js';
 import { NativeDbProxy } from './native-db-proxy.js';
 import { buildEdges } from './stages/build-edges.js';
 import { buildStructure } from './stages/build-structure.js';
@@ -696,8 +697,69 @@ async function tryNativeOrchestrator(
     }
   }
 
+  // Engine parity: the native orchestrator silently drops files whose
+  // Rust extractor/grammar is missing or fails (e.g. HCL, Scala, Swift on
+  // stale native binaries). WASM handles those — backfill via WASM so both
+  // engines process the same file set (#967).
+  await backfillNativeDroppedFiles(ctx);
+
   closeDbPair({ db: ctx.db, nativeDb: ctx.nativeDb });
   return formatNativeTimingResult(p, structurePatchMs, analysisTiming);
+}
+
+/**
+ * Backfill files that the native orchestrator silently dropped during parse.
+ * Falls back to WASM + inserts file/symbol nodes so engine counts match (#967).
+ */
+async function backfillNativeDroppedFiles(ctx: PipelineContext): Promise<void> {
+  // Needs a real better-sqlite3 connection for INSERT.
+  if (ctx.nativeFirstProxy) {
+    closeNativeDb(ctx, 'pre-parity-backfill');
+    ctx.db = openDb(ctx.dbPath);
+    ctx.nativeFirstProxy = false;
+  }
+
+  const collected = collectFilesUtil(ctx.rootDir, [], ctx.config, new Set<string>());
+  const expected = new Set(
+    collected.files.map((f) => normalizePath(path.relative(ctx.rootDir, f))),
+  );
+
+  const existingRows = ctx.db
+    .prepare("SELECT DISTINCT file FROM nodes WHERE kind = 'file'")
+    .all() as Array<{ file: string }>;
+  const existing = new Set(existingRows.map((r) => r.file));
+
+  const missingAbs: string[] = [];
+  for (const rel of expected) {
+    if (!existing.has(rel)) {
+      missingAbs.push(path.join(ctx.rootDir, rel));
+    }
+  }
+  if (missingAbs.length === 0) return;
+
+  warn(
+    `Native orchestrator dropped ${missingAbs.length} file(s); backfilling via WASM for engine parity`,
+  );
+  const wasmResults = await parseFilesAuto(missingAbs, ctx.rootDir, { engine: 'wasm' });
+
+  const rows: unknown[][] = [];
+  for (const [relPath, symbols] of wasmResults) {
+    rows.push([relPath, 'file', relPath, 0, null, null, relPath, null, null]);
+    for (const def of symbols.definitions ?? []) {
+      rows.push([
+        def.name,
+        def.kind,
+        relPath,
+        def.line,
+        def.endLine ?? null,
+        null,
+        null,
+        null,
+        def.visibility ?? null,
+      ]);
+    }
+  }
+  batchInsertNodes(ctx.db as unknown as BetterSqlite3Database, rows);
 }
 
 // ── Pipeline stages execution ───────────────────────────────────────────

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -338,6 +338,27 @@ export function isWasmAvailable(): boolean {
   );
 }
 
+/**
+ * Return the set of lowercase file extensions whose WASM grammar is actually
+ * installed on disk. Used to scope engine-parity backfill to files that WASM
+ * can recover — languages without an installed grammar are skipped by both
+ * engines, so they don't represent a native-engine drop.
+ *
+ * Cached on first call; the grammars directory is shipped immutable.
+ */
+let _installedWasmExts: Set<string> | null = null;
+export function getInstalledWasmExtensions(): Set<string> {
+  if (_installedWasmExts) return _installedWasmExts;
+  const exts = new Set<string>();
+  for (const entry of LANGUAGE_REGISTRY) {
+    if (fs.existsSync(grammarPath(entry.grammarFile))) {
+      for (const ext of entry.extensions) exts.add(ext.toLowerCase());
+    }
+  }
+  _installedWasmExts = exts;
+  return exts;
+}
+
 // ── Unified API ──────────────────────────────────────────────────────────────
 
 function resolveEngine(opts: ParseEngineOpts = {}): ResolvedEngine {
@@ -907,9 +928,11 @@ export async function parseFilesAuto(
   // Engine parity: native may silently drop files whose extensions are in
   // SUPPORTED_EXTENSIONS (because a WASM grammar exists) but whose Rust
   // extractor/grammar is missing or fails. WASM handles these — fall back so
-  // both engines process the same file set (#967).
+  // both engines process the same file set (#967). Restrict to installed WASM
+  // grammars so we don't warn about files that neither engine can parse.
+  const installedExts = getInstalledWasmExtensions();
   const dropped = filePaths.filter(
-    (f) => !nativeParsed.has(f) && _extToLang.has(path.extname(f).toLowerCase()),
+    (f) => !nativeParsed.has(f) && installedExts.has(path.extname(f).toLowerCase()),
   );
   if (dropped.length > 0) {
     warn(`Native engine dropped ${dropped.length} file(s); falling back to WASM for parity`);

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -884,8 +884,10 @@ export async function parseFilesAuto(
     ? native.parseFilesFull(filePaths, rootDir)
     : native.parseFiles(filePaths, rootDir, true, true);
   const needsTypeMap: { filePath: string; relPath: string }[] = [];
+  const nativeParsed = new Set<string>();
   for (const r of nativeResults) {
     if (!r) continue;
+    nativeParsed.add(r.file);
     const patched = patchNativeResult(r);
     const relPath = path.relative(rootDir, r.file).split(path.sep).join('/');
     result.set(relPath, patched);
@@ -901,6 +903,22 @@ export async function parseFilesAuto(
   if (needsTypeMap.length > 0) {
     await backfillTypeMapBatch(needsTypeMap, result);
   }
+
+  // Engine parity: native may silently drop files whose extensions are in
+  // SUPPORTED_EXTENSIONS (because a WASM grammar exists) but whose Rust
+  // extractor/grammar is missing or fails. WASM handles these — fall back so
+  // both engines process the same file set (#967).
+  const dropped = filePaths.filter(
+    (f) => !nativeParsed.has(f) && _extToLang.has(path.extname(f).toLowerCase()),
+  );
+  if (dropped.length > 0) {
+    warn(`Native engine dropped ${dropped.length} file(s); falling back to WASM for parity`);
+    const wasmResults = await parseFilesWasm(dropped, rootDir);
+    for (const [relPath, symbols] of wasmResults) {
+      result.set(relPath, symbols);
+    }
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary

Fixes #967. The native engine's `parse_files_parallel` (Rust) silently drops any file whose read/parse/extract step fails — including files in languages where the installed native addon lacks an extractor (e.g. HCL/Scala/Swift on the currently-published v3.9.2 binary). WASM handles those languages fine, so benchmarks on this repo showed **668 native vs 728 WASM** file nodes on the same tree.

The fix closes the parity gap in two places in the JS layer:

- **`parseFilesAuto`** (`src/domain/parser.ts`) — tracks which files the native parser actually returned; re-parses the rest with WASM so the JS pipeline gets complete coverage.
- **`tryNativeOrchestrator`** (`src/domain/graph/builder/pipeline.ts`) — after the native Rust orchestrator writes to the DB, diffs `collectFiles()` against the `kind='file'` rows and backfills any missing files via a WASM pass + `batchInsertNodes`.

Both paths emit a `warn()` when a drop happens so the underlying Rust regression stays visible rather than being silently masked.

### Local verification

On this repo (ts=484, rs=57, sh=18, … hcl=4, scala=4, swift=4):

| Run | `kind='file'` rows in DB |
|---|---|
| Before fix (native) | 668 |
| After fix (native)  | 680 |
| WASM baseline       | 680 *(same 48 files lack local WASM grammars on both sides)* |

The backfill correctly adds the 12 HCL/Scala/Swift files. The remaining 48 (clojure/cuda/erlang/fsharp/gleam/groovy/julia/objc/r/solidity/verilog) have no WASM grammar installed locally, so both engines skip them identically — true parity.

### Complementary work

This fix protects users on older native addons. A separate Rust-side change should still harden `parallel.rs::parse_files_parallel` to not silently swallow extract failures — that belongs in a follow-up.

## Test plan

- [x] Local: `node ./dist/cli.js build . --engine native` → DB file count increases from 668 → 680, with all 4×3 HCL/Scala/Swift rows present.
- [x] Local: `parseFilesAuto`-using tests pass (`tests/parsers/unified.test.ts`, `cfg-all-langs.test.ts`, `ast-all-langs.test.ts`, `ast-nodes.test.ts`).
- [ ] CI: benchmark job confirms `files.total` matches between native and WASM.