### PR TITLE
fix(build): warn before --no-incremental wipes embeddings

### DIFF
--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -976,6 +976,10 @@ export async function buildGraph(
             `Codegraph version changed (${prevVersion} → ${CODEGRAPH_VERSION}), promoting to full rebuild.`,
           );
           ctx.forceFullRebuild = true;
+          // Re-check embeddings: the initial warnOnEmbeddingsWipe ran before
+          // forceFullRebuild was set here, so the silent-data-loss guard
+          // would otherwise miss this late-promotion path (#986 follow-up).
+          warnOnEmbeddingsWipe(ctx);
         }
       }
     }

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -106,6 +106,21 @@ function checkEngineSchemaMismatch(ctx: PipelineContext): void {
   }
 }
 
+function warnOnEmbeddingsWipe(ctx: PipelineContext): void {
+  const willBeFullBuild = !ctx.incremental || ctx.forceFullRebuild;
+  if (!willBeFullBuild) return;
+  let count = 0;
+  try {
+    count = (ctx.db.prepare('SELECT COUNT(*) AS c FROM embeddings').get() as { c: number }).c;
+  } catch {
+    return; // embeddings table missing — nothing to warn about
+  }
+  if (count === 0) return;
+  warn(
+    `Full rebuild will discard ${count} embedding${count === 1 ? '' : 's'}; re-run \`codegraph embed\` after the build.`,
+  );
+}
+
 function loadAliases(ctx: PipelineContext): void {
   ctx.aliases = loadPathAliases(ctx.rootDir);
   if (ctx.config.aliases) {
@@ -151,6 +166,7 @@ function setupPipeline(ctx: PipelineContext): void {
 
   initializeEngine(ctx);
   checkEngineSchemaMismatch(ctx);
+  warnOnEmbeddingsWipe(ctx);
   loadAliases(ctx);
 
   // Workspace packages (monorepo)


### PR DESCRIPTION
## Summary

`codegraph build --no-incremental` (and any full rebuild promoted by engine/schema/version mismatch) silently drops every row in the `embeddings` table. Users who spent minutes on `codegraph embed` lose their embeddings with no warning; the next `codegraph search` returns zero hits with no clue why.

Add a `warnOnEmbeddingsWipe` step at the pipeline entry — just after the incremental/forceFullRebuild decision is made. When the build is full AND the embeddings table is non-empty, it logs:

```
[codegraph WARN] Full rebuild will discard N embeddings; re-run `codegraph embed` after the build.
```

Because the warning sits at the shared pipeline entry point, it fires uniformly regardless of which path (native orchestrator or JS fallback) actually performs the delete.

## Found during

Dogfooding v3.9.4 — see #982

## Test plan

- [x] Full rebuild with embeddings present → warning fires with correct count
- [x] Full rebuild with empty/missing embeddings table → no warning
- [x] Incremental build (even if promoted to full by mismatch) → warning still fires only when embeddings exist
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean