### PR TITLE
fix(groovy): emit ClassRelation for interface inheritance in both engines

### DIFF
--- a/crates/codegraph-core/src/extractors/groovy.rs
+++ b/crates/codegraph-core/src/extractors/groovy.rs
@@ -555,4 +555,18 @@ mod tests {
             rels
         );
     }
+
+    #[test]
+    fn interface_inheritance_line_tracks_extends_clause() {
+        // Engine-parity guard: the relation line should match the
+        // `extends_interfaces` node's start line, not the `interface_declaration`'s
+        // — `collect_interfaces` re-evaluates `start_line(interfaces)` on every
+        // recursive call, and the WASM extractor must match.
+        let s = parse_groovy("interface Serializable\n  extends Comparable, Cloneable {}");
+        let rels: Vec<_> = s.classes.iter().filter(|c| c.name == "Serializable").collect();
+        assert!(!rels.is_empty(), "expected at least one ClassRelation");
+        for rel in &rels {
+            assert_eq!(rel.line, 2, "line should track the extends clause, got: {:?}", rel);
+        }
+    }
 }

--- a/crates/codegraph-core/src/extractors/groovy.rs
+++ b/crates/codegraph-core/src/extractors/groovy.rs
@@ -158,8 +158,9 @@ fn collect_interfaces(
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let Some(name_node) = node.child_by_field_name("name") else { return };
+    let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
-        name: node_text(&name_node, source).to_string(),
+        name: iface_name.clone(),
         kind: "interface".to_string(),
         line: start_line(node),
         end_line: Some(end_line(node)),
@@ -168,6 +169,18 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
     });
+
+    // `interface X extends Y, Z` — tree-sitter-groovy 0.1.x exposes parent
+    // interfaces as an unnamed `extends_interfaces` child wrapping a `type_list`.
+    // collect_interfaces already recurses into `type_list`, so passing the
+    // wrapper node works without a dedicated helper.
+    for i in 0..node.child_count() {
+        let Some(child) = node.child(i) else { continue };
+        if child.kind() == "extends_interfaces" {
+            collect_interfaces(&child, &iface_name, source, symbols);
+            break;
+        }
+    }
 }
 
 fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
@@ -522,5 +535,24 @@ mod tests {
         assert!(rels.iter().any(|c| c.extends.as_deref() == Some("Base")));
         assert!(rels.iter().any(|c| c.implements.as_deref() == Some("I1")));
         assert!(rels.iter().any(|c| c.implements.as_deref() == Some("I2")));
+    }
+
+    #[test]
+    fn extracts_interface_inheritance() {
+        // `interface X extends Y, Z` — the grammar exposes parent interfaces
+        // via an unnamed `extends_interfaces` child (not a field), distinct
+        // from class declarations which use the `interfaces` field.
+        let s = parse_groovy("interface Serializable extends Comparable, Cloneable {}");
+        let rels: Vec<_> = s.classes.iter().filter(|c| c.name == "Serializable").collect();
+        assert!(
+            rels.iter().any(|c| c.implements.as_deref() == Some("Comparable")),
+            "missing implements=Comparable, got: {:?}",
+            rels
+        );
+        assert!(
+            rels.iter().any(|c| c.implements.as_deref() == Some("Cloneable")),
+            "missing implements=Cloneable, got: {:?}",
+            rels
+        );
     }
 }

--- a/src/extractors/groovy.ts
+++ b/src/extractors/groovy.ts
@@ -157,7 +157,7 @@ function handleGroovyInterfaceDecl(node: TreeSitterNode, ctx: ExtractorOutput): 
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     if (child && child.type === 'extends_interfaces') {
-      collectGroovyParentInterfaces(child, ifaceName, node.startPosition.row + 1, ctx);
+      collectGroovyParentInterfaces(child, ifaceName, ctx);
       break;
     }
   }
@@ -166,9 +166,12 @@ function handleGroovyInterfaceDecl(node: TreeSitterNode, ctx: ExtractorOutput): 
 function collectGroovyParentInterfaces(
   parent: TreeSitterNode,
   name: string,
-  line: number,
   ctx: ExtractorOutput,
 ): void {
+  // Use the current node's start line at each recursion level — matches the
+  // Rust `collect_interfaces` helper, which re-evaluates `start_line(interfaces)`
+  // for whatever node (`extends_interfaces` → `type_list`) is being processed.
+  const line = parent.startPosition.row + 1;
   for (let i = 0; i < parent.childCount; i++) {
     const child = parent.child(i);
     if (!child) continue;
@@ -185,7 +188,7 @@ function collectGroovyParentInterfaces(
         break;
       }
       case 'type_list':
-        collectGroovyParentInterfaces(child, name, line, ctx);
+        collectGroovyParentInterfaces(child, name, ctx);
         break;
     }
   }

