### PR TITLE
fix(scripts): use --experimental-strip-types on every Node version

### DIFF
--- a/scripts/node-ts.js
+++ b/scripts/node-ts.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-// node-ts.js — Version-aware TypeScript launcher
-// Uses --strip-types on Node 23+ and --experimental-strip-types on Node 22.x.
+// node-ts.js — TypeScript launcher
+// Uses --experimental-strip-types, which is accepted on every supported Node
+// version (>=22.6). Node 23 briefly shipped a --strip-types alias that was
+// removed in Node 24, so we avoid it.
 // Usage: node scripts/node-ts.js <script.ts> [args...]
 
 import { execFileSync } from "node:child_process";
 
-const [major] = process.versions.node.split(".").map(Number);
-const flag = major >= 23 ? "--strip-types" : "--experimental-strip-types";
+const flag = "--experimental-strip-types";
 const [script, ...args] = process.argv.slice(2);
 
 if (!script) {


### PR DESCRIPTION
## Summary

`scripts/node-ts.js` selected between `--strip-types` and `--experimental-strip-types` based on Node major version (`major >= 23 ? "--strip-types" : "--experimental-strip-types"`). Node 23 briefly shipped `--strip-types` as an alias, but Node 24 removed it — on Node 24.10.0 the script fails immediately with `node: bad option: --strip-types`, which breaks:

- `npm run build:wasm`
- `npm run deps:tree`
- `npm run version`

`--experimental-strip-types` still works on 22.x, 23.x, and 24.x, so use it unconditionally.

## Found during

Dogfooding v3.9.4 — see #980

## Test plan

- [x] `node scripts/node-ts.js /tmp/sample.ts` runs on Node 24.10.0
- [x] `npm run verify-imports` succeeds (routes through `node-ts.js`)
- [x] `npm run lint` clean