### PR TITLE
fix(hooks): use portable sed for guard-git -C work_dir detection

### DIFF
--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -117,8 +117,14 @@ detect_work_dir() {
   # `git -C` is the explicit git-level override and wins over any ambient cd prefix,
   # so check it first (e.g. `cd /tmp && git -C /worktree push` targets /worktree).
   # Greedy `.*-C` anchors on the LAST `-C` in the chosen segment.
+  # Split into two sed invocations (quoted form, then unquoted) — BSD sed (macOS)
+  # parses `;t;` as a `t` branch to a label named `;s/...`, not as "branch on
+  # substitution made; end statement", so the GNU one-liner errors on macOS.
   if echo "$search_str" | grep -qE 'git\s+([^&|;]*\s)?-C\s+'; then
-    work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+"([^"]+)".*/\1/p;t;s/.*-C[[:space:]]+([^[:space:]]+).*/\1/p')
+    work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+"([^"]+)".*/\1/p')
+    if [ -z "$work_dir" ]; then
+      work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+([^[:space:]]+).*/\1/p')
+    fi
   fi
   if [ -z "$work_dir" ] && echo "$COMMAND" | grep -qE '^\s*cd\s+'; then
     work_dir=$(echo "$COMMAND" | sed -nE 's/^\s*cd\s+"?([^"&]+)"?\s*&&.*/\1/p')


### PR DESCRIPTION
## Summary

- `detect_work_dir()` in `.claude/hooks/guard-git.sh` used a `;t;` chained sed expression that GNU sed accepts but BSD sed (macOS default) rejects with `undefined label`.
- When the sed errored, `work_dir` stayed empty and the hook fell back to the ambient cwd's branch — so `git -C /other-worktree push` from an agent in a worktree like `worktree-agent-XXXX` was always denied even when the targeted worktree had a valid branch.
- Split the one-liner into two sed invocations (quoted form first, unquoted fallback). Behavior is identical on GNU sed and now works on BSD sed.

## Test plan

- [x] Reproduce on macOS: `printf '{"tool_input":{"command":"git -C /tmp push"}}' | bash .claude/hooks/guard-git.sh` — sed error gone.
- [x] `git -C /real-worktree push` against a worktree on a valid branch — no deny.
- [x] Multi-`-C` (last wins): `git -C /a -C /b push` resolves to `/b`.
- [x] Quoted `-C "/path with spaces"` — quoted regex still matches.
- [x] No `-C`, ambient invalid branch — still denied (unchanged behavior).

Closes #1135