### PR TITLE
chore: gitignore Rust target/ build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ generated/DEPENDENCIES.md
 generated/DEPENDENCIES.json
 artifacts/
 pkg/
+target/


### PR DESCRIPTION
## Summary

- Adds `target/` to `.gitignore`. Cargo writes workspace build artifacts there (~582MB locally) and the directory was previously untracked, polluting `git status` and risking accidental commits of build output.

## Test plan

- [ ] `git status` no longer shows `target/` as untracked after a `cargo build`
- [ ] Existing tracked files unaffected