### PR TITLE
fix(test): skip --strip-types injection on Node 24+ to unblock vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 const [major, minor] = process.versions.node.split('.').map(Number);
 const existing = process.env.NODE_OPTIONS || '';
-const supportsStripTypes = major > 22 || (major === 22 && minor >= 6);
-const stripFlag = major >= 23 ? '--strip-types' : '--experimental-strip-types';
+// Node 24+ has type stripping on by default and removed --strip-types from the
+// NODE_OPTIONS allowlist, so injecting the flag is both unnecessary and fatal
+// (workers refuse to start). Only inject for the Node 22.6+ / Node 23 window
+// where the flag is required and accepted.
+const needsStripFlag = (major === 22 && minor >= 6) || major === 23;
+const stripFlag = major === 23 ? '--strip-types' : '--experimental-strip-types';
 
 export default defineConfig({
   resolve: {
@@ -19,7 +23,7 @@ export default defineConfig({
     env: {
       NODE_OPTIONS: [
         existing,
-        supportsStripTypes && !existing.includes('--experimental-strip-types') && !existing.includes('--strip-types')
+        needsStripFlag && !existing.includes('--experimental-strip-types') && !existing.includes('--strip-types')
           ? stripFlag
           : '',
       ].filter(Boolean).join(' '),


### PR DESCRIPTION
## Summary

- Vitest worker forks die at startup on Node 24 with `--strip-types is not allowed in NODE_OPTIONS`.
- Node 24 enables type stripping by default and dropped `--strip-types` from the NODE_OPTIONS allowlist; the config was unconditionally injecting it for `major>=23`.
- Gate injection to the Node 22.6+ / Node 23 window (where the flag is required and accepted), and pick `--strip-types` only on exactly Node 23 — Node 22 still needs `--experimental-strip-types`.

## Why now

Blocks local verification of any other PR on a Node 24 machine. CI is pinned to Node 22 in `ci.yml` so this hasn't surfaced there, but anyone on a recent Homebrew install hits it immediately.

## Test plan

- [x] `npx vitest run tests/builder/detect-changes.test.ts` — passes on Node 24.10
- [ ] CI green on Node 22 (regression check that the Node 22 path is unchanged)