### PR TITLE
fix(hooks): guard-git.sh uses [[:space:]] in sed for BSD compatibility

### DIFF
--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -33,8 +33,8 @@ fi
 # the opening `"` of a quoted path (which would leave a trailing `path"` in
 # NCOMMAND). The pattern re-anchors on `git`, so multi-`-C` chains (e.g.
 # `git -C /a -C /b push`) need a second pass to collapse the residual `-C`.
-NCOMMAND=$(echo "$COMMAND" | sed -E 's/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
-NCOMMAND=$(echo "$NCOMMAND" | sed -E 's/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|\s|&&\s*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
+NCOMMAND=$(echo "$COMMAND" | sed -E 's/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
+NCOMMAND=$(echo "$NCOMMAND" | sed -E 's/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
 
 deny() {
   local reason="$1"
@@ -121,7 +121,7 @@ detect_work_dir() {
     work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+"([^"]+)".*/\1/p;t;s/.*-C[[:space:]]+([^[:space:]]+).*/\1/p')
   fi
   if [ -z "$work_dir" ] && echo "$COMMAND" | grep -qE '^\s*cd\s+'; then
-    work_dir=$(echo "$COMMAND" | sed -nE 's/^\s*cd\s+"?([^"&]+)"?\s*&&.*/\1/p')
+    work_dir=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+"?([^"&]+)"?[[:space:]]*&&.*/\1/p')
   fi
   # Trim trailing whitespace
   work_dir="${work_dir%"${work_dir##*[![:space:]]}"}"


### PR DESCRIPTION
## Summary
- BSD sed (macOS default) does not interpret `\s` as whitespace, so the `cd <path> && git ...` extractor and the `git -C` normalization regexes in `.claude/hooks/guard-git.sh` silently produced no output.
- `detect_work_dir` then fell back to the shell cwd's branch, blocking valid pushes from worktrees whose cwd had a non-conformant branch name (e.g. `worktree-agent-<hash>`).
- Replaced all three `\s` sites in sed regexes with `[[:space:]]`, which is portable across BSD and GNU sed.

## Test plan
- [x] Manual: feed the hook a JSON payload with `{"command":"cd /tmp/fake-wt && git push origin HEAD:fix/some-fix"}` while cwd is on a non-conformant branch — hook now exits 0 (previously denied).
- [x] Manual: confirm BSD sed locally treats `\s` as literal `s` and `[[:space:]]` as expected.

Closes #1132