### PR TITLE
fix(extractors): guard empty-text identifiers and isolate extractor crashes

### DIFF
--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -786,7 +786,13 @@ function wasmExtractSymbols(
   if (!entry) return null;
   const query = _queryCache.get(entry.id) ?? undefined;
   // Query (web-tree-sitter) is structurally compatible with TreeSitterQuery at runtime
-  const symbols = entry.extractor(tree as any, filePath, query as any);
+  let symbols: ExtractorOutput | null;
+  try {
+    symbols = entry.extractor(tree as any, filePath, query as any);
+  } catch (e: unknown) {
+    warn(`Extractor error in ${filePath}: ${(e as Error).message}`);
+    return null;
+  }
   return symbols ? { symbols, tree, langId: entry.id } : null;
 }
 

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -791,6 +791,9 @@ function wasmExtractSymbols(
     symbols = entry.extractor(tree as any, filePath, query as any);
   } catch (e: unknown) {
     warn(`Extractor error in ${filePath}: ${(e as Error).message}`);
+    // Free WASM tree to prevent memory leak — web-tree-sitter trees are backed
+    // by WASM linear memory and are not garbage-collected automatically.
+    if (typeof (tree as any).delete === 'function') (tree as any).delete();
     return null;
   }
   return symbols ? { symbols, tree, langId: entry.id } : null;

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1182,7 +1182,11 @@ function handleVarDeclaratorTypeMap(
       const obj = fn.childForFieldName('object');
       if (obj && obj.type === 'identifier') {
         const objName = obj.text;
-        if (objName[0]! !== objName[0]!.toLowerCase() && !BUILTIN_GLOBALS.has(objName)) {
+        if (
+          objName[0] &&
+          objName[0] !== objName[0].toLowerCase() &&
+          !BUILTIN_GLOBALS.has(objName)
+        ) {
           setTypeMapEntry(typeMap, nameN.text, objName, 0.7);
         }
       }

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -184,6 +184,79 @@ describe('JavaScript parser', () => {
       expect(symbols.typeMap.has('d')).toBe(false);
       expect(symbols.typeMap.has('p')).toBe(false);
     });
+
+    // Regression: GH #964 — tree-sitter can produce partial/corrupted trees in
+    // which an identifier node has empty `text`. Previously the factory path
+    // crashed with "Cannot read properties of undefined (reading 'toLowerCase')"
+    // because `objName[0]` is undefined for an empty string. The guard now
+    // mirrors the Python extractor's short-circuit check.
+    it('does not crash when factory call has an empty-text identifier', () => {
+      // Build a mock tree that mimics `const x = <empty-identifier>.create()`.
+      // The walk path calls handleVarDeclaratorTypeMap → factory branch, which
+      // reads `obj.text` ("") and would previously call "".toLowerCase() via
+      // `objName[0]!.toLowerCase()`. The fix's `objName[0] &&` guard short-circuits.
+      const pos = { row: 0, column: 0 };
+      const makeNode = (
+        type: string,
+        text = '',
+        fields: Record<string, any> = {},
+        children: any[] = [],
+      ) => {
+        const node: any = {
+          type,
+          text,
+          startPosition: pos,
+          endPosition: pos,
+          childCount: children.length,
+          child: (i: number) => children[i] ?? null,
+          childForFieldName: (name: string) => fields[name] ?? null,
+          parent: null,
+        };
+        for (const c of children) {
+          c.parent = node;
+        }
+        return node;
+      };
+
+      const emptyIdentifier = makeNode('identifier', '');
+      const createName = makeNode('property_identifier', 'create');
+      const memberExpr = makeNode(
+        'member_expression',
+        '.create',
+        {
+          object: emptyIdentifier,
+          property: createName,
+        },
+        [emptyIdentifier, createName],
+      );
+      const callExpr = makeNode(
+        'call_expression',
+        '.create()',
+        {
+          function: memberExpr,
+        },
+        [memberExpr],
+      );
+      const nameIdent = makeNode('identifier', 'x');
+      const declarator = makeNode(
+        'variable_declarator',
+        'x = .create()',
+        {
+          name: nameIdent,
+          value: callExpr,
+        },
+        [nameIdent, callExpr],
+      );
+      const lexDecl = makeNode('lexical_declaration', 'const x = .create();', {}, [declarator]);
+      const root = makeNode('program', '', {}, [lexDecl]);
+      const fakeTree: any = { rootNode: root };
+
+      // Before the fix this would throw TypeError. Now it should complete and
+      // simply leave `x` out of the typeMap (empty identifier is ignored).
+      expect(() => extractSymbols(fakeTree, 'test.js')).not.toThrow();
+      const symbols = extractSymbols(fakeTree, 'test.js');
+      expect(symbols.typeMap.has('x')).toBe(false);
+    });
   });
 
   it('does not set receiver for .call()/.apply()/.bind() unwrapped calls', () => {


### PR DESCRIPTION
## Summary
- Adds `objName[0] &&` short-circuit in `src/extractors/javascript.ts` to match the Python extractor pattern, preventing `Cannot read properties of undefined (reading 'toLowerCase')` when tree-sitter returns a corrupted/partial parse where `obj.text` is empty.
- Wraps the `entry.extractor(...)` call in `src/domain/parser.ts::wasmExtractSymbols` with try/catch that logs via `warn()` and returns `null`, matching the parse-error handler right above it. A single misbehaving file no longer kills the whole WASM build.
- Adds a targeted regression test in `tests/parsers/javascript.test.ts` for the empty-identifier case.

Fixes #964.

Also fully addresses the hardening scope of #965 (catchable WASM errors now skip the file instead of aborting the build). Root-cause V8/WASM aborts in #965 are uncatchable and tracked separately.

## Test plan
- [x] \`npm run lint\` — clean (6 pre-existing warnings in untouched files)
- [x] \`tests/parsers/javascript.test.ts\` — 46/46 pass incl. new regression test
- [x] \`tests/unit/*\` — 976/976 pass
- [ ] CI — verify full suite on Linux (local Windows env missing optional tree-sitter grammars)