### PR TITLE
build: restore libc discriminator on linux lockfile entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           node-version: 22
 
+      # Runs before `npm install` because npm 11 silently strips the `libc`
+      # field from optional-dependency lockfile entries (see #1160). If the
+      # check ran post-install we'd flag every CI run instead of the PRs that
+      # actually introduce the regression.
+      - name: Verify lockfile libc discriminators
+        run: node scripts/verify-lockfile-libc.mjs
+
       - name: Install dependencies
         timeout-minutes: 20
         shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,6 +1478,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1491,6 +1494,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1503,6 +1509,9 @@
       "integrity": "sha512-+wyAT+aWAE1QBbDe5dqwUoB7mB/UUsO6B1ndSevBBjR0rg9refK9zIZdf08rBe1Tfqft89iIVn1uq+yQx7e4aw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/scripts/verify-lockfile-libc.mjs
+++ b/scripts/verify-lockfile-libc.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Verifies that @optave/codegraph-linux-* entries in package-lock.json declare
+// the `libc` discriminator. npm 11 silently strips this field when generating
+// the lockfile on non-Linux hosts (and sometimes on Linux too), even though the
+// published packages declare it. Without it, npm cannot disambiguate
+// linux-x64-gnu vs linux-x64-musl when resolving from the lockfile and may
+// install (or load) the wrong native binary on Alpine/musl hosts.
+//
+// Run via `npm run lint` (or directly) in CI to catch silent regressions from
+// Dependabot bumps and contributor `npm install` runs.
+import { readFileSync } from 'node:fs';
+
+const EXPECTED_LIBC = {
+  '@optave/codegraph-linux-arm64-gnu': 'glibc',
+  '@optave/codegraph-linux-x64-gnu': 'glibc',
+  '@optave/codegraph-linux-x64-musl': 'musl',
+};
+
+const lock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
+const failures = [];
+
+for (const [pkgName, expectedLibc] of Object.entries(EXPECTED_LIBC)) {
+  const entry = lock.packages?.[`node_modules/${pkgName}`];
+  if (!entry) {
+    failures.push(`${pkgName}: missing from package-lock.json`);
+    continue;
+  }
+  const libc = entry.libc;
+  if (!Array.isArray(libc) || !libc.includes(expectedLibc)) {
+    failures.push(
+      `${pkgName}: expected libc=["${expectedLibc}"], got ${JSON.stringify(libc)}`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('package-lock.json libc discriminator check failed:\n');
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    '\nnpm install may have stripped the libc field. Restore it by editing\n' +
+      'package-lock.json so each @optave/codegraph-linux-* entry includes\n' +
+      'its libc field (see expected values above). Tracked in #1160.',
+  );
+  process.exit(1);
+}
+
+console.log('package-lock.json libc discriminators OK');

--- a/scripts/verify-lockfile-libc.mjs
+++ b/scripts/verify-lockfile-libc.mjs
@@ -9,6 +9,8 @@
 // Run via `npm run lint` (or directly) in CI to catch silent regressions from
 // Dependabot bumps and contributor `npm install` runs.
 import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const EXPECTED_LIBC = {
   '@optave/codegraph-linux-arm64-gnu': 'glibc',
@@ -16,7 +18,12 @@ const EXPECTED_LIBC = {
   '@optave/codegraph-linux-x64-musl': 'musl',
 };
 
-const lock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
+// Resolve relative to this script's location so it works regardless of CWD
+// (e.g. running `node scripts/verify-lockfile-libc.mjs` from the `scripts/`
+// subdirectory still finds the repo-root lockfile).
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const lockfilePath = resolve(__dirname, '..', 'package-lock.json');
+const lock = JSON.parse(readFileSync(lockfilePath, 'utf8'));
 const failures = [];
 
 for (const [pkgName, expectedLibc] of Object.entries(EXPECTED_LIBC)) {


### PR DESCRIPTION
## Summary

- Restore the `libc` field on `@optave/codegraph-linux-{arm64-gnu,x64-gnu,x64-musl}` entries in `package-lock.json`. npm 11 silently strips this field on `npm install`, even though the published packages declare it (`npm view @optave/codegraph-linux-x64-musl libc` → `'musl'`).
- Add `scripts/verify-lockfile-libc.mjs` and wire it into the `lint` CI job **before** the `npm install` step, so any PR (including Dependabot bumps) that lands a lockfile missing the discriminator now fails fast.

Without the discriminator, npm cannot disambiguate `linux-x64-gnu` vs `linux-x64-musl` when resolving from the lockfile, so the wrong native binary may load on Alpine/musl hosts.

Investigation: the strip behavior is reproducible with npm 11.6.0 even after `npm cache clean --force`, and affects other napi-rs projects (e.g. `@biomejs/cli-linux-*` entries in this same lockfile). There is no root-`package.json` field that constrains libc on optional deps, so the only robust fix is to commit the field directly and guard regressions in CI.

Closes #1160

## Test plan
- [x] `node scripts/verify-lockfile-libc.mjs` passes on the new lockfile
- [x] Manually stripped libc and re-ran the verifier — exits 1 with a clear message naming each missing entry
- [x] Confirmed npm 11.6.0 strips libc on `npm install --package-lock-only --ignore-scripts` (which is why the CI step runs **before** install)
- [ ] CI lint job passes on the PR