### PR TITLE
fix(ci): force clang for Linux x86_64 native builds (#1054)

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -72,6 +72,17 @@ jobs:
         with:
           workspaces: crates/codegraph-core
 
+      # Force clang for the host x86_64-linux-gnu build. With gcc (the runner's
+      # default `cc`) the bundled C parsers in tree-sitter-hcl produce a binary
+      # whose HCL extractor silently drops files (#1054). Clang produces a
+      # working binary.
+      - name: Use clang for x86_64-linux-gnu
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          clang --version
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
       - name: Install cross-compilation tools (aarch64-gnu)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,16 @@ jobs:
         with:
           workspaces: crates/codegraph-core
 
+      # Force clang on Linux runners. With gcc (the default cc) the bundled
+      # C parsers in tree-sitter-hcl produce a binary whose HCL extractor
+      # silently drops files (#1054). Clang produces a working binary.
+      - name: Use clang on Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          clang --version
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
       - name: Install napi-rs CLI
         run: npm install -g @napi-rs/cli@3
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,15 @@ jobs:
         with:
           workspaces: crates/codegraph-core
 
+      # Match the build-native job: gcc-built tree-sitter parsers drop files
+      # on Linux x86_64 (#1054). Use clang here too so preflight parity tests
+      # exercise the same binary characteristics as the published artifact.
+      - name: Use clang for native build
+        run: |
+          clang --version
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
       - name: Install napi-rs CLI
         run: npm install -g @napi-rs/cli@3
 
@@ -177,6 +186,18 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates/codegraph-core
+
+      # Force clang for the host x86_64-linux-gnu build. With gcc (the runner's
+      # default `cc`) the bundled C parsers in tree-sitter-hcl produce a binary
+      # whose HCL extractor silently drops files (#1054), triggering an
+      # expensive WASM backfill on every build call. Clang produces a working
+      # binary. Verified locally: gcc 14.2.0 drops .tf files, clang does not.
+      - name: Use clang for x86_64-linux-gnu
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          clang --version
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
 
       - name: Install cross-compilation tools (aarch64-gnu)
         if: matrix.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
## Summary

- The Linux x86_64 native binary built in CI silently drops the 4 HCL fixture files in \`tests/benchmarks/resolution/fixtures/hcl/\`. The drop triggers an engine-parity WASM backfill on every full \`buildGraph\` call, which the pre-publish gate detects as a perf regression (#1054).
- Verified locally that this is a **C compiler** issue — same Rust source, same Cargo.lock, same toolchain version: gcc 14.2.0 builds a dropping binary; clang 14 builds a working one. The bundled parser.c in tree-sitter-hcl is what \`cc-rs\` compiles via \`CC\`, and gcc apparently optimizes some part of it differently.
- Sets \`CC=clang\`/\`CXX=clang++\` for the three places that build the host x86_64-linux-gnu artifact: \`publish.yml\` \`build-native\` matrix, \`publish.yml\` \`preflight\` job, \`build-native.yml\`, and \`ci.yml\`'s ubuntu-latest leg.

## Why clang specifically

Reproduced both sides locally in Docker:

| Compiler | Image | Binary parses HCL? | noopRebuild |
|---|---|---|---|
| gcc 14.2.0 | node:22-trixie | ❌ drops 4 .tf files | (warning fires) |
| clang 14 | node:22-bookworm | ✅ parses cleanly | clean |

Same Rust source (current main), same \`napi build --release\`, only \`CC\` differs.

## Scope

- Cross-compile targets (\`aarch64-unknown-linux-gnu\`, \`x86_64-unknown-linux-musl\`) are unaffected — they already pin their own toolchains via separate steps.
- macOS and Windows builds are unaffected.
- End users on Linux x86_64 GNU now get the clang-built binary, which fixes the silent HCL drop they would also have hit had they happened to install v3.10.0.

## Companion PR

#1058 makes the WASM backfill cheap when it does fire (defense-in-depth). This PR removes the trigger condition. With both, \`Native orchestrator dropped 4 file(s)\` should disappear from gate logs entirely.

## Test plan

- [x] Local Docker: gcc-14 build → drops files; clang build → no drops.
- [ ] Pre-publish benchmark gate runs cleanly on dispatch.
- [ ] CI \`native-host-build\` and parity tests pass on the new clang-built binary.

Refs #1054