### PR TITLE
Fix jina-code model alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ A single trailing semicolon is ignored (falls back to single-query mode). The `-
 | `minilm` | all-MiniLM-L6-v2 | 384 | ~23 MB | Apache-2.0 | Fastest, good for quick iteration |
 | `jina-small` | jina-embeddings-v2-small-en | 512 | ~33 MB | Apache-2.0 | Better quality, still small |
 | `jina-base` | jina-embeddings-v2-base-en | 768 | ~137 MB | Apache-2.0 | High quality, 8192 token context |
-| `jina-code` | jina-embeddings-v2-base-code | 768 | ~137 MB | Apache-2.0 | Best for code search, trained on code+text (requires HF token) |
+| `jina-code` | jina-embeddings-v2-base-code | 768 | ~137 MB | Apache-2.0 | Best for code search, trained on code+text |
 | `nomic` | nomic-embed-text-v1 | 768 | ~137 MB | Apache-2.0 | Good quality, 8192 context |
 | `nomic-v1.5` (default) | nomic-embed-text-v1.5 | 768 | ~137 MB | Apache-2.0 | **Improved nomic, Matryoshka dimensions** |
 | `bge-large` | bge-large-en-v1.5 | 1024 | ~335 MB | MIT | Best general retrieval, top MTEB scores |

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -42,7 +42,7 @@ export const MODELS: Record<string, ModelConfig> = {
     quantized: false,
   },
   'jina-code': {
-    name: 'Xenova/jina-embeddings-v2-base-code',
+    name: 'jinaai/jina-embeddings-v2-base-code',
     dim: 768,
     contextWindow: 8192,
     desc: 'Code-aware (~137MB). Trained on code+text, best for code search.',

--- a/tests/search/embedding-strategy.test.ts
+++ b/tests/search/embedding-strategy.test.ts
@@ -143,6 +143,10 @@ describe('MODELS contextWindow', () => {
       expect(config.contextWindow, `${key} missing contextWindow`).toBeGreaterThan(0);
     }
   });
+
+  test('jina-code points to the published code embedding model', () => {
+    expect(MODELS['jina-code'].name).toBe('jinaai/jina-embeddings-v2-base-code');
+  });
 });
 
 describe('buildEmbeddings with structured strategy', () => {


### PR DESCRIPTION
Fixes #1025.

## Summary
- Point `jina-code` at `jinaai/jina-embeddings-v2-base-code`, which exists on Hugging Face.
- Remove the stale README note that this model requires an HF token.
- Add a regression test for the alias.

## Verification
- `npm test -- tests/search/embedding-strategy.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)