### PR TITLE
fix(parity): gate astTypeMap lookup with Object.hasOwn

### DIFF
--- a/src/ast-analysis/visitors/ast-store-visitor.ts
+++ b/src/ast-analysis/visitors/ast-store-visitor.ts
@@ -269,6 +269,13 @@ export function createAstStoreVisitor(
       // unrelated subtree. The parent call's skipChildren handles the intended case.
       if (matched.has(node.id)) return;
 
+      // Gate with `hasOwn` because plain-object lookup walks Object.prototype:
+      // tree-sitter node types like `constructor` (Haskell sum-types: Left,
+      // Right) would otherwise resolve to `Object.prototype.constructor` (the
+      // Object() function), which then crashes the worker boundary with
+      // "function Object() { [native code] } could not be cloned" when the
+      // resulting astNodes row is structured-cloned back to the main thread.
+      if (!Object.hasOwn(astTypeMap, node.type)) return;
       const kind = astTypeMap[node.type];
       if (!kind) return;
 

--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -90,9 +90,14 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  *   above the natural variance of the small target set. Not reproducible
  *   locally (~30ms steady-state); will be re-validated on v3.9.7+ data.
  *
- * - 3.9.6:resolution haskell precision/recall — separate Haskell resolver
- *   regression introduced in 3.9.6, unrelated to #1036 / PR #1038. Tracked
- *   in #1039.
+ * - 3.9.6:resolution haskell precision/recall — Haskell AST visitor walked
+ *   `astTypeMap` with bracket-notation lookup, so node type `constructor`
+ *   (Haskell sum-types: Left, Right) resolved to `Object.prototype.constructor`
+ *   instead of `undefined`. The Object() function landed in the astNodes row
+ *   and crashed the worker boundary with "function Object() could not be
+ *   cloned", skipping every Haskell file with constructors. Fixed by gating
+ *   with `Object.hasOwn` (#1039). Benchmarks captured before the fix landed;
+ *   will reclear in v3.9.7+ data.
  */
 const KNOWN_REGRESSIONS = new Set([
   '3.9.0:1-file rebuild',


### PR DESCRIPTION
## Summary

- AST-store visitor looked up `astTypeMap[node.type]` with plain bracket notation; tree-sitter node type `constructor` (Haskell sum-types: `Left`, `Right`, `Just`, …) walked the prototype chain to `Object.prototype.constructor`, dropping the `Object()` function into the astNodes row's `kind` field.
- The non-cloneable function then crashed the worker boundary with `function Object() { [native code] } could not be cloned`, skipping every Haskell file containing constructors and dragging the resolver from 100%/33% precision/recall in v3.9.4 to 0%/0% in v3.9.6.
- Gate the lookup with `Object.hasOwn` so prototype-derived members never leak into the result. Restores the four expected truePositives in the Haskell fixture; metrics return to the v3.9.4 baseline (precision=1.0, recall=0.333).

The `KNOWN_REGRESSIONS` entries stay until v3.9.7 benchmark data is captured (matching the established pattern for the other 3.9.6 entries).

Closes #1039

## Test plan

- [x] `npx vitest run tests/benchmarks/resolution/resolution-benchmark.test.ts` — all 170 pass; Haskell now parses 4/4 files (was 2/4).
- [x] Direct precision/recall check on the Haskell fixture: `precision=1.000 (4/4)`, `recall=0.333 (4/12)` — matches v3.9.4 baseline.
- [x] `npx vitest run tests/parsers/ tests/integration/ast.test.ts tests/engines/ast-parity.test.ts` — 493 pass, no regressions.
- [x] `npx vitest run tests/benchmarks/regression-guard.test.ts` — 17 pass.