### PR TITLE
chore(diag): log fast-skip rejection reason in CI bench gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -242,6 +242,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Surface why detectNoChanges returns false on each fast-skip pre-flight
+      # so we can pinpoint the cause of the ~2s incremental-rebuild regression
+      # observed in CI but not locally (#1066). Remove once root cause is fixed.
+      CODEGRAPH_FAST_SKIP_DIAG: "1"
 
     steps:
       - uses: actions/checkout@v6

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -1010,6 +1010,24 @@ export async function buildGraph(
     // source files have changed. Tier-2 hashing is left to the native
     // side: any mismatch falls through and lets Rust's detect_changes
     // remain the source of truth.
+    //
+    // Diagnostic logging gated by CODEGRAPH_FAST_SKIP_DIAG (#1066) — when
+    // any of the call-site guards short-circuit (forceFullRebuild,
+    // engineName, scope, etc.) we log the reason so the bench gate run
+    // produces observable output even if `detectNoChanges` is never
+    // entered.
+    const fastSkipDiag = process.env.CODEGRAPH_FAST_SKIP_DIAG === '1';
+    if (fastSkipDiag) {
+      const reasons: string[] = [];
+      if (!ctx.nativeAvailable) reasons.push('nativeAvailable=false');
+      if (ctx.engineName !== 'native') reasons.push(`engineName=${ctx.engineName}`);
+      if (!ctx.incremental) reasons.push('incremental=false');
+      if (ctx.forceFullRebuild) reasons.push('forceFullRebuild=true');
+      if ((ctx.opts as Record<string, unknown>).scope) reasons.push('scope=set');
+      if (reasons.length > 0) {
+        info(`[fast-skip] false: pre-flight gate skipped — ${reasons.join(', ')}`);
+      }
+    }
     if (
       ctx.nativeAvailable &&
       ctx.engineName === 'native' &&

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -540,6 +540,14 @@ export function detectNoChanges(
   rootDir: string,
   opts?: Record<string, unknown>,
 ): boolean {
+  // Diagnostic logging gated by env var — used by the bench gate to surface
+  // why the fast-skip is not firing on CI runners (#1066). Off by default to
+  // avoid noise on every regular incremental build.
+  const diag = process.env.CODEGRAPH_FAST_SKIP_DIAG === '1';
+  const log = (reason: string): void => {
+    if (diag) info(`[fast-skip] ${reason}`);
+  };
+
   let hasTable = false;
   try {
     db.prepare('SELECT 1 FROM file_hashes LIMIT 1').get();
@@ -547,10 +555,16 @@ export function detectNoChanges(
   } catch {
     /* table missing — first build */
   }
-  if (!hasTable) return false;
+  if (!hasTable) {
+    log('false: file_hashes table missing');
+    return false;
+  }
 
   const rows = db.prepare('SELECT file, hash, mtime, size FROM file_hashes').all() as FileHashRow[];
-  if (rows.length === 0) return false;
+  if (rows.length === 0) {
+    log('false: file_hashes table empty');
+    return false;
+  }
   const existing = new Map<string, FileHashRow>(rows.map((r) => [r.file, r]));
 
   const currentFiles = new Set<string>();
@@ -558,19 +572,36 @@ export function detectNoChanges(
     currentFiles.add(normalizePath(path.relative(rootDir, file)));
   }
   for (const existingFile of existing.keys()) {
-    if (!currentFiles.has(existingFile)) return false;
+    if (!currentFiles.has(existingFile)) {
+      log(`false: tracked file no longer collected: ${existingFile}`);
+      return false;
+    }
   }
 
   for (const file of allFiles) {
     const relPath = normalizePath(path.relative(rootDir, file));
     const record = existing.get(relPath);
-    if (!record) return false;
+    if (!record) {
+      log(`false: collected file missing from file_hashes: ${relPath}`);
+      return false;
+    }
     const stat = fileStat(file) as FileStat | undefined;
-    if (!stat) return false;
+    if (!stat) {
+      log(`false: stat failed for ${relPath}`);
+      return false;
+    }
     const storedMtime = record.mtime || 0;
     const storedSize = record.size || 0;
-    if (storedSize <= 0) return false;
-    if (Math.floor(stat.mtimeMs) !== storedMtime || stat.size !== storedSize) return false;
+    if (storedSize <= 0) {
+      log(`false: stored size <= 0 for ${relPath} (stored=${record.size})`);
+      return false;
+    }
+    if (Math.floor(stat.mtimeMs) !== storedMtime || stat.size !== storedSize) {
+      log(
+        `false: mtime/size diff for ${relPath}: stat=${Math.floor(stat.mtimeMs)}/${stat.size} stored=${storedMtime}/${storedSize} (mtimeMs=${stat.mtimeMs})`,
+      );
+      return false;
+    }
   }
 
   // Pending-analysis guard: if CFG/dataflow is enabled but the corresponding
@@ -578,10 +609,17 @@ export function detectNoChanges(
   // fall through so the orchestrator / JS pipeline can run runPendingAnalysis.
   // Mirrors the check at the top of runPendingAnalysis (see line ~244).
   if (opts) {
-    if (opts.cfg !== false && hasEmptyAnalysisTable(db, 'cfg_blocks')) return false;
-    if (opts.dataflow !== false && hasEmptyAnalysisTable(db, 'dataflow')) return false;
+    if (opts.cfg !== false && hasEmptyAnalysisTable(db, 'cfg_blocks')) {
+      log('false: pending-analysis guard — cfg_blocks is empty');
+      return false;
+    }
+    if (opts.dataflow !== false && hasEmptyAnalysisTable(db, 'dataflow')) {
+      log('false: pending-analysis guard — dataflow is empty');
+      return false;
+    }
   }
 
+  log(`true: all checks passed (${allFiles.length} files)`);
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Add env-gated diagnostic logging to \`detectNoChanges\` (\`src/domain/graph/builder/stages/detect-changes.ts\`) — every \`return false\` now emits a \`[fast-skip]\` line via \`info()\` naming the check that rejected and including the relevant values (mtime, size, file path, table-empty reason). The \`true\` path also logs to confirm the fast-skip fired.
- Set \`CODEGRAPH_FAST_SKIP_DIAG: "1"\` at the \`pre-publish-benchmark\` job level in \`.github/workflows/publish.yml\` so the next workflow_dispatch publish run surfaces the cause of the regression in #1066.

Behavior is unchanged when the env var is unset, so regular incremental builds stay quiet.

## Why

The v3.10.0 publish gate (run [25361005381](https://github.com/optave/ops-codegraph-tool/actions/runs/25361005381)) measured native incremental no-op rebuilds at ~2000ms vs the 10–13ms 3.9.6 baseline — exactly the regression PR #1064's JS-side fast-skip was meant to fix. Code inspection (issue #1066) narrowed the cause to one of:

- mtime precision mismatch between Rust-written \`file_hashes.mtime\` and JS-read \`Math.floor(stat.mtimeMs)\`
- pending-analysis guard tripping because \`cfg_blocks\` / \`dataflow\` are empty after the full build
- \`forceFullRebuild\` set due to engine/version mismatch
- file enumeration drift between full and noop

Reading the code didn't pinpoint which. One CI run with this diagnostic does.

## What to look for in the next publish run

After merging and triggering a workflow_dispatch publish, search the \"Run incremental benchmark\" / \"Run build benchmark\" step logs for \`[fast-skip]\`. Expected outcomes:

- \`true: all checks passed (N files)\` → fast-skip is firing; regression is elsewhere (look at orchestrator path)
- \`false: mtime/size diff for X: stat=A/B stored=C/D\` → confirms the mtime-precision hypothesis
- \`false: pending-analysis guard — cfg_blocks is empty\` → confirms the guard is the cause despite Rust orchestrator allegedly populating the table
- \`false: tracked file no longer collected: X\` → file enumeration disagrees between writes and reads

## Test plan

- [ ] Merge to main
- [ ] Trigger workflow_dispatch on Publish workflow
- [ ] Inspect \`Run build benchmark\` and \`Run incremental benchmark\` step logs for \`[fast-skip]\` lines
- [ ] File a follow-up fix targeting the identified root cause and revert this diag PR

Refs #1066