### PR TITLE
ci(greptile): scope auto-reviews to maintainer only

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,3 @@
+{
+  "includeAuthors": ["carlos-alm"]
+}


### PR DESCRIPTION
## Summary
- Adds `.greptile/config.json` with an `includeAuthors` allowlist so Greptile only auto-reviews PRs from `carlos-alm`.
- Other contributors (and bots like Dependabot) won't trigger automatic reviews; they can still request one on demand by commenting `@greptileai`.

## Test plan
- [ ] Confirm Greptile does not post a review on PRs opened by other accounts after this lands on `main`.
- [ ] Confirm `@greptileai` manual trigger still works on any PR.