### PR TITLE
ci(release): restore resolution + tracer gates in pre-publish-benchmark

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,12 +253,12 @@ jobs:
           node-version: "22"
           cache: "npm"
 
-      - name: Setup Python (for resolution benchmark)
+      - name: Setup Python (for resolution benchmark + tracer validation)
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Setup Go (for resolution benchmark)
+      - name: Setup Go (for resolution benchmark + tracer validation)
         uses: actions/setup-go@v6
         with:
           go-version: "stable"
@@ -288,6 +288,14 @@ jobs:
         run: |
           STRIP_FLAG=$(node -e "const [M]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
           node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/resolution-benchmark.ts --version "$VERSION" > resolution-result.json
+
+      - name: Gate on resolution thresholds
+        timeout-minutes: 30
+        run: npx vitest run tests/benchmarks/resolution/resolution-benchmark.test.ts --reporter=verbose
+
+      - name: Run tracer validation (same-file edge recall)
+        timeout-minutes: 10
+        run: npx vitest run tests/benchmarks/resolution/tracer/tracer-validation.test.ts --reporter=verbose
 
       - name: Merge resolution into build result
         run: |


### PR DESCRIPTION
## Summary

- Re-add the `Gate on resolution thresholds` step (runs `tests/benchmarks/resolution/resolution-benchmark.test.ts`) to `pre-publish-benchmark` in publish.yml
- Re-add the `Run tracer validation` step (runs `tests/benchmarks/resolution/tracer/tracer-validation.test.ts`) to the same job
- Both gates were dropped in #1040 when the build/query/incremental jobs were consolidated into the pre-publish gate. Restoring them where the gating mechanism actually lives means a precision/recall or same-file-recall regression now blocks publish — previously the old post-publish workflow could only paint the run red after npm had already accepted the bad version.

Inserted between `Run resolution benchmark` and `Merge resolution into build result`, matching the original ordering. Python and Go are already set up at the top of the job, so no extra setup needed.

## Test plan

- [ ] Trigger a manual \`workflow_dispatch\` of the Publish workflow against a known-good commit and verify both new steps run and pass
- [ ] Confirm regression-guard step still runs after these gates
- [ ] On the next real release, confirm the gates either pass cleanly or block with a clear failure message