### PR TITLE
fix(bench): dispose WASM worker pool and keep progress off stdout

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -82,6 +82,13 @@ const { buildGraph } = await import(srcImport(srcDir, 'domain/graph/builder.js')
 const { fnDepsData, fnImpactData, pathData, rolesData, statsData } = await import(
 	srcImport(srcDir, 'domain/queries.js')
 );
+// v3.9.5+ parses WASM in a worker_thread that keeps the event loop alive until
+// disposed. Older releases don't export disposeParsers — fall back to a no-op.
+let disposeParsers = async () => {};
+try {
+	const parser = await import(srcImport(srcDir, 'domain/parser.js'));
+	if (typeof parser.disposeParsers === 'function') disposeParsers = parser.disposeParsers;
+} catch { /* older release — no worker pool to dispose */ }
 
 const INCREMENTAL_RUNS = 3;
 const QUERY_RUNS = 5;
@@ -226,4 +233,6 @@ const workerResult = {
 
 console.log(JSON.stringify(workerResult));
 
+await disposeParsers();
 cleanup();
+process.exit(0);

--- a/scripts/incremental-benchmark.ts
+++ b/scripts/incremental-benchmark.ts
@@ -143,6 +143,13 @@ const { srcDir, cleanup } = await resolveBenchmarkSource();
 const dbPath = path.join(root, '.codegraph', 'graph.db');
 
 const { buildGraph } = await import(srcImport(srcDir, 'domain/graph/builder.js'));
+// v3.9.5+ parses WASM in a worker_thread that keeps the event loop alive until
+// disposed. Older releases don't export disposeParsers — fall back to a no-op.
+let disposeParsers = async () => {};
+try {
+	const parser = await import(srcImport(srcDir, 'domain/parser.js'));
+	if (typeof parser.disposeParsers === 'function') disposeParsers = parser.disposeParsers;
+} catch { /* older release — no worker pool to dispose */ }
 
 // Redirect console.log to stderr so only JSON goes to stdout
 const origLog = console.log;
@@ -218,4 +225,6 @@ console.log = origLog;
 const workerResult = { fullBuildMs, noopRebuildMs, oneFileRebuildMs, oneFilePhases };
 console.log(JSON.stringify(workerResult));
 
+await disposeParsers();
 cleanup();
+process.exit(0);

--- a/scripts/lib/fork-engine.ts
+++ b/scripts/lib/fork-engine.ts
@@ -93,7 +93,18 @@ export function forkWorker(scriptPath, envKey, workerName, argv = [], timeoutMs 
 
 			if (signal) {
 				console.error(`[fork] ${workerName} worker killed by signal ${signal}`);
-				settle(null);
+				// A worker can finish its measurements and write valid JSON to
+				// stdout before hanging on a non-daemonized handle (e.g. an
+				// un-disposed worker_thread pool). SIGKILL from our timeout
+				// then discards the result. Try to parse captured stdout first
+				// so we don't lose real data to a lingering event-loop keepalive.
+				try {
+					const parsed = JSON.parse(stdout);
+					console.error(`[fork] ${workerName} worker produced results before being killed — salvaging`);
+					settle(parsed);
+				} catch {
+					settle(null);
+				}
 				return;
 			}
 

--- a/scripts/query-benchmark.ts
+++ b/scripts/query-benchmark.ts
@@ -94,6 +94,13 @@ const { buildGraph } = await import(srcImport(srcDir, 'domain/graph/builder.js')
 const { fnDepsData, fnImpactData, diffImpactData } = await import(
 	srcImport(srcDir, 'domain/queries.js')
 );
+// v3.9.5+ parses WASM in a worker_thread that keeps the event loop alive until
+// disposed. Older releases don't export disposeParsers — fall back to a no-op.
+let disposeParsers = async () => {};
+try {
+	const parser = await import(srcImport(srcDir, 'domain/parser.js'));
+	if (typeof parser.disposeParsers === 'function') disposeParsers = parser.disposeParsers;
+} catch { /* older release — no worker pool to dispose */ }
 
 // Redirect console.log to stderr so only JSON goes to stdout
 const origLog = console.log;
@@ -259,4 +266,6 @@ console.log = origLog;
 const workerResult = { targets, fnDeps, fnImpact, diffImpact };
 console.log(JSON.stringify(workerResult));
 
+await disposeParsers();
 cleanup();
+process.exit(0);

--- a/scripts/resolution-benchmark.ts
+++ b/scripts/resolution-benchmark.ts
@@ -219,6 +219,14 @@ console.log = (...args) => console.error(...args);
 
 const { srcDir, cleanup } = await resolveBenchmarkSource();
 
+// v3.9.5+ parses WASM in a worker_thread that keeps the event loop alive until
+// disposed. Older releases don't export disposeParsers — fall back to a no-op.
+let disposeParsers = async () => {};
+try {
+	const parser = await import(srcImport(srcDir, 'domain/parser.js'));
+	if (typeof parser.disposeParsers === 'function') disposeParsers = parser.disposeParsers;
+} catch { /* older release — no worker pool to dispose */ }
+
 try {
 	const { buildGraph } = await import(srcImport(srcDir, 'domain/graph/builder.js'));
 	const { openReadonlyOrFail } = await import(srcImport(srcDir, 'db/index.js'));
@@ -296,5 +304,7 @@ try {
 	console.log(JSON.stringify(results, null, 2));
 } finally {
 	console.log = origLog;
+	await disposeParsers();
 	cleanup();
+	process.exit(0);
 }

--- a/scripts/resolution-benchmark.ts
+++ b/scripts/resolution-benchmark.ts
@@ -306,5 +306,5 @@ try {
 	console.log = origLog;
 	await disposeParsers();
 	cleanup();
-	process.exit(0);
 }
+process.exit(0);

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -253,7 +253,7 @@ export async function embed(
     }
 
     if (texts.length > batchSize) {
-      process.stdout.write(`  Embedded ${Math.min(i + batchSize, texts.length)}/${texts.length}\r`);
+      process.stderr.write(`  Embedded ${Math.min(i + batchSize, texts.length)}/${texts.length}\r`);
     }
   }
 


### PR DESCRIPTION
## Summary

The v3.9.5 benchmark workflow ([run 24863501577](https://github.com/optave/ops-codegraph-tool/actions/runs/24863501577)) failed three of four jobs. Two independent bugs were responsible.

### 1. `build-benchmark` & `query-benchmark` — regression in v3.9.5
PR #975 moved WASM tree-sitter parsing into a `node:worker_threads.Worker` managed by a shared singleton pool (`src/domain/wasm-worker-pool.ts`). That pool is only terminated via `disposeParsers()`. The benchmark worker scripts never call it — so after `JSON.stringify(workerResult)` was written to stdout, the worker thread kept the event loop alive. The parent `fork-engine` timer fired at 600s, sent SIGKILL, and the parent's `onClose` handler discarded the valid stdout because `signal` was set — reporting `Error: Both engines failed`.

### 2. `embedding-benchmark` — pre-existing bug
`src/domain/search/models.ts:256` wrote `"  Embedded N/M\r"` directly to `process.stdout`. The benchmark worker redirects `console.log → console.error` to keep stdout clean for JSON, but `process.stdout.write` bypassed it, corrupting every model's output with `Unexpected token 'E', "  Embedded 3"...`.

## Fix

- **benchmark/query/incremental/resolution scripts:** import `disposeParsers` from the installed package (try/catch for older releases) and call it before `cleanup()`, then `process.exit(0)` to guarantee termination.
- **`fork-engine.ts`:** on SIGKILL, try to parse captured stdout as JSON before giving up — defence-in-depth against future event-loop-keepalive bugs.
- **`search/models.ts`:** progress now writes to `stderr` so it can't pollute stdout in JSON-consuming workers.

## Test plan

- [x] `npm run lint` passes (only pre-existing warnings in unrelated files).
- [x] `npx vitest run tests/parsers/wasm-hardening.test.ts` — 3/3 pass.
- [x] `npx vitest run tests/search` — 74/74 pass.
- [x] `node scripts/benchmark.ts` (local) — exits 0 in 24s, full JSON for both engines. Previously hung for 600s.
- [x] `node scripts/query-benchmark.ts` (local) — exits 0 in 25s, clean JSON on stdout, engine logs on stderr.
- [ ] Benchmark workflow re-runs green on next release.