### PR TITLE
ci: force rustup proxy on PATH for macos-14 x86_64 builds

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -67,6 +67,18 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Verify cargo resolves to rustup proxy (macos-14 shim workaround)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # macos-14 ARM runners intermittently expose a stale `cargo` on
+          # PATH that resolves to `rustup-init`, breaking `cargo metadata`
+          # invocations from napi-rs (#1136). Force the rustup proxy bin
+          # dir to the front of PATH and fail fast if cargo is unhealthy.
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          "$HOME/.cargo/bin/cargo" --version
+          "$HOME/.cargo/bin/rustc" --version
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -67,14 +67,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Verify cargo resolves to rustup proxy (macos-14 shim workaround)
+      - name: Verify cargo resolves to rustup proxy (macOS shim workaround)
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          # macos-14 ARM runners intermittently expose a stale `cargo` on
-          # PATH that resolves to `rustup-init`, breaking `cargo metadata`
-          # invocations from napi-rs (#1136). Force the rustup proxy bin
-          # dir to the front of PATH and fail fast if cargo is unhealthy.
+          # macOS runners (most often `macos-14` ARM, but also observed on
+          # `macos-latest`/aarch64 builds — see #1136) intermittently expose
+          # a stale `cargo` on PATH that resolves to `rustup-init`, breaking
+          # `cargo metadata` invocations from napi-rs. Force the rustup
+          # proxy bin dir to the front of PATH and fail fast if cargo is
+          # unhealthy. Applied to all macOS matrix entries as a safety net.
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           "$HOME/.cargo/bin/cargo" --version
           "$HOME/.cargo/bin/rustc" --version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,6 +176,18 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Verify cargo resolves to rustup proxy (macos-14 shim workaround)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # macos-14 ARM runners intermittently expose a stale `cargo` on
+          # PATH that resolves to `rustup-init`, breaking `cargo metadata`
+          # invocations from napi-rs (#1136). Force the rustup proxy bin
+          # dir to the front of PATH and fail fast if cargo is unhealthy.
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          "$HOME/.cargo/bin/cargo" --version
+          "$HOME/.cargo/bin/rustc" --version
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,14 +176,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Verify cargo resolves to rustup proxy (macos-14 shim workaround)
+      - name: Verify cargo resolves to rustup proxy (macOS shim workaround)
         if: runner.os == 'macOS'
         shell: bash
         run: |
-          # macos-14 ARM runners intermittently expose a stale `cargo` on
-          # PATH that resolves to `rustup-init`, breaking `cargo metadata`
-          # invocations from napi-rs (#1136). Force the rustup proxy bin
-          # dir to the front of PATH and fail fast if cargo is unhealthy.
+          # macOS runners (most often `macos-14` ARM, but also observed on
+          # `macos-latest`/aarch64 builds — see #1136) intermittently expose
+          # a stale `cargo` on PATH that resolves to `rustup-init`, breaking
+          # `cargo metadata` invocations from napi-rs. Force the rustup
+          # proxy bin dir to the front of PATH and fail fast if cargo is
+          # unhealthy. Applied to all macOS matrix entries as a safety net.
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           "$HOME/.cargo/bin/cargo" --version
           "$HOME/.cargo/bin/rustc" --version


### PR DESCRIPTION
## Summary

- macos-14 ARM runners intermittently expose a stale `cargo` on PATH that resolves to `rustup-init`, breaking napi-rs `cargo metadata` calls during the `Build x86_64-apple-darwin` job (#1136).
- Add a step right after `dtolnay/rust-toolchain` that re-prepends `$HOME/.cargo/bin` to `$GITHUB_PATH` and runs `cargo --version` / `rustc --version` so any future shim regressions fail fast and obviously instead of deep inside `napi build`.
- Same step added to both `build-native.yml` and `publish.yml` (the matrix entry is duplicated across the two workflows).

## Test plan

- [ ] Manually dispatch `Build Native` against this branch and confirm `Build x86_64-apple-darwin` succeeds.
- [ ] Confirm `Verify cargo resolves to rustup proxy` step runs only on macOS jobs and is skipped on Linux/Windows.

Closes #1136