### PR TITLE
fix(bench): warmup + median for queryTimeMs to remove cold-start noise

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -92,6 +92,7 @@ try {
 
 const INCREMENTAL_RUNS = 3;
 const QUERY_RUNS = 5;
+const QUERY_WARMUP_RUNS = 3;
 const PROBE_FILE = path.join(root, 'src', 'domain', 'queries.ts');
 
 function median(arr) {
@@ -135,21 +136,12 @@ const buildTimeMs = performance.now() - buildStart;
 
 // Warmed median of QUERY_RUNS samples with `noTests: true` to match the
 // methodology used by query-benchmark.ts and the per-target `queries.*Ms`
-// block below. Earlier versions of this script measured a single cold call,
-// which conflated steady-state query latency with NAPI/rusqlite/OS-page-cache
-// init costs (~65ms on macOS) and inflated growth from test-fixture files
-// pulled in by new native extractors. See #1113 for the methodology rationale.
-const QUERY_WARMUP_RUNS = 3;
-for (let i = 0; i < QUERY_WARMUP_RUNS; i++) {
-	fnDepsData('buildGraph', dbPath, { depth: 3, noTests: true });
-}
-const queryTimings: number[] = [];
-for (let i = 0; i < QUERY_RUNS; i++) {
-	const start = performance.now();
-	fnDepsData('buildGraph', dbPath, { depth: 3, noTests: true });
-	queryTimings.push(performance.now() - start);
-}
-const queryTimeMs = median(queryTimings);
+// block below (which calls `benchQuery`, also warmed). Earlier versions of
+// this script measured a single cold call, which conflated steady-state
+// query latency with NAPI/rusqlite/OS-page-cache init costs (~65ms on
+// macOS) and inflated growth from test-fixture files pulled in by new
+// native extractors. See #1113 for the methodology rationale.
+const queryTimeMs = benchQuery(fnDepsData, 'buildGraph', dbPath, { depth: 3, noTests: true });
 
 const stats = statsData(dbPath);
 const totalFiles = stats.files.total;
@@ -205,6 +197,11 @@ const targets = workerTargets() || selectTargets();
 console.error(`    hub=${targets.hub}, leaf=${targets.leaf}`);
 
 function benchQuery(fn, ...args) {
+	// Warmup runs prime NAPI bindings, the rusqlite statement cache, and the
+	// OS page cache so the timed loop measures steady-state query latency
+	// rather than first-call init (~65ms on macOS). Each call site warms
+	// independently — methodology does not rely on call ordering elsewhere.
+	for (let i = 0; i < QUERY_WARMUP_RUNS; i++) fn(...args);
 	const timings = [];
 	for (let i = 0; i < QUERY_RUNS; i++) {
 		const start = performance.now();

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -133,9 +133,23 @@ const buildStart = performance.now();
 const buildResult = await buildGraph(root, { engine, incremental: false });
 const buildTimeMs = performance.now() - buildStart;
 
-const queryStart = performance.now();
-fnDepsData('buildGraph', dbPath);
-const queryTimeMs = performance.now() - queryStart;
+// Warmed median of QUERY_RUNS samples with `noTests: true` to match the
+// methodology used by query-benchmark.ts and the per-target `queries.*Ms`
+// block below. Earlier versions of this script measured a single cold call,
+// which conflated steady-state query latency with NAPI/rusqlite/OS-page-cache
+// init costs (~65ms on macOS) and inflated growth from test-fixture files
+// pulled in by new native extractors. See #1113 for the methodology rationale.
+const QUERY_WARMUP_RUNS = 3;
+for (let i = 0; i < QUERY_WARMUP_RUNS; i++) {
+	fnDepsData('buildGraph', dbPath, { depth: 3, noTests: true });
+}
+const queryTimings: number[] = [];
+for (let i = 0; i < QUERY_RUNS; i++) {
+	const start = performance.now();
+	fnDepsData('buildGraph', dbPath, { depth: 3, noTests: true });
+	queryTimings.push(performance.now() - start);
+}
+const queryTimeMs = median(queryTimings);
 
 const stats = statsData(dbPath);
 const totalFiles = stats.files.total;

--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -188,16 +188,19 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  *   one-time bump as the cost of supporting Verilog. Tracked separately;
  *   exempt this release.
  *
- * - 3.10.0:Query time — cumulative effect of adding two native extractors
- *   (Solidity #1100 + R #1102) in quick succession. Neither tripped the
- *   threshold individually (Solidity PR's Query time stayed at 49ms, R PR
- *   showed no warning), but the combined +110% (49.6 → ~105ms) on the
- *   `fnDepsData('buildGraph', dbPath)` measurement reflects natural graph
- *   growth: ~1100 LoC of new extractor code + 9 fixture files added to the
- *   self-build benchmark expand `buildGraph`'s transitive callee count and
- *   DB row counts. Tracked in #1113 — exempt this release; remove once
- *   3.11.0+ data captures the new steady-state and the per-language
- *   fixture footprint has been evaluated.
+ * - 3.10.0:Query time — methodology artifact, not a real regression. The
+ *   metric was a single-shot cold call to `fnDepsData('buildGraph', dbPath)`
+ *   with no warmup, no median, and `noTests: false` — so it captured ~65ms
+ *   of NAPI/rusqlite/OS-page-cache init plus the cost of walking through
+ *   fixture files added by new language extractors. Local v3.9.6 vs HEAD
+ *   on the same corpus measured 78.8ms vs 67.5ms single-shot (HEAD faster),
+ *   while the warmed `queries.fnDepsMs` in the same benchmark showed 4.0ms
+ *   vs 2.8ms — confirming no underlying regression. Methodology fixed in
+ *   #1113: queryTimeMs now uses 3 warmup runs + median of 5 with
+ *   `noTests: true`, matching query-benchmark.ts hygiene. Exemption kept
+ *   in place until 3.11.0+ data captures the new steady-state under the
+ *   updated methodology (expected ~36ms native on this corpus); remove
+ *   the entry then.
  *
  * - 3.10.0:fnDeps depth 5 — same cause as Query time above. Merging main
  *   into #1102 added the Erlang extractor (#1103) on top of the existing


### PR DESCRIPTION
## Summary

The build-benchmark `queryTimeMs` metric was a single-shot cold call to `fnDepsData('buildGraph', dbPath)` with no warmup, no median, and `noTests:false`. This conflated steady-state query latency with NAPI / rusqlite statement-cache / OS-page-cache init (~65ms on macOS) and let fixture-file growth from new native extractors inflate the measurement.

Local verification on the same 757-file corpus (HEAD source tree):

| | v3.9.6 | HEAD | Δ |
|---|---|---|---|
| `queryTimeMs` (old single-shot, noTests:false) | 78.8 ms | 67.5 ms | −14% |
| `queries.fnDepsMs` (warmed median, noTests:true, depth 3) | 4.0 ms | 2.8 ms | −30% |
| files / nodes / edges | 757 / 18,796 / 39,549 | 757 / 18,828 / 39,682 | flat |

HEAD is faster than v3.9.6 on both metrics — the +110% spike (49.6→104.4) that tripped the publish gate during the R + Solidity merge (#1100, #1102) was single-shot cold-start variance on a ~70ms cold call, **not** a real regression. The exemption `3.10.0:Query time` added to `KNOWN_REGRESSIONS` was the right defensive move at merge time, but the metric itself was the bug.

## Changes

- `scripts/benchmark.ts`: `queryTimeMs` now uses 3 warmup runs + median of 5 with `noTests: true`, matching the methodology already used by `query-benchmark.ts` and the per-target `queries.*Ms` block in the same script.
- `tests/benchmarks/regression-guard.test.ts`: update `3.10.0:Query time` comment to describe the methodology fix. Entry kept in place — per the issue's action #3, remove only after 3.11.0+ data captures the new steady-state under the updated methodology (expected ~36ms native on this corpus, no longer cold-start-dominated).

Backwards-compat note: published 3.10.0 has `queryTimeMs ≈ 50ms` (old methodology); after this fix dev/3.11.0+ will land at ~36ms. The per-PR regression gate will see this as an improvement, not a regression — no exemption changes needed.

Closes #1113

## Test plan

- [x] `node scripts/benchmark.ts` — produces sensible `queryTimeMs` (36.3 ms native, 36.3 ms wasm on local HEAD); the field is still present and in ms units.
- [x] Verified v3.9.6 baseline numbers locally via `node scripts/benchmark.ts --npm --version 3.9.6` to confirm no real regression.
- [ ] CI: the pre-publish benchmark gate compares dev vs 3.10.0 (≈50ms old methodology) — should pass cleanly as an improvement.
- [ ] Lint check on changed files (no new warnings introduced).