### PR TITLE
ci(bench): build dist/ before pre-publish benchmark gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -275,19 +275,27 @@ jobs:
       - name: Install native addon over published binary
         run: node scripts/ci-install-native.mjs
 
+      # Build dist/ so benchmarks load the same compiled JS that ships to npm.
+      # Historical baselines (v3.9.6 and earlier) were measured against dist/
+      # via the post-publish --npm path; running pre-publish against src/ with
+      # --strip-types changed the load path and introduced version-to-version
+      # noise unrelated to the code under test (#1055).
+      - name: Build TypeScript
+        run: npm run build
+
       - name: Run build benchmark
         env:
           VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           STRIP_FLAG=$(node -e "const [M]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
-          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/benchmark.ts --version "$VERSION" > benchmark-result.json
+          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/benchmark.ts --version "$VERSION" --dist > benchmark-result.json
 
       - name: Run resolution benchmark
         env:
           VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           STRIP_FLAG=$(node -e "const [M]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
-          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/resolution-benchmark.ts --version "$VERSION" > resolution-result.json
+          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/resolution-benchmark.ts --version "$VERSION" --dist > resolution-result.json
 
       - name: Merge resolution into build result
         run: |
@@ -304,14 +312,14 @@ jobs:
           VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           STRIP_FLAG=$(node -e "const [M]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
-          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/query-benchmark.ts --version "$VERSION" > query-benchmark-result.json
+          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/query-benchmark.ts --version "$VERSION" --dist > query-benchmark-result.json
 
       - name: Run incremental benchmark
         env:
           VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           STRIP_FLAG=$(node -e "const [M]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
-          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/incremental-benchmark.ts --version "$VERSION" > incremental-benchmark-result.json
+          node $STRIP_FLAG --import ./scripts/ts-resolve-loader.js scripts/incremental-benchmark.ts --version "$VERSION" --dist > incremental-benchmark-result.json
 
       - name: Update build report
         run: |

--- a/scripts/lib/bench-config.ts
+++ b/scripts/lib/bench-config.ts
@@ -85,6 +85,10 @@ export function parseArgs() {
 export async function resolveBenchmarkSource() {
 	const { version: cliVersion, npm, dist } = parseArgs();
 
+	if (dist && npm) {
+		console.error('Warning: --dist is ignored in --npm mode (the installed package already uses dist/ automatically).');
+	}
+
 	if (!npm) {
 		// Local mode — use repo src/ (or dist/ when --dist), version from git state
 		const root = path.resolve(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1')), '..', '..');

--- a/scripts/lib/bench-config.ts
+++ b/scripts/lib/bench-config.ts
@@ -45,22 +45,33 @@ function assertSafePkgVersion(version: string): string {
 }
 
 /**
- * Parse `--version <v>` and `--npm` from process.argv.
+ * Parse `--version <v>`, `--npm`, and `--dist` from process.argv.
+ *
+ * `--dist` selects local-built `dist/` over `src/` so the benchmark loads the
+ * compiled JavaScript that ships to npm — matching the loading path used for
+ * historical baselines (where `--npm` installs a published package whose
+ * `bench-config` already prefers `dist/`). Without this, the pre-publish gate
+ * runs `src/` via `--strip-types` while baselines were measured against
+ * compiled JS, which introduces per-call JIT/loader overhead deltas that are
+ * artifacts of measurement, not the code under test.
  */
 export function parseArgs() {
 	const args = process.argv.slice(2);
 	let version = null;
 	let npm = false;
+	let dist = false;
 
 	for (let i = 0; i < args.length; i++) {
 		if (args[i] === '--version' && i + 1 < args.length) {
 			version = args[++i];
 		} else if (args[i] === '--npm') {
 			npm = true;
+		} else if (args[i] === '--dist') {
+			dist = true;
 		}
 	}
 
-	return { version, npm };
+	return { version, npm, dist };
 }
 
 /**
@@ -72,15 +83,23 @@ export function parseArgs() {
  *   - cleanup:  call when done — removes the temp dir in npm mode, no-op otherwise
  */
 export async function resolveBenchmarkSource() {
-	const { version: cliVersion, npm } = parseArgs();
+	const { version: cliVersion, npm, dist } = parseArgs();
 
 	if (!npm) {
-		// Local mode — use repo src/, version derived from git state
+		// Local mode — use repo src/ (or dist/ when --dist), version from git state
 		const root = path.resolve(path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1')), '..', '..');
 		const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+		let srcDir = path.join(root, 'src');
+		if (dist) {
+			const distDir = path.join(root, 'dist');
+			if (!fs.existsSync(distDir)) {
+				throw new Error(`--dist requested but ${distDir} does not exist. Run "npm run build" first.`);
+			}
+			srcDir = distDir;
+		}
 		return {
 			version: cliVersion || getBenchmarkVersion(pkg.version, root),
-			srcDir: path.join(root, 'src'),
+			srcDir,
 			cleanup() {},
 		};
 	}


### PR DESCRIPTION
## Summary

- Pre-publish benchmark ran `src/` via `--strip-types` while every historical baseline was measured against compiled `dist/` via the post-publish `--npm` path. Same code, two load paths — version-to-version deltas were largely measurement artifacts.
- Adds `--dist` to `bench-config.ts` so local mode can opt into `dist/`. CI now `npm run build`s and passes `--dist` to all four benchmark scripts. Local developer flow (no `--dist`) is unchanged.

## Why this addresses #1055

The reported +52% on `fnDeps` (and the related +2080ms native rebuild flat overhead in #1054) appeared on Linux CI between v3.9.6 and v3.10.0 even though the `fnDeps` query path code (`domain/queries.ts` → `analysis/dependencies.ts` → `db/repository/native-repository.ts` → `db/connection.ts` → `infrastructure/native.ts`) was unchanged across those tags.

What did change is how the benchmark loads the code under test:
- v3.9.6's row in `QUERY-BENCHMARKS.md` was produced by the post-publish workflow installing `@optave/codegraph@3.9.6` and running benchmarks against `dist/` (`bench-config.ts` line 204 prefers `dist/` when present in npm mode).
- v3.10.0's pre-publish gate (added in #1040) runs `node --strip-types --import ./scripts/ts-resolve-loader.js scripts/benchmark.ts` against `src/`. Same Rust binary, but the JS layer is now type-stripped TypeScript instead of `tsc`-compiled JavaScript.

This PR aligns the gate with the historical methodology so 3.10.x and later are measured the same way 3.9.6 was.

## Test plan

- [x] `npm run build` produces a working `dist/`.
- [x] `node --import ./scripts/ts-resolve-loader.js scripts/query-benchmark.ts --dist` runs end-to-end on Mac M1 and produces sensible numbers (`fnDeps depth3 = 23.2ms`, in line with `src/`-loaded run at `24.9ms`).
- [x] `npx tsc --noEmit` clean.
- [ ] Pre-publish benchmark gate runs cleanly on next dispatch and produces v3.10.x numbers comparable to v3.9.6.

Fixes #1055
Refs #1054