### PR TITLE
chore(ci): rename benchmark/ branch prefix to chore/

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,7 +82,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          BRANCH="benchmark/v${VERSION}-$(date +%Y%m%d-%H%M%S)"
+          BRANCH="chore/bench-v${VERSION}-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
           git add generated/benchmarks/BUILD-BENCHMARKS.md generated/benchmarks/QUERY-BENCHMARKS.md generated/benchmarks/INCREMENTAL-BENCHMARKS.md README.md
           git commit -m "docs: update performance benchmarks (${VERSION})"
@@ -249,9 +249,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [ "$VERSION" = "dev" ]; then
-            BRANCH="benchmark/embedding-dev-$(date +%Y%m%d-%H%M%S)"
+            BRANCH="chore/embedding-bench-dev-$(date +%Y%m%d-%H%M%S)"
           else
-            BRANCH="benchmark/embedding-v${VERSION}-$(date +%Y%m%d-%H%M%S)"
+            BRANCH="chore/embedding-bench-v${VERSION}-$(date +%Y%m%d-%H%M%S)"
           fi
           git checkout -b "$BRANCH"
           git add generated/benchmarks/EMBEDDING-BENCHMARKS.md

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Check branch name
         run: |
           BRANCH="${{ github.head_ref }}"
-          PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|release|dependabot|revert|benchmark)/"
+          PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|release|dependabot|revert)/"
           if [[ ! "$BRANCH" =~ $PATTERN ]]; then
             echo "::error::Branch name '$BRANCH' does not match the required pattern."
-            echo "Branch names must start with one of: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, dependabot/, revert/, benchmark/"
+            echo "Branch names must start with one of: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, dependabot/, revert/"
             exit 1
           fi
           echo "Branch name '$BRANCH' is valid."


### PR DESCRIPTION
## Summary

The benchmark workflow currently creates auto-generated PR branches under a `benchmark/` prefix that is not in the local `guard-git.sh` allow-list. When a developer needs to push a fix to one of those PRs from a Claude Code session, the hook denies the push and the only workaround is bypassing the hook.

This PR renames all auto-generated branches to use the standard `chore/` prefix and drops `benchmark/` from the commitlint allow-list since no workflow creates such branches anymore.

## Changes

- `.github/workflows/benchmark.yml` — three `BRANCH=...` lines updated:
  - `benchmark/v\${VERSION}-…` → `chore/bench-v\${VERSION}-…` (combined record-benchmarks job)
  - `benchmark/embedding-dev-…` → `chore/embedding-bench-dev-…`
  - `benchmark/embedding-v\${VERSION}-…` → `chore/embedding-bench-v\${VERSION}-…`
- `.github/workflows/commitlint.yml` — drop `benchmark` from the branch-name regex and the human-readable error message.

The discriminator (`bench`, `embedding-bench`) is preserved so generated branches remain self-describing under the new prefix.

## Context

Surfaced during /sweep on PR #1032: the benchmark workflow created `benchmark/incremental-v3.9.6-…` and the local guard hook blocked the push. Aligning the workflow with the guard's allow-list is cleaner than expanding the allow-list.

## Test plan

- [ ] Workflows still parse — GitHub Actions YAML validation succeeds on push.
- [ ] Commitlint job still runs and rejects branches outside the allow-list.
- [ ] Next benchmark run (manual `workflow_dispatch` or post-publish) opens a PR with a `chore/...` branch.