--- a/src/extractors/groovy.ts
+++ b/src/extractors/groovy.ts
@@ -141,14 +141,54 @@ function handleGroovyClassDecl(node: TreeSitterNode, ctx: ExtractorOutput): void
 function handleGroovyInterfaceDecl(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const nameNode = node.childForFieldName('name');
   if (!nameNode) return;
+  const ifaceName = nameNode.text;
 
   ctx.definitions.push({
-    name: nameNode.text,
+    name: ifaceName,
     kind: 'interface',
     line: node.startPosition.row + 1,
     endLine: nodeEndLine(node),
     visibility: extractModifierVisibility(node),
   });
+
+  // `interface X extends Y, Z` — tree-sitter-groovy 0.1.x exposes parent
+  // interfaces via an unnamed `extends_interfaces` child (not a field), which
+  // wraps a `type_list` of `_type` nodes. Mirrors the Rust extractor.
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child && child.type === 'extends_interfaces') {
+      collectGroovyParentInterfaces(child, ifaceName, node.startPosition.row + 1, ctx);
+      break;
+    }
+  }
+}
+
+function collectGroovyParentInterfaces(
+  parent: TreeSitterNode,
+  name: string,
+  line: number,
+  ctx: ExtractorOutput,
+): void {
+  for (let i = 0; i < parent.childCount; i++) {
+    const child = parent.child(i);
+    if (!child) continue;
+    switch (child.type) {
+      case 'type_identifier':
+      case 'identifier':
+      case 'scoped_type_identifier': {
+        ctx.classes.push({ name, implements: child.text, line });
+        break;
+      }
+      case 'generic_type': {
+        const inner = child.child(0)?.text;
+        if (inner) ctx.classes.push({ name, implements: inner, line });
+        break;
+      }
+      case 'type_list':
+        collectGroovyParentInterfaces(child, name, line, ctx);
+        break;
+    }
+  }
 }
 
 function handleGroovyEnumDecl(node: TreeSitterNode, ctx: ExtractorOutput): void {

--- a/tests/parsers/groovy.test.ts
+++ b/tests/parsers/groovy.test.ts
@@ -64,6 +64,20 @@ describe('Groovy parser', () => {
     );
   });
 
+  it('reports line of extends_interfaces clause for multi-line declarations', () => {
+    // Engine-parity guard: the line should match the `extends_interfaces`
+    // node's start line, not the `interface_declaration`'s start line, so the
+    // WASM extractor stays consistent with the Rust `collect_interfaces`
+    // helper which re-evaluates the current node's `start_line` at each
+    // recursion level.
+    const symbols = parseGroovy(`interface Serializable\n  extends Comparable, Cloneable {}`);
+    const rels = symbols.classes.filter((c) => c.name === 'Serializable');
+    expect(rels.length).toBeGreaterThan(0);
+    for (const rel of rels) {
+      expect(rel.line).toBe(2);
+    }
+  });
+
   it('extracts enum declarations', () => {
     const symbols = parseGroovy(`enum Color {
     RED, GREEN, BLUE

--- a/tests/parsers/groovy.test.ts
+++ b/tests/parsers/groovy.test.ts
@@ -50,6 +50,20 @@ describe('Groovy parser', () => {
     );
   });
 
+  it('extracts interface inheritance (extends_interfaces)', () => {
+    // `interface X extends Y, Z` — the grammar exposes parent interfaces via
+    // an unnamed `extends_interfaces` child (not a field), distinct from class
+    // declarations which use the `interfaces` field.
+    const symbols = parseGroovy(`interface Serializable extends Comparable, Cloneable {}`);
+    const rels = symbols.classes.filter((c) => c.name === 'Serializable');
+    expect(rels).toContainEqual(
+      expect.objectContaining({ name: 'Serializable', implements: 'Comparable' }),
+    );
+    expect(rels).toContainEqual(
+      expect.objectContaining({ name: 'Serializable', implements: 'Cloneable' }),
+    );
+  });
+
   it('extracts enum declarations', () => {
     const symbols = parseGroovy(`enum Color {
     RED, GREEN, BLUE


### PR DESCRIPTION
## Summary

- `interface X extends Y, Z` produced no class-graph edges because both Groovy extractors pushed a single `Definition` for the interface but never inspected the unnamed `extends_interfaces` child.
- The Rust handler now reuses the existing `collect_interfaces` helper (which already recurses into `type_list`); the TS handler gains an equivalent `collectGroovyParentInterfaces` helper that mirrors the same traversal.
- Both engines emit `ClassRelation { name: X, implements: Y, line }` for each parent interface — consistent with the existing `collect_interfaces` helper, with class-implements behavior, and with the downstream `IMPLEMENTS_TARGET_KINDS` filter that already accepts interface targets.

## Notes

- `tree-sitter-groovy` 0.1.x exposes parent interfaces as an unnamed `extends_interfaces` child of `interface_declaration` (not a field), distinct from class declarations which use the `interfaces` field that wraps `super_interfaces → type_list`.
- This PR fixes the extraction layer only. The downstream `HIERARCHY_SOURCE_KINDS` set in `src/domain/graph/builder/stages/build-edges.ts` does not currently include `interface`, so emitted relations still won't materialize as graph edges until that filter is extended — that's a broader cross-language change worth tracking separately.

Closes #1115

## Test plan

- [x] `cargo test -p codegraph-core --lib extractors::groovy` — new `extracts_interface_inheritance` test passes alongside existing 8 tests
- [x] `npx vitest run tests/parsers/groovy.test.ts` — new `extracts interface inheritance (extends_interfaces)` test passes alongside existing 6 tests
- [x] `npx biome check src/extractors/groovy.ts tests/parsers/groovy.test.ts` — clean