### PR TITLE
ci: add 10-minute timeout to npm install steps

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -138,7 +138,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm install --prefer-offline --no-audit --no-fund
 
       - name: Determine benchmark mode

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -138,6 +138,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: npm install --prefer-offline --no-audit --no-fund
 
       - name: Determine benchmark mode

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -96,6 +96,7 @@ jobs:
           sudo ln -sf /lib/x86_64-linux-gnu/libgcc_s.so.1 "${GNU_LIB}/libgcc_s.so.1"
 
       - name: Install napi-rs CLI
+        timeout-minutes: 5
         run: npm install -g @napi-rs/cli@3
 
       - name: Build native addon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           workspaces: crates/codegraph-core
 
       - name: Install napi-rs CLI
+        timeout-minutes: 5
         run: npm install -g @napi-rs/cli@3
 
       - name: Build native addon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
+        timeout-minutes: 10
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -103,6 +104,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
+        timeout-minutes: 10
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -141,6 +143,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
+        timeout-minutes: 10
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -169,6 +172,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: npm ci
 
       - name: Audit production dependencies
@@ -209,6 +213,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
+        timeout-minutes: 10
         shell: bash
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -104,7 +104,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -143,7 +143,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         shell: bash
         run: |
           for attempt in 1 2 3; do
@@ -172,7 +172,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm ci
 
       - name: Audit production dependencies
@@ -213,7 +213,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         shell: bash
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/codegraph-impact.yml
+++ b/.github/workflows/codegraph-impact.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install dependencies
+        timeout-minutes: 10
         shell: bash
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/codegraph-impact.yml
+++ b/.github/workflows/codegraph-impact.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         shell: bash
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npm install
+      - name: Install dependencies
+        timeout-minutes: 10
+        run: npm install
 
       - name: Validate PR commits
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm install
 
       - name: Validate PR commits

--- a/.github/workflows/embedding-regression.yml
+++ b/.github/workflows/embedding-regression.yml
@@ -29,6 +29,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: npm install
 
       - name: Cache HuggingFace models

--- a/.github/workflows/embedding-regression.yml
+++ b/.github/workflows/embedding-regression.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm install
 
       - name: Cache HuggingFace models

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm install -g @napi-rs/cli@3
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm install
 
       - name: Build native addon from current source
@@ -273,7 +273,7 @@ jobs:
           path: crates/codegraph-core/
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm install
 
       - name: Install native addon over published binary
@@ -394,7 +394,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm install
 
       - name: Set version
@@ -575,7 +575,7 @@ jobs:
           node-version: "24"
 
       - name: Install dependencies
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm install
 
       - name: Set version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Install napi-rs CLI
         run: npm install -g @napi-rs/cli@3
 
-      - run: npm install
+      - name: Install dependencies
+        timeout-minutes: 10
+        run: npm install
 
       - name: Build native addon from current source
         working-directory: crates/codegraph-core
@@ -270,7 +272,9 @@ jobs:
           name: native-linux-x64
           path: crates/codegraph-core/
 
-      - run: npm install
+      - name: Install dependencies
+        timeout-minutes: 10
+        run: npm install
 
       - name: Install native addon over published binary
         run: node scripts/ci-install-native.mjs
@@ -389,7 +393,9 @@ jobs:
         with:
           node-version: "22"
 
-      - run: npm install
+      - name: Install dependencies
+        timeout-minutes: 10
+        run: npm install
 
       - name: Set version
         env:
@@ -568,7 +574,9 @@ jobs:
         with:
           node-version: "24"
 
-      - run: npm install
+      - name: Install dependencies
+        timeout-minutes: 10
+        run: npm install
 
       - name: Set version
         env:
@@ -702,6 +710,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Refresh node_modules after publish
+        timeout-minutes: 10
         run: npm install --ignore-scripts
 
       - name: Generate DEPENDENCIES.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
           workspaces: crates/codegraph-core
 
       - name: Install napi-rs CLI
+        timeout-minutes: 5
         run: npm install -g @napi-rs/cli@3
 
       - name: Install dependencies
@@ -214,6 +215,7 @@ jobs:
           mv "${CARGO}.tmp" "$CARGO"
 
       - name: Install napi-rs CLI
+        timeout-minutes: 5
         run: npm install -g @napi-rs/cli@3
 
       - name: Build native addon

--- a/.github/workflows/shield-license-compliance.yml
+++ b/.github/workflows/shield-license-compliance.yml
@@ -29,6 +29,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
+        timeout-minutes: 10
         shell: bash
         run: |
           for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary

The retry loops in CI install steps only catch non-zero exits, not hangs. When `npm install` hangs (as happened on #1064's `Engine parity (macos-latest)` job for 1h+), the loop never iterates and the job runs until GitHub's 6h job-level timeout.

Adding `timeout-minutes` at the step level caps each install step. A hung runner now produces a fast red CI signal that can be retried by re-running the failed job, rather than blocking the PR for an hour.

## Timeout values

- **Project `npm install`** (runs the `prepare` script that builds 30+ wasm grammars) — **20 minutes**. Linux finishes in ~7m; macOS / Windows in ~10-12m on cold cache. 20m is ~2x worst-case, leaving comfortable headroom for transient registry slowness while still catching hangs.
- **Post-publish refresh** (`npm install --ignore-scripts`) — **10 minutes**. Skips the wasm build, so a much shorter cap is fine.
- **`npm install -g @napi-rs/cli@3`** — **5 minutes**. Small global install that typically completes in 5-10s.

## Scope

Step-level `timeout-minutes` added to every dependency-install step across the CI workflows:

- `ci.yml` — lint, test, typecheck, audit (`npm ci`), parity, and the native-host-build matrix `Install napi-rs CLI` step
- `build-native.yml` — the multi-OS / multi-target matrix `Install napi-rs CLI` step
- `benchmark.yml` — benchmark job
- `codegraph-impact.yml` — impact job
- `commitlint.yml` — validate-commits (also named the previously unnamed step)
- `embedding-regression.yml` — embedding-regression
- `publish.yml` — preflight + build-native `Install napi-rs CLI` steps, preflight / pre-publish-benchmark / publish-dev / publish project installs, refresh-after-publish
- `shield-license-compliance.yml` — os-license (uses `--ignore-scripts`, kept at 10m)

The retry loops are unchanged (still 3 attempts, 15s sleep between). A follow-up could add per-attempt `timeout` wrappers so the retries also fire on hang; deferred for a separate PR.

## Test plan

- [ ] CI passes on this PR — confirms YAML is valid and timeout doesn't trip on a normal run