### PR TITLE
fix(watch): accept -d/--db to point at a graph.db outside cwd

### DIFF
--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -6,6 +6,7 @@ export const command: CommandDefinition = {
   name: 'watch [dir]',
   description: 'Watch project for file changes and incrementally update the graph',
   options: [
+    ['-d, --db <path>', 'Path to graph.db'],
     ['--poll', 'Use stat-based polling (default on Windows to avoid ReFS/Dev Drive crashes)'],
     ['--native', 'Force native OS file watchers instead of polling'],
     ['--poll-interval <ms>', 'Polling interval in milliseconds (default: 2000)'],
@@ -22,6 +23,7 @@ export const command: CommandDefinition = {
       engine,
       poll,
       pollInterval: opts.pollInterval ? Number(opts.pollInterval) : undefined,
+      dbPath: opts.db ? path.resolve(opts.db) : undefined,
     });
   },
 };

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -165,8 +165,8 @@ interface WatcherContext {
 }
 
 /** Initialize DB, engine, cache, and statements for watch mode. */
-function setupWatcher(rootDir: string, opts: { engine?: string }): WatcherContext {
-  const dbPath = path.join(rootDir, '.codegraph', 'graph.db');
+function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string }): WatcherContext {
+  const dbPath = opts.dbPath ?? path.join(rootDir, '.codegraph', 'graph.db');
   if (!fs.existsSync(dbPath)) {
     throw new DbError('No graph.db found. Run `codegraph build` first.', { file: dbPath });
   }
@@ -297,7 +297,7 @@ function setupShutdownHandler(ctx: WatcherContext, cleanup: () => void): void {
 
 export async function watchProject(
   rootDir: string,
-  opts: { engine?: string; poll?: boolean; pollInterval?: number } = {},
+  opts: { engine?: string; poll?: boolean; pollInterval?: number; dbPath?: string } = {},
 ): Promise<void> {
   const ctx = setupWatcher(rootDir, opts);
 


### PR DESCRIPTION
## Summary

Every other command that operates on a graph DB (`build`, `stats`, `query`, `fn-impact`, `impact`, `diff-impact`, `export`, `embed`, `search`, `triage`, `complexity`, `audit`, `roles`, `cycles`, `map`, `plot`, `co-change`, `owners`, `batch`, `check`, `children`) accepts `-d, --db <path>`. `watch` did not — it rejected the flag with `error: unknown option '--db'`, forcing users in monorepo and multi-repo MCP setups to `cd` into the watched directory.

Add the option, plumb it through `watchProject` → `setupWatcher`, and fall back to `<rootDir>/.codegraph/graph.db` when it's absent.

## Found during

Dogfooding v3.9.4 — see #984

## Test plan

- [x] `codegraph watch --help` shows `-d, --db <path>`
- [x] `codegraph watch <dir> --db <path>` runs against the specified DB from a different cwd
- [x] `codegraph watch <dir> --db /missing.db` errors cleanly with `No graph.db found. Run \`codegraph build\` first.`
- [x] `codegraph watch <dir>` (no `--db`) behaves exactly as before (default `.codegraph/graph.db` under the watched dir)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean