### PR TITLE
chore(bench): per-iteration phase trace for #1054 diagnosis [DO NOT MERGE]

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -126,12 +126,27 @@ function selectTargets() {
 const origLog = console.log;
 console.log = (...args) => console.error(...args);
 
+// ───── Issue #1054 timing instrumentation (one-off) ─────
+// Per-iteration phase breakdown so we can see which step eats the 2s/call
+// CI overhead. Throwaway after we read the gate logs.
+function logTrace(scenario: string, iter: number, totalMs: number, phases: any) {
+	const p = phases || {};
+	const order = [
+		'setupMs', 'collectMs', 'detectMs', 'parseMs', 'insertMs', 'resolveMs',
+		'edgesMs', 'structureMs', 'rolesMs', 'astMs', 'complexityMs', 'cfgMs',
+		'dataflowMs', 'finalizeMs',
+	];
+	const parts = order.map(k => `${k.replace(/Ms$/, '')}=${p[k] ?? '?'}`).join(' ');
+	console.error(`[1054-trace] ${engine}.${scenario}[${iter}] total=${Math.round(totalMs)}ms ${parts}`);
+}
+
 // Clean DB for a full build
 if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
 const buildStart = performance.now();
 const buildResult = await buildGraph(root, { engine, incremental: false });
 const buildTimeMs = performance.now() - buildStart;
+logTrace('full', 0, buildTimeMs, buildResult?.phases);
 
 const queryStart = performance.now();
 fnDepsData('buildGraph', dbPath);
@@ -150,8 +165,10 @@ try {
 	const noopTimings = [];
 	for (let i = 0; i < INCREMENTAL_RUNS; i++) {
 		const start = performance.now();
-		await buildGraph(root, { engine, incremental: true });
-		noopTimings.push(performance.now() - start);
+		const res = await buildGraph(root, { engine, incremental: true });
+		const elapsed = performance.now() - start;
+		noopTimings.push(elapsed);
+		logTrace('noop', i, elapsed, res?.phases);
 	}
 	noopRebuildMs = Math.round(median(noopTimings));
 } catch (err) {
@@ -168,7 +185,9 @@ try {
 		fs.writeFileSync(PROBE_FILE, original + `\n// probe-${i}\n`);
 		const start = performance.now();
 		const res = await buildGraph(root, { engine, incremental: true });
-		oneFileRuns.push({ ms: performance.now() - start, phases: res?.phases || null });
+		const elapsed = performance.now() - start;
+		oneFileRuns.push({ ms: elapsed, phases: res?.phases || null });
+		logTrace('1file', i, elapsed, res?.phases);
 	}
 	oneFileRuns.sort((a, b) => a.ms - b.ms);
 	const medianRun = oneFileRuns[Math.floor(oneFileRuns.length / 2)];

--- a/scripts/incremental-benchmark.ts
+++ b/scripts/incremental-benchmark.ts
@@ -166,13 +166,31 @@ function median(arr) {
 
 console.error(`Benchmarking ${engine} engine...`);
 
+// ───── Issue #1054 timing instrumentation (one-off) ─────
+// Emits per-iteration phase breakdown for every buildGraph call so we can
+// see which step eats the 2s/call CI overhead that doesn't reproduce locally.
+// The plan: dispatch the gate against this branch, read the log, then
+// throw the branch away.
+function logTrace(scenario: string, iter: number, totalMs: number, phases: any) {
+	const p = phases || {};
+	const order = [
+		'setupMs', 'collectMs', 'detectMs', 'parseMs', 'insertMs', 'resolveMs',
+		'edgesMs', 'structureMs', 'rolesMs', 'astMs', 'complexityMs', 'cfgMs',
+		'dataflowMs', 'finalizeMs',
+	];
+	const parts = order.map(k => `${k.replace(/Ms$/, '')}=${p[k] ?? '?'}`).join(' ');
+	console.error(`[1054-trace] ${engine}.${scenario}[${iter}] total=${Math.round(totalMs)}ms ${parts}`);
+}
+
 // Full build (delete DB first)
 const fullTimings = [];
 for (let i = 0; i < RUNS; i++) {
 	if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 	const start = performance.now();
-	await buildGraph(root, { engine, incremental: false });
-	fullTimings.push(performance.now() - start);
+	const res = await buildGraph(root, { engine, incremental: false });
+	const elapsed = performance.now() - start;
+	fullTimings.push(elapsed);
+	logTrace('full', i, elapsed, res?.phases);
 }
 const fullBuildMs = Math.round(median(fullTimings));
 
@@ -182,8 +200,10 @@ try {
 	const noopTimings = [];
 	for (let i = 0; i < RUNS; i++) {
 		const start = performance.now();
-		await buildGraph(root, { engine, incremental: true });
-		noopTimings.push(performance.now() - start);
+		const res = await buildGraph(root, { engine, incremental: true });
+		const elapsed = performance.now() - start;
+		noopTimings.push(elapsed);
+		logTrace('noop', i, elapsed, res?.phases);
 	}
 	noopRebuildMs = Math.round(median(noopTimings));
 } catch (err) {
@@ -200,7 +220,9 @@ try {
 		fs.writeFileSync(PROBE_FILE, original + `\n// probe-${i}\n`);
 		const start = performance.now();
 		const res = await buildGraph(root, { engine, incremental: true });
-		oneFileRuns.push({ ms: performance.now() - start, phases: res?.phases || null });
+		const elapsed = performance.now() - start;
+		oneFileRuns.push({ ms: elapsed, phases: res?.phases || null });
+		logTrace('1file', i, elapsed, res?.phases);
 	}
 	oneFileRuns.sort((a, b) => a.ms - b.ms);
 	const medianRun = oneFileRuns[Math.floor(oneFileRuns.length / 2)];


### PR DESCRIPTION
## Purpose

Throwaway diagnostic branch. **Do not merge.**

The pre-publish gate shows a flat ~2-second-per-call native overhead in CI that doesn't reproduce locally on Windows or in Docker Linux. The .tf drops (#1054) explain part of the picture but not this — even with backfill firing locally, no-op rebuild is ~7ms; in CI it's 2307ms.

This branch adds per-iteration phase breakdown to \`benchmark.ts\` and \`incremental-benchmark.ts\`. Every full / no-op / 1-file iteration prints a line like:

\`\`\`
[1054-trace] native.noop[0] total=2307ms setup=? collect=? detect=? parse=? insert=? resolve=? edges=? structure=? roles=? ast=? complexity=? cfg=? dataflow=? finalize=?
\`\`\`

When the gate runs against this branch, the log will show which specific stage (or stages) eats the 2 seconds — \`parseMs\`, \`edgesMs\`, \`rolesMs\`, \`structureMs\`, etc. That'll tell us where to dig next.

## Plan

1. Dispatch \`publish.yml\` against this branch.
2. Read the gate log, grep for \`[1054-trace]\`.
3. Identify the dominant phase.
4. Open the actual fix in a focused PR.
5. Close this PR without merging.

## Why diagnostic prints don't go to main

The trace lines go to stderr only and don't affect the JSON the gate consumes, so the gate's regression-guard verdict is unchanged. But committing diagnostic prints to mainline benchmarks pollutes future runs and obscures real signal. Hence the throwaway-branch shape.

Refs #1054