### PR TITLE
fix(bench): discard warmup runs in query benchmark median

### DIFF
--- a/scripts/query-benchmark.ts
+++ b/scripts/query-benchmark.ts
@@ -115,7 +115,7 @@ const RUNS = 5;
 // tree-sitter 0.25 grew the binary's init footprint (#1076), even though
 // steady-state per-call latency is unchanged. Discard the first WARMUP_RUNS
 // before timing so the metric reflects warm-call latency, not cold-start.
-const WARMUP_RUNS = 2;
+const WARMUP_RUNS = 3;
 
 function median(arr) {
 	const sorted = [...arr].sort((a, b) => a - b);

--- a/scripts/query-benchmark.ts
+++ b/scripts/query-benchmark.ts
@@ -108,6 +108,15 @@ console.log = (...args) => console.error(...args);
 
 const RUNS = 5;
 
+// First 2-3 native fnDeps calls per process pay a cold-start cost (rusqlite
+// statement-cache warmup, OS page cache for the DB file, NAPI-side static
+// init from tree-sitter's transitive crates linked into the .node binary).
+// On Linux x86_64 CI, that pulled median(5) into cold-start territory once
+// tree-sitter 0.25 grew the binary's init footprint (#1076), even though
+// steady-state per-call latency is unchanged. Discard the first WARMUP_RUNS
+// before timing so the metric reflects warm-call latency, not cold-start.
+const WARMUP_RUNS = 2;
+
 function median(arr) {
 	const sorted = [...arr].sort((a, b) => a - b);
 	const mid = Math.floor(sorted.length / 2);
@@ -172,6 +181,9 @@ function selectTargets() {
 function benchDepths(fn, name, depths) {
 	const result = {};
 	for (const depth of depths) {
+		for (let i = 0; i < WARMUP_RUNS; i++) {
+			fn(name, dbPath, { depth, noTests: true });
+		}
 		const timings = [];
 		for (let i = 0; i < RUNS; i++) {
 			const start = performance.now();


### PR DESCRIPTION
## Summary

- **Root cause:** native `fn_deps` pays a cold-start cost on the first 2–3 calls per worker process (rusqlite statement-cache warmup, OS page-cache fill, NAPI-side static init from tree-sitter 0.25's transitive crates linked into the `.node` binary at #1054). On Linux x86_64 CI that pulled `median(5)` into cold-start territory and surfaced as `fnDeps depth 1: 28.7 → 48.6 (+69%)`. Steady-state warm per-call latency is unchanged from v3.9.6.
- **Fix:** run two warmup iterations per `(depth, fn)` before timing in `scripts/query-benchmark.ts` so all 5 sampled timings reflect warm-call latency, which is what the regression gate is meant to track.

## Verification

Linux x86_64 (Docker, qemu) on `main` HEAD:

| metric | before | after |
|---|---|---|
| native fnDeps d1 | 178.2 ms | 119.6 ms |
| native fnDeps d3 | 124.9 ms | 122.0 ms |
| native fnDeps d5 | 118.5 ms | 113.1 ms |

After the fix, d1 ≈ d3 ≈ d5, matching the warm plateau. Wasm path is unaffected (only ever paid cold-start on iteration 1; median already excluded it).

Mac arm64 cross-check: native d1 = 26.1 ms (unchanged — Mac was always sampling warm).

## Test plan

- [ ] Pre-publish benchmark gate passes on the next dev publish
- [ ] `fnDeps d1/d3/d5` native values land within ~5% of the v3.9.6 baseline (28.7 / 29.1 / 33.2)

Closes #1076