### PR TITLE
fix(journal): stamp header timestamp on watcher appends (#997)

### DIFF
--- a/src/domain/graph/journal.ts
+++ b/src/domain/graph/journal.ts
@@ -66,9 +66,7 @@ export function appendJournalEntries(
   const dir = path.join(rootDir, '.codegraph');
   const journalPath = path.join(dir, JOURNAL_FILENAME);
 
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  fs.mkdirSync(dir, { recursive: true });
 
   if (!fs.existsSync(journalPath)) {
     fs.writeFileSync(journalPath, `${HEADER_PREFIX}0\n`);
@@ -87,9 +85,7 @@ export function writeJournalHeader(rootDir: string, timestamp: number): void {
   const journalPath = path.join(dir, JOURNAL_FILENAME);
   const tmpPath = `${journalPath}.tmp`;
 
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  fs.mkdirSync(dir, { recursive: true });
 
   try {
     fs.writeFileSync(tmpPath, `${HEADER_PREFIX}${timestamp}\n`);
@@ -124,9 +120,7 @@ export function appendJournalEntriesAndStampHeader(
   const journalPath = path.join(dir, JOURNAL_FILENAME);
   const tmpPath = `${journalPath}.tmp`;
 
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  fs.mkdirSync(dir, { recursive: true });
 
   let existingBody = '';
   try {

--- a/src/domain/graph/journal.ts
+++ b/src/domain/graph/journal.ts
@@ -103,3 +103,54 @@ export function writeJournalHeader(rootDir: string, timestamp: number): void {
     }
   }
 }
+
+/**
+ * Atomically append entries while advancing the header timestamp.
+ *
+ * Used by the watcher: without this, the header timestamp stays frozen at the
+ * last build's finalize time while entries accumulate, so the next build's
+ * Tier 0 check sees `journal.timestamp < MAX(file_hashes.mtime)`, rejects the
+ * journal, and falls through to the expensive mtime+size / hash scan.
+ *
+ * Writes a tmp file then renames — a crash mid-rename leaves the previous
+ * journal state intact.
+ */
+export function appendJournalEntriesAndStampHeader(
+  rootDir: string,
+  entries: Array<{ file: string; deleted?: boolean }>,
+  timestamp: number,
+): void {
+  const dir = path.join(rootDir, '.codegraph');
+  const journalPath = path.join(dir, JOURNAL_FILENAME);
+  const tmpPath = `${journalPath}.tmp`;
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  let existingBody = '';
+  try {
+    const content = fs.readFileSync(journalPath, 'utf-8');
+    const newlineIdx = content.indexOf('\n');
+    if (newlineIdx >= 0) existingBody = content.slice(newlineIdx + 1);
+  } catch {
+    /* no existing journal — fall through to write header + new entries */
+  }
+  if (existingBody && !existingBody.endsWith('\n')) existingBody = `${existingBody}\n`;
+
+  const newLines = entries.map((e) => (e.deleted ? `DELETED ${e.file}` : e.file));
+  const appended = newLines.length > 0 ? `${newLines.join('\n')}\n` : '';
+  const content = `${HEADER_PREFIX}${timestamp}\n${existingBody}${appended}`;
+
+  try {
+    fs.writeFileSync(tmpPath, content);
+    fs.renameSync(tmpPath, journalPath);
+  } catch (err) {
+    warn(`Failed to update journal: ${(err as Error).message}`);
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -274,15 +274,35 @@ function startNativeWatcher(ctx: WatcherContext): () => void {
   return () => watcher.close();
 }
 
+/**
+ * Build journal entries for a pending-path set, detecting deletions by
+ * existence check.
+ *
+ * `ctx.pending` is an untyped `Set<string>` — it carries no event-type
+ * metadata. Without this check, a file deleted during the watch session
+ * would be journaled as "changed", causing the next incremental build to
+ * try to re-parse a non-existent file instead of removing it from the graph.
+ * Mirrors the deletion detection in `rebuildFile` (see builder/incremental.ts).
+ *
+ * Exported for unit-testing; prefer `setupShutdownHandler` in production paths.
+ */
+export function buildFlushEntriesFromPending(
+  rootDir: string,
+  pending: Iterable<string>,
+): Array<{ file: string; deleted: boolean }> {
+  return [...pending].map((filePath) => ({
+    file: normalizePath(path.relative(rootDir, filePath)),
+    deleted: !fs.existsSync(filePath),
+  }));
+}
+
 /** Register SIGINT handler to flush journal and clean up. */
 function setupShutdownHandler(ctx: WatcherContext, cleanup: () => void): void {
   process.once('SIGINT', () => {
     info('Stopping watcher...');
     cleanup();
     if (ctx.pending.size > 0) {
-      const entries = [...ctx.pending].map((filePath) => ({
-        file: normalizePath(path.relative(ctx.rootDir, filePath)),
-      }));
+      const entries = buildFlushEntriesFromPending(ctx.rootDir, ctx.pending);
       try {
         appendJournalEntriesAndStampHeader(ctx.rootDir, entries, Date.now());
       } catch (e: unknown) {

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -7,7 +7,7 @@ import { DbError } from '../../shared/errors.js';
 import { createParseTreeCache, getActiveEngine } from '../parser.js';
 import { type IncrementalStmts, rebuildFile } from './builder/incremental.js';
 import { appendChangeEvents, buildChangeEvent, diffSymbols } from './change-journal.js';
-import { appendJournalEntries } from './journal.js';
+import { appendJournalEntriesAndStampHeader } from './journal.js';
 
 function shouldIgnorePath(filePath: string): boolean {
   const parts = filePath.split(path.sep);
@@ -100,7 +100,7 @@ function writeJournalAndChangeEvents(rootDir: string, updates: RebuildResult[]):
     deleted: r.deleted || false,
   }));
   try {
-    appendJournalEntries(rootDir, entries);
+    appendJournalEntriesAndStampHeader(rootDir, entries, Date.now());
   } catch (e: unknown) {
     debug(`Journal write failed (non-fatal): ${(e as Error).message}`);
   }
@@ -284,7 +284,7 @@ function setupShutdownHandler(ctx: WatcherContext, cleanup: () => void): void {
         file: normalizePath(path.relative(ctx.rootDir, filePath)),
       }));
       try {
-        appendJournalEntries(ctx.rootDir, entries);
+        appendJournalEntriesAndStampHeader(ctx.rootDir, entries, Date.now());
       } catch (e: unknown) {
         debug(`Journal flush on exit failed (non-fatal): ${(e as Error).message}`);
       }

--- a/tests/unit/journal.test.ts
+++ b/tests/unit/journal.test.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   appendJournalEntries,
+  appendJournalEntriesAndStampHeader,
   JOURNAL_FILENAME,
   readJournal,
   writeJournalHeader,
@@ -193,6 +194,81 @@ describe('appendJournalEntries', () => {
 
     const result = readJournal(root);
     expect(result.changed).toEqual(['src/a.js', 'src/b.js']);
+  });
+});
+
+describe('appendJournalEntriesAndStampHeader', () => {
+  it('creates journal with header + entries when none exists', () => {
+    const root = makeRoot();
+    appendJournalEntriesAndStampHeader(root, [{ file: 'src/a.js' }], 1700000000000);
+
+    const result = readJournal(root);
+    expect(result.valid).toBe(true);
+    expect(result.timestamp).toBe(1700000000000);
+    expect(result.changed).toEqual(['src/a.js']);
+  });
+
+  it('advances the header timestamp while preserving prior entries', () => {
+    const root = makeRoot();
+    writeJournalHeader(root, 1000);
+    appendJournalEntries(root, [{ file: 'src/a.js' }, { file: 'src/b.js', deleted: true }]);
+
+    appendJournalEntriesAndStampHeader(root, [{ file: 'src/c.js' }], 2000);
+
+    const result = readJournal(root);
+    expect(result.valid).toBe(true);
+    expect(result.timestamp).toBe(2000);
+    expect(result.changed).toEqual(['src/a.js', 'src/c.js']);
+    expect(result.removed).toEqual(['src/b.js']);
+  });
+
+  it('advances the header even when no new entries are supplied', () => {
+    const root = makeRoot();
+    writeJournalHeader(root, 1000);
+    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+
+    appendJournalEntriesAndStampHeader(root, [], 2000);
+
+    const result = readJournal(root);
+    expect(result.timestamp).toBe(2000);
+    expect(result.changed).toEqual(['src/a.js']);
+  });
+
+  it('is atomic: interleaved reads see either old or new state, never a truncated header', () => {
+    const root = makeRoot();
+    writeJournalHeader(root, 1000);
+    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+
+    appendJournalEntriesAndStampHeader(root, [{ file: 'src/b.js' }], 2000);
+
+    // No leftover .tmp file after the rename
+    expect(fs.existsSync(`${journalPath(root)}.tmp`)).toBe(false);
+    const content = fs.readFileSync(journalPath(root), 'utf-8');
+    expect(content.startsWith('# codegraph-journal v1 2000\n')).toBe(true);
+  });
+});
+
+describe('regression: watch session keeps header ahead of DB mtime', () => {
+  it('header timestamp reflects latest append, not prior build', () => {
+    // Simulates the bug in #997: after a build finalizes the journal header
+    // at T0, the watcher appends entries at T1 > T0. A later build's Tier 0
+    // check compares journal.timestamp against MAX(file_hashes.mtime).
+    // If the header stays at T0, Tier 0 bails out and the fast path is lost.
+    const root = makeRoot();
+
+    const buildFinalizedAt = 1000;
+    writeJournalHeader(root, buildFinalizedAt);
+
+    const watcherAppendAt = 2500;
+    appendJournalEntriesAndStampHeader(root, [{ file: 'src/a.js' }], watcherAppendAt);
+
+    const journal = readJournal(root);
+    expect(journal.valid).toBe(true);
+    expect(journal.timestamp).toBeGreaterThanOrEqual(watcherAppendAt);
+    // latestDbMtime can never exceed the timestamp of the most recent append
+    // because the watcher journals a file immediately after processing it.
+    const simulatedDbMtime = watcherAppendAt;
+    expect(journal.timestamp!).toBeGreaterThanOrEqual(simulatedDbMtime);
   });
 });
 

--- a/tests/unit/watcher-flush.test.ts
+++ b/tests/unit/watcher-flush.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for PR #1001 Greptile P1:
+ *   Deleted files journaled as "changed" in SIGINT flush.
+ *
+ * `ctx.pending` in the watcher is a plain `Set<string>` that carries no
+ * event-type metadata. The SIGINT flush must detect deletions via existence
+ * check — otherwise a file removed during a watch session is journaled as a
+ * changed path, and the next incremental build tries to re-parse a file that
+ * no longer exists instead of removing it from the graph.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildFlushEntriesFromPending } from '../../src/domain/graph/watcher.js';
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-watcher-flush-'));
+});
+
+afterAll(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeRoot(): string {
+  return fs.mkdtempSync(path.join(tmpDir, 'root-'));
+}
+
+describe('buildFlushEntriesFromPending', () => {
+  it('flags entries whose file no longer exists as deleted', () => {
+    const root = makeRoot();
+    const existing = path.join(root, 'src', 'kept.ts');
+    const removed = path.join(root, 'src', 'gone.ts');
+    fs.mkdirSync(path.dirname(existing), { recursive: true });
+    fs.writeFileSync(existing, 'export const x = 1;\n');
+    // Note: `removed` is intentionally not created — simulates a file
+    // deleted during the watch session that is still in `ctx.pending`.
+
+    const entries = buildFlushEntriesFromPending(root, [existing, removed]);
+
+    const byName = new Map(entries.map((e) => [e.file, e.deleted]));
+    expect(byName.get('src/kept.ts')).toBe(false);
+    expect(byName.get('src/gone.ts')).toBe(true);
+  });
+
+  it('produces relative, normalized paths (forward slashes) regardless of platform', () => {
+    const root = makeRoot();
+    const nested = path.join(root, 'a', 'b', 'c.ts');
+    fs.mkdirSync(path.dirname(nested), { recursive: true });
+    fs.writeFileSync(nested, '');
+
+    const [entry] = buildFlushEntriesFromPending(root, [nested]);
+    expect(entry!.file).toBe('a/b/c.ts');
+    expect(entry!.deleted).toBe(false);
+  });
+
+  it('handles an empty pending set without throwing', () => {
+    const root = makeRoot();
+    expect(buildFlushEntriesFromPending(root, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #997.

## Summary
- The watcher appended journal entries but never touched the header timestamp, so after any watch session `journal.timestamp` stayed frozen at the previous build's finalize time while DB `file_hashes.mtime` advanced. The next build's Tier 0 check then saw `journal.timestamp < MAX(file_hashes.mtime)`, bailed out, and fell through to the expensive mtime+size and SHA256 rescans — a silent performance cliff on the first build after every watch.
- Introduces `appendJournalEntriesAndStampHeader` in `src/domain/graph/journal.ts`. It reads the existing entries, writes a new header + existing entries + new entries to a tmp file, then atomically renames over the journal. Entries are preserved; the header advances in the same write.
- Watcher uses it in both journal write paths: the debounced batch handler (`processPendingFiles`) and the SIGINT flush handler. The "entries newer than header" invariant violation described in #997 can no longer occur.

Scoped to the header-lag bug only — the parallel-append locking issue tracked in #996 is out of scope.

## Test plan
- [x] `npx vitest run tests/unit/journal.test.ts` — 22 tests, all pass (added 5 new tests covering creation, header advance, empty-entries stamping, atomic rename, and a #997 regression guard comparing `journal.timestamp` against a simulated `latestDbMtime`).
- [x] `npx vitest run tests/builder/detect-changes.test.ts` — Tier 0 path unaffected.
- [x] `npx vitest run tests/integration/watcher-rebuild.test.ts tests/incremental/watcher-incremental.test.ts` — watcher tests pass.
- [x] `npx biome check src/domain/graph/journal.ts src/domain/graph/watcher.ts tests/unit/journal.test.ts` — clean.