### PR TITLE
fix(builder): remove duplicate early-return in backfillNativeDroppedFiles

### DIFF
--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -1023,8 +1023,6 @@ async function backfillNativeDroppedFiles(
 
   if (missingAbs.length === 0) return;
 
-  if (missingAbs.length === 0) return;
-
   // Classify drops so users see per-extension reasons instead of just a count
   // (#1011). `unsupported-by-native` is a legitimate parser limit (no Rust
   // extractor); `native-extractor-failure` indicates a real native bug since


### PR DESCRIPTION
## Summary
- Remove an unreachable duplicate `if (missingAbs.length === 0) return;` in `backfillNativeDroppedFiles` — the first identical check on the preceding line guaranteed the second could never execute.

## Test plan
- [x] `npm run lint -- src/domain/graph/builder/pipeline.ts` clean for the modified file.
- [x] Behavior is a no-op (dead-code removal only).

Closes #1144

Note: `tests/integration/dropped-language-gap.test.ts` has 2 pre-existing failures on `main` unrelated to this change — tracked separately in #1147.