### PR TITLE
refactor(objc): use if let Some in for-loop instead of ?

### DIFF
--- a/crates/codegraph-core/src/extractors/objc.rs
+++ b/crates/codegraph-core/src/extractors/objc.rs
@@ -493,13 +493,14 @@ fn collect_class_members(class_node: &Node, source: &[u8]) -> Vec<Definition> {
 fn extract_property_name(prop_node: &Node, source: &[u8]) -> Option<String> {
     let struct_decl = find_child(prop_node, "struct_declaration")?;
     for i in 0..struct_decl.child_count() {
-        let child = struct_decl.child(i)?;
-        if child.kind() == "struct_declarator" {
-            // struct_declarator > pointer_declarator > identifier
-            // or struct_declarator > identifier (no pointer)
-            let name = unwrap_property_declarator(&child, source);
-            if !name.is_empty() {
-                return Some(name);
+        if let Some(child) = struct_decl.child(i) {
+            if child.kind() == "struct_declarator" {
+                // struct_declarator > pointer_declarator > identifier
+                // or struct_declarator > identifier (no pointer)
+                let name = unwrap_property_declarator(&child, source);
+                if !name.is_empty() {
+                    return Some(name);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaces `let child = struct_decl.child(i)?;` inside the `for i in 0..struct_decl.child_count()` loop in `extract_property_name` with `if let Some(child) = struct_decl.child(i)`.
- The `?` operator short-circuits the entire enclosing function on the first `None`, not just the current loop iteration. In practice `node.child(i)` returns `Some` for every `i < child_count()`, so this is harmless today, but `if let Some` is more defensively correct and matches the pattern already used in the Verilog extractor after #1155.
- Completes the broader sweep tracked in #1116. `objc.rs` was the only remaining occurrence of the anti-pattern in `crates/codegraph-core/src/extractors/` (verified via `grep -rnE "for\s+\w+\s+in\s+0\.\." crates/codegraph-core/src/extractors/` followed by checking each loop body).

## Test plan
- [x] \`cargo test -p codegraph-core --lib extractors::objc\` (9/9 pass)

Closes #1116