### PR TITLE
fix(hooks): guard-git.sh sed patterns work on macOS BSD sed

### DIFF
--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -33,8 +33,8 @@ fi
 # the opening `"` of a quoted path (which would leave a trailing `path"` in
 # NCOMMAND). The pattern re-anchors on `git`, so multi-`-C` chains (e.g.
 # `git -C /a -C /b push`) need a second pass to collapse the residual `-C`.
-NCOMMAND=$(echo "$COMMAND" | sed -E 's/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
-NCOMMAND=$(echo "$NCOMMAND" | sed -E 's/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
+NCOMMAND=$(echo "$COMMAND" | sed -E 's/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
+NCOMMAND=$(echo "$NCOMMAND" | sed -E 's/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
 
 deny() {
   local reason="$1"
@@ -117,11 +117,16 @@ detect_work_dir() {
   # `git -C` is the explicit git-level override and wins over any ambient cd prefix,
   # so check it first (e.g. `cd /tmp && git -C /worktree push` targets /worktree).
   # Greedy `.*-C` anchors on the LAST `-C` in the chosen segment.
-  if echo "$search_str" | grep -qE 'git\s+([^&|;]*\s)?-C\s+'; then
-    work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+"([^"]+)".*/\1/p;t;s/.*-C[[:space:]]+([^[:space:]]+).*/\1/p')
+  # Two separate sed invocations (quoted path first, then unquoted fallback) instead
+  # of a single `;t;s` chain — BSD sed parses chained s/// after `t` as a label.
+  if echo "$search_str" | grep -qE 'git[[:space:]]+([^&|;]*[[:space:]])?-C[[:space:]]+'; then
+    work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+"([^"]+)".*/\1/p')
+    if [ -z "$work_dir" ]; then
+      work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+([^[:space:]]+).*/\1/p')
+    fi
   fi
-  if [ -z "$work_dir" ] && echo "$COMMAND" | grep -qE '^\s*cd\s+'; then
-    work_dir=$(echo "$COMMAND" | sed -nE 's/^\s*cd\s+"?([^"&]+)"?\s*&&.*/\1/p')
+  if [ -z "$work_dir" ] && echo "$COMMAND" | grep -qE '^[[:space:]]*cd[[:space:]]+'; then
+    work_dir=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+"?([^"&]+)"?[[:space:]]*&&.*/\1/p')
   fi
   # Trim trailing whitespace
   work_dir="${work_dir%"${work_dir##*[![:space:]]}"}"


### PR DESCRIPTION
## Summary

- `\s` and `s///;t;s///` flow-control are GNU sed extensions that BSD sed (macOS default) does not support. The pre-fix patterns silently produced empty output, causing the hook to fall back to the calling shell's cwd and emit false "Branch does not match required pattern" denials when pushing to another worktree (e.g. `cd /path/to/wt && git push`).
- Replaced `\s` with `[[:space:]]` in all sed patterns (lines 36, 37, 124) and updated the matching `grep -qE` cd/-C guards for consistency.
- Split the `s/quoted/.../p;t;s/unquoted/.../p` chain on the `-C` extraction into two separate `sed -nE` invocations — BSD sed parses the chained `s///` after `t` as a label and errors with `undefined label`.

## Reproduction (pre-fix, macOS)

```bash
echo 'git -C /tmp push' | sed -nE 's/.*-C[[:space:]]+"([^"]+)".*/\1/p;t;s/.*-C[[:space:]]+([^[:space:]]+).*/\1/p'
# → sed: undefined label

echo 'cd /tmp/wt && git push' | sed -nE 's/^\s*cd\s+"?([^"&]+)"?\s*&&.*/\1/p'
# → (empty — silent failure)
```

## Test plan

- [x] Reproduced both BSD-sed failures on macOS (`sed: undefined label`; empty cd-extract).
- [x] End-to-end test with two mock worktrees (good branch + bad branch name) across 7 cases:
  - `cd <good-wt> && git push` from `<bad-wt>` → ALLOW
  - `cd <bad-wt> && git push` from `<good-wt>` → DENY (was silently ALLOWed pre-fix)
  - `git -C <good-wt> push` → ALLOW
  - `git -C <bad-wt> push` → DENY
  - `git -C "<bad-wt>" push` (quoted path) → DENY
  - `git -C <good-wt> -C <bad-wt> push` (multi-C bypass) → DENY (last `-C` wins)
  - `cd <good-wt> && git -C <bad-wt> push` → DENY (`-C` overrides cd)
- [x] Confirmed pre-fix vs post-fix delta: old cd-extract returned `[]`, new returns the actual path.

Closes #1145