### PR TITLE
refactor(verilog): use if let Some in for-loops instead of ?

### DIFF
--- a/crates/codegraph-core/src/extractors/verilog.rs
+++ b/crates/codegraph-core/src/extractors/verilog.rs
@@ -148,9 +148,10 @@ fn find_class_name(node: &Node, source: &[u8]) -> Option<String> {
         return Some(text.to_string());
     }
     for i in 0..node.child_count() {
-        let child = node.child(i)?;
-        if child.kind() == "class_identifier" {
-            return Some(extract_identifier_text(&child, source));
+        if let Some(child) = node.child(i) {
+            if child.kind() == "class_identifier" {
+                return Some(extract_identifier_text(&child, source));
+            }
         }
     }
     None
@@ -161,12 +162,13 @@ fn find_class_name(node: &Node, source: &[u8]) -> Option<String> {
 /// `class_identifier > simple_identifier`.
 fn find_class_superclass(node: &Node, source: &[u8]) -> Option<String> {
     for i in 0..node.child_count() {
-        let child = node.child(i)?;
-        if child.kind() == "class_type" {
-            if let Some(id) = find_child(&child, "class_identifier") {
-                return Some(extract_identifier_text(&id, source));
+        if let Some(child) = node.child(i) {
+            if child.kind() == "class_type" {
+                if let Some(id) = find_child(&child, "class_identifier") {
+                    return Some(extract_identifier_text(&id, source));
+                }
+                return Some(node_text(&child, source).trim().to_string());
             }
-            return Some(node_text(&child, source).trim().to_string());
         }
     }
     None


### PR DESCRIPTION
## Summary
- Replaces `node.child(i)?` inside `for` loops in `find_class_name` and `find_class_superclass` with `if let Some(child) = node.child(i)`.
- The `?` operator short-circuits the entire enclosing function on the first `None`, not just the current loop iteration. In practice `node.child(i)` returns `Some` for every `i < child_count()`, so this is harmless today, but the `if let Some` form is more defensively correct and matches the pattern already used in `handle_package_import` and `handle_include_directive`.

## Test plan
- [x] `cargo test -p codegraph-core --lib extractors::verilog` (9/9 pass)
- [x] `cargo check -p codegraph-core` (clean)

Closes #1118