### PR TITLE
fix(native): skip unsupported-extension files in detect_removed_files

### DIFF
--- a/crates/codegraph-core/src/change_detection.rs
+++ b/crates/codegraph-core/src/change_detection.rs
@@ -10,6 +10,7 @@
 //! when switching between JS and native engines, so hash format compatibility is
 //! not required.
 
+use crate::file_collector::is_supported_extension;
 use crate::journal;
 use rusqlite::Connection;
 use sha2::{Digest, Sha256};
@@ -129,6 +130,14 @@ fn load_file_hashes(conn: &Connection) -> Option<HashMap<String, FileHashRow>> {
 /// When `scoped_rel_paths` is provided (scoped rebuild), only files within that
 /// scope are considered candidates for removal. Without it, all DB files not
 /// found on disk are treated as removed.
+///
+/// Files whose extension is outside the Rust file_collector's supported set
+/// (e.g. `.clj`, `.gleam`, `.jl`, `.fs` — WASM-only languages) are skipped:
+/// the orchestrator's narrower collector never sees them, so absence from
+/// `current` is a capability boundary, not a deletion. Their `nodes` and
+/// `file_hashes` rows are owned by the JS-side WASM backfill (#967, #1068)
+/// and must be left alone, otherwise every incremental rebuild purges and
+/// re-creates them — the ~2s floor reported in #1066.
 fn detect_removed_files(
     existing: &HashMap<String, FileHashRow>,
     all_files: &[String],
@@ -143,6 +152,9 @@ fn detect_removed_files(
     existing
         .keys()
         .filter(|f| {
+            if !is_supported_extension(f) {
+                return false;
+            }
             // When scope is set, only consider files within scope as candidates.
             if let Some(scope) = scoped_rel_paths {
                 scope.contains(*f) && !current.contains(*f)
@@ -758,5 +770,46 @@ mod tests {
         let all_files = vec!["/project/src/a.ts".to_string()];
         let removed = detect_removed_files(&existing, &all_files, "/project", None);
         assert_eq!(removed, vec!["src/b.ts"]);
+    }
+
+    #[test]
+    fn detect_removed_skips_unsupported_extensions() {
+        // Files in WASM-only languages (Clojure, Gleam, Julia, F#) live in
+        // `file_hashes` because the JS-side WASM backfill writes them, but
+        // Rust's narrower file_collector never collects them. Without this
+        // skip, every incremental rebuild would flag them as removed and
+        // purge their rows — the #1066 ~2s floor.
+        let mut existing = HashMap::new();
+        for path in [
+            "tests/fixtures/clojure/main.clj",
+            "tests/fixtures/gleam/main.gleam",
+            "tests/fixtures/julia/main.jl",
+            "tests/fixtures/fsharp/Main.fs",
+        ] {
+            existing.insert(
+                path.to_string(),
+                FileHashRow {
+                    file: path.to_string(),
+                    hash: "h".to_string(),
+                    mtime: 0,
+                    size: 0,
+                },
+            );
+        }
+        // Also include a supported file that IS missing from disk — should
+        // still be flagged as removed.
+        existing.insert(
+            "src/deleted.ts".to_string(),
+            FileHashRow {
+                file: "src/deleted.ts".to_string(),
+                hash: "h".to_string(),
+                mtime: 0,
+                size: 0,
+            },
+        );
+
+        let all_files: Vec<String> = Vec::new();
+        let removed = detect_removed_files(&existing, &all_files, "/project", None);
+        assert_eq!(removed, vec!["src/deleted.ts"]);
     }
 }

--- a/crates/codegraph-core/src/file_collector.rs
+++ b/crates/codegraph-core/src/file_collector.rs
@@ -38,6 +38,25 @@ const SUPPORTED_EXTENSIONS: &[&str] = &[
     "kts", "swift", "scala", "sh", "bash", "ex", "exs", "lua", "dart", "zig", "hs", "ml", "mli",
 ];
 
+/// Returns whether `path` has an extension the Rust file_collector would accept.
+///
+/// Mirrors the predicate at the heart of `collect_files`: a file is collected
+/// if `LanguageKind::from_extension` recognizes it OR its raw extension is in
+/// `SUPPORTED_EXTENSIONS`. Exposed for `change_detection::detect_removed_files`
+/// so that files outside Rust's capability (e.g. WASM-only `.clj`, `.gleam`,
+/// `.jl`) are not flagged as "removed" merely because the orchestrator's
+/// narrower collector never sees them.
+pub fn is_supported_extension(path: &str) -> bool {
+    if LanguageKind::from_extension(path).is_some() {
+        return true;
+    }
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    SUPPORTED_EXTENSIONS.contains(&ext)
+}
+
 /// Result of file collection.
 pub struct CollectResult {
     /// Absolute paths of all collected source files.


### PR DESCRIPTION
## Summary

- `detect_removed_files` now filters out files outside Rust's supported-extension set before flagging them as removed. Files whose extension is unknown to `LanguageKind::from_extension` and absent from `SUPPORTED_EXTENSIONS` (e.g. `.clj`, `.gleam`, `.jl`, `.fs`) are owned by the JS-side WASM backfill (#967, #1068) — the orchestrator must leave their rows alone.
- Adds `is_supported_extension` to `file_collector`, exposing the same OR predicate used by `collect_files`. `change_detection` reuses it so the two stages can never drift.
- Adds a regression unit test covering the four common WASM-only extensions.

Refs #1066.

## Why this fixes the 1-file rebuild ~2s floor

Issue #1066 has two halves. PR #1069 closed the no-op half by ensuring `file_hashes` rows are persisted for every collected file. The 1-file half remained — fast-skip can't fire when there's a real change, so each rebuild went through `tryNativeOrchestrator`, which:

1. Ran Rust's narrower `file_collector::collect_files`. WASM-only files (.clj/.gleam/.jl/.fs) were absent from `current`.
2. `detect_removed_files` flagged every such row as removed.
3. `purge_changed_files` ran `DELETE FROM nodes WHERE file = ?1` and `DELETE FROM file_hashes WHERE file = ?1` for each (`native_db.rs:1322`).
4. `backfillNativeDroppedFiles` (now on every pass per #1069) re-parsed the WASM-only files and re-inserted the rows.

On the codegraph repo, that loop hits the multi-language fixtures in `tests/benchmarks/resolution/fixtures/`, which is exactly the ~2s floor reported by the regression guard:

```
1-file rebuild: 78 → 1986 (+2446%)
```

With this change, those rows persist across incremental rebuilds and the missing-file early-return in `backfillNativeDroppedFiles` (`pipeline.ts:811`) finally fires.

## Test plan

- [ ] CI regression-guard gate shows native 1-file rebuild back under 100ms (was 1986ms in run 25415028370)
- [ ] CI regression-guard gate shows native no-op rebuild back under 30ms (was 21ms post-#1069 — not blocking but should also benefit)
- [ ] Existing `detect_removed_finds_missing` test still passes
- [ ] New `detect_removed_skips_unsupported_extensions` test passes (covers .clj/.gleam/.jl/.fs)
- [ ] No build-parity regression (the `.clj` etc. paths are still owned by the JS backfill, untouched here)

## Notes

- Verification was limited to `cargo check -p codegraph-core --lib -j 1` locally; full `cargo test` could not run on the maintainer's Windows machine due to a rustc/LLVM toolchain memory issue (unrelated to these changes). CI runs the suite.
- The `is_supported_extension` helper deliberately mirrors the OR predicate at `file_collector.rs:248-256`. Keeping it as a single function lets both stages stay in lockstep — one source of truth for what the orchestrator considers "in scope".