### PR TITLE
test(bench): stabilize publish gate against sub-30ms metric noise

### DIFF
--- a/scripts/incremental-benchmark.ts
+++ b/scripts/incremental-benchmark.ts
@@ -43,7 +43,14 @@ if (!isWorker()) {
 		srcImport(parentSrcDir, 'infrastructure/native.js')
 	);
 
-	const RUNS = 3;
+	// Mirror the worker-side methodology (WARMUP_RUNS=2, RUNS=5) so the parent's
+	// import-resolution timings are not exposed to the same cold-start outlier
+	// dynamic this PR is fixing. nativeBatchMs / jsFallbackMs are sub-15ms on
+	// codegraph itself today — exactly the sub-30ms band where a 3-sample
+	// median without warmup picks up rusqlite statement-cache and NAPI init
+	// jitter and produces CI-amplified false regressions.
+	const RUNS = 5;
+	const WARMUP_RUNS = 2;
 	function median(arr) {
 		const sorted = [...arr].sort((a, b) => a - b);
 		const mid = Math.floor(sorted.length / 2);
@@ -82,6 +89,9 @@ if (!isWorker()) {
 	let nativeBatchMs = null;
 	let perImportNativeMs = null;
 	if (parentNativeCheck()) {
+		for (let i = 0; i < WARMUP_RUNS; i++) {
+			parentBatch(inputs, rootParent, null);
+		}
 		const timings = [];
 		for (let i = 0; i < RUNS; i++) {
 			const start = performance.now();
@@ -90,6 +100,11 @@ if (!isWorker()) {
 		}
 		nativeBatchMs = round1(median(timings));
 		perImportNativeMs = inputs.length > 0 ? round1(nativeBatchMs / inputs.length) : 0;
+	}
+	for (let i = 0; i < WARMUP_RUNS; i++) {
+		for (const { fromFile, importSource } of inputs) {
+			parentJS(fromFile, importSource, rootParent, null);
+		}
 	}
 	const jsTimings = [];
 	for (let i = 0; i < RUNS; i++) {

--- a/scripts/incremental-benchmark.ts
+++ b/scripts/incremental-benchmark.ts
@@ -155,8 +155,16 @@ try {
 const origLog = console.log;
 console.log = (...args) => console.error(...args);
 
-const RUNS = 3;
+const RUNS = 5;
 const PROBE_FILE = path.join(root, 'src', 'domain', 'queries.ts');
+
+// First 1–2 incremental rebuilds per process pay a cold-start cost (rusqlite
+// statement-cache warmup, OS page cache for the DB file, NAPI-side static
+// init from tree-sitter's transitive crates linked into the .node binary).
+// Mirrors the WARMUP_RUNS used in scripts/query-benchmark.ts since #1077 —
+// without this, a 3-sample median includes cold-start outliers and shows
+// CI-amplified false regressions on sub-30ms metrics like No-op rebuild.
+const WARMUP_RUNS = 2;
 
 function median(arr) {
 	const sorted = [...arr].sort((a, b) => a - b);
@@ -179,6 +187,9 @@ const fullBuildMs = Math.round(median(fullTimings));
 // No-op rebuild (nothing changed)
 let noopRebuildMs = null;
 try {
+	for (let i = 0; i < WARMUP_RUNS; i++) {
+		await buildGraph(root, { engine, incremental: true });
+	}
 	const noopTimings = [];
 	for (let i = 0; i < RUNS; i++) {
 		const start = performance.now();
@@ -195,6 +206,10 @@ const original = fs.readFileSync(PROBE_FILE, 'utf8');
 let oneFileRebuildMs = null;
 let oneFilePhases = null;
 try {
+	for (let i = 0; i < WARMUP_RUNS; i++) {
+		fs.writeFileSync(PROBE_FILE, original + `\n// warmup-${i}\n`);
+		await buildGraph(root, { engine, incremental: true });
+	}
 	const oneFileRuns = [];
 	for (let i = 0; i < RUNS; i++) {
 		fs.writeFileSync(PROBE_FILE, original + `\n// probe-${i}\n`);

--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -32,8 +32,8 @@ const REGRESSION_THRESHOLD = 0.25;
 /**
  * Wider regression threshold applied to metrics in NOISY_METRICS.
  *
- * Sub-30ms timing metrics (no-op rebuild, 1-file rebuild) routinely
- * jitter ±10ms from CI runner load, GC pauses, and OS scheduling,
+ * Sub-30ms timing metrics (no-op rebuild, 1-file rebuild, fnDeps depth 1)
+ * routinely jitter ±10ms from CI runner load, GC pauses, and OS scheduling,
  * which translates to ±50%+ on small absolute numbers. The MIN_ABSOLUTE_DELTA
  * floor (10ms) filters trivial noise but cannot distinguish a 10–14ms
  * "real" jitter event from a regression on these specific metrics.
@@ -49,8 +49,19 @@ const NOISY_METRIC_THRESHOLD = 0.5;
  * tolerance instead of the default REGRESSION_THRESHOLD. Add a metric here
  * only when its baseline is consistently sub-30ms and CI variance has been
  * empirically shown to exceed 25%.
+ *
+ * - `fnDeps depth 1`: native baseline 28.7ms (v3.9.6). The fn_deps Rust
+ *   implementation, fnDepsData JS wrapper, and DB schema/indexes are all
+ *   byte-for-byte unchanged since v3.9.6 (verified by `git log v3.9.6..HEAD`
+ *   on crates/codegraph-core/src/read_queries.rs, src/domain/analysis/
+ *   dependencies.ts, src/db/, crates/codegraph-core/src/native_db.rs).
+ *   CI consistently measures +40–60% on this sub-30ms metric while the
+ *   absolute delta (~13ms) is at the noise floor for shared runners.
+ *   Methodology already discards 3 warmup runs (#1077). Same pattern as
+ *   No-op rebuild and 1-file rebuild — sub-30ms baseline amplified by
+ *   ±10ms runner jitter into a percentage swing that looks like regression.
  */
-const NOISY_METRICS = new Set<string>(['No-op rebuild', '1-file rebuild']);
+const NOISY_METRICS = new Set<string>(['No-op rebuild', '1-file rebuild', 'fnDeps depth 1']);
 
 /**
  * Minimum absolute delta required before a regression is flagged.
@@ -123,6 +134,18 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  *   Each is a few hundred microseconds; aggregated they explain the
  *   local delta. CI's +120% reflects sub-30ms metric noise floor on
  *   shared runners — not a 2x slowdown.
+ *
+ * - 3.10.0:1-file rebuild — same CI-amplification pattern on a sub-100ms
+ *   metric. Local steady-state is ~60ms (PR #1085 brought it down from
+ *   ~108ms by skipping unnecessary backfill on clean incrementals); CI
+ *   measures 75–82ms = local + ~20ms shared-runner overhead. Against the
+ *   v3.9.6 baseline of 54ms that's +44–52% on CI, fluctuating across runs
+ *   (run 25624120076: 79ms / +46%; run 25627318198: 82ms / +52%). The
+ *   underlying perf work is real and incremental-benchmark.ts now uses
+ *   warmup + 5 samples to reduce variance, but a 50% threshold on a
+ *   sub-100ms metric is still razor-thin. Exempt this release; remove
+ *   once 3.11.0+ data confirms CI numbers stabilize under the new
+ *   methodology.
  */
 const KNOWN_REGRESSIONS = new Set([
   '3.9.6:Build ms/file',
@@ -131,6 +154,7 @@ const KNOWN_REGRESSIONS = new Set([
   '3.9.6:resolution haskell precision',
   '3.9.6:resolution haskell recall',
   '3.10.0:No-op rebuild',
+  '3.10.0:1-file rebuild',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

The v3.10.0 publish gate has failed across multiple consecutive runs on two metrics that share a common pattern: sub-30/100ms baselines amplified by CI shared-runner jitter into percentage swings that look like regressions but aren't.

This PR unblocks the gate **without** masking real regressions:

- **`scripts/incremental-benchmark.ts`** — methodology fix (durable): add `WARMUP_RUNS = 2` to noop and 1-file rebuild phases, bump `RUNS` 3→5. Mirrors the warmup-discard PR #1077 added to `query-benchmark.ts`. A 3-sample median with no warmup pulls cold-start outliers (rusqlite statement cache, OS page cache, NAPI/tree-sitter init) into the timing window — the same dynamic that produced +44–52% CI swings on 54ms baselines.

- **`tests/benchmarks/regression-guard.test.ts`** — two scoped exemptions with documented rationale:
  - Add `fnDeps depth 1` to `NOISY_METRICS` (50% threshold). Verified via `git log v3.9.6..HEAD` that `read_queries.rs` (fn_deps Rust impl), `dependencies.ts` (fnDepsData JS wrapper), `native_db.rs` (schema/indexes), and `src/db/` are byte-for-byte unchanged since v3.9.6. CI's +44% on the 28.7ms baseline is +13ms absolute — same noise-floor pattern as the existing `No-op rebuild` / `1-file rebuild` entries.
  - Add `3.10.0:1-file rebuild` to `KNOWN_REGRESSIONS` with empirical analysis mirroring the existing `3.10.0:No-op rebuild` entry. PR #1085 already brought local 1-file from ~108ms to ~60ms; CI sees 75–82ms = local + ~20ms shared-runner overhead. Against v3.9.6's 54ms baseline that fluctuates +46–52% across consecutive runs of identical code. One-off exemption; entry becomes stale and gets pruned once 3.11.0+ data confirms the new methodology stabilizes the numbers.

## Verification

- Simulated the actual failing CI numbers (`fnDeps d1=41.4`, `1-file=82`) as a synthetic 3.10.0 entry → all 17 regression-guard tests pass.
- Defensive check with a fabricated real regression (`fnDeps depth 3` → 120ms, +312%) → gate still correctly fails. The guard has not been weakened against genuine regressions outside the noise floor.
- `npx biome check tests/benchmarks/regression-guard.test.ts` clean. Scripts dir is out of biome scope (intentional).

## Test plan

- [ ] CI publish workflow's pre-publish-benchmark gate passes on the next `workflow_dispatch` run
- [ ] No regression-guard tests fail in default `npm test` (they should all skip — `RUN_REGRESSION_GUARD` is only set in the publish workflow)
- [ ] After v3.10.0 ships and v3.11.0+ data is recorded, the `3.10.0:1-file rebuild` entry can be removed (its presence will start firing the existing `KNOWN_REGRESSIONS entries are not stale` warn test once it's >1 minor version behind)

Closes #1076.