### PR TITLE
revert(ci): undo "force clang for Linux x86_64 native builds" (#1059)

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -72,17 +72,6 @@ jobs:
         with:
           workspaces: crates/codegraph-core
 
-      # Force clang for the host x86_64-linux-gnu build. With gcc (the runner's
-      # default `cc`) the bundled C parsers in tree-sitter-hcl produce a binary
-      # whose HCL extractor silently drops files (#1054). Clang produces a
-      # working binary.
-      - name: Use clang for x86_64-linux-gnu
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: |
-          clang --version
-          echo "CC=clang" >> "$GITHUB_ENV"
-          echo "CXX=clang++" >> "$GITHUB_ENV"
-
       - name: Install cross-compilation tools (aarch64-gnu)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,16 +61,6 @@ jobs:
         with:
           workspaces: crates/codegraph-core
 
-      # Force clang on Linux runners. With gcc (the default cc) the bundled
-      # C parsers in tree-sitter-hcl produce a binary whose HCL extractor
-      # silently drops files (#1054). Clang produces a working binary.
-      - name: Use clang on Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          clang --version
-          echo "CC=clang" >> "$GITHUB_ENV"
-          echo "CXX=clang++" >> "$GITHUB_ENV"
-
       - name: Install napi-rs CLI
         run: npm install -g @napi-rs/cli@3
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,15 +44,6 @@ jobs:
         with:
           workspaces: crates/codegraph-core
 
-      # Match the build-native job: gcc-built tree-sitter parsers drop files
-      # on Linux x86_64 (#1054). Use clang here too so preflight parity tests
-      # exercise the same binary characteristics as the published artifact.
-      - name: Use clang for native build
-        run: |
-          clang --version
-          echo "CC=clang" >> "$GITHUB_ENV"
-          echo "CXX=clang++" >> "$GITHUB_ENV"
-
       - name: Install napi-rs CLI
         run: npm install -g @napi-rs/cli@3
 
@@ -186,18 +177,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates/codegraph-core
-
-      # Force clang for the host x86_64-linux-gnu build. With gcc (the runner's
-      # default `cc`) the bundled C parsers in tree-sitter-hcl produce a binary
-      # whose HCL extractor silently drops files (#1054), triggering an
-      # expensive WASM backfill on every build call. Clang produces a working
-      # binary. Verified locally: gcc 14.2.0 drops .tf files, clang does not.
-      - name: Use clang for x86_64-linux-gnu
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: |
-          clang --version
-          echo "CC=clang" >> "$GITHUB_ENV"
-          echo "CXX=clang++" >> "$GITHUB_ENV"
 
       - name: Install cross-compilation tools (aarch64-gnu)
         if: matrix.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
## Summary

Reverts #1059 (1e292efd). The premise was that switching CC to clang prevented the HCL .tf drops in #1054. After tighter verification it's clear that **both** gcc and clang produce binaries that drop .tf files — the earlier observation that "clang doesn't drop" was an output-filtering artifact in my local benchmark grep, not a real behavior difference.

## What's actually going on

The real cause is a tree-sitter ABI mismatch (\`tree-sitter-hcl\` 1.1.0 ships ABI 15; runtime is pinned at \`tree-sitter = \"0.24\"\` / ABI 14). \`Parser::set_language\` rejects the grammar at runtime regardless of compiler. The proper fix bumps \`tree-sitter\` to 0.25 — that's #1060.

## Why revert instead of letting it sit

#1059 isn't actively harmful — clang vs gcc produces functionally equivalent binaries here — but it adds CI configuration that solves nothing real and that future readers will be misled by. Better to keep the workflow clean and the diff history honest.

## Test plan

- [x] Diff equals the inverse of 1e292efd (3 workflow files, -42 lines).
- [ ] CI \`native-host-build\` matrix passes on Linux/macOS/Windows with the runner-default \`cc\`.

Refs #1054