### PR TITLE
fix(test): use --experimental-strip-types in Worker execArgv

### DIFF
--- a/tests/unit/snapshot.test.ts
+++ b/tests/unit/snapshot.test.ts
@@ -149,16 +149,16 @@ describe('snapshotSave', () => {
   // snapshotSave. better-sqlite3 is synchronous, so Promise-based
   // concurrency would queue two sequential microtasks — only separate
   // threads exercise the TOCTOU race.
-  const nodeMajor = Number(process.versions.node.split('.')[0]);
   const raceWorkerPath = path.join(__dirname, 'snapshot-race-worker.mjs');
   // --import requires a URL (file://…) or a bare/relative specifier, not a
   // drive-letter path on Windows. Use the file:// URL directly.
   const loaderUrl = new URL('../../scripts/ts-resolve-loader.js', import.meta.url).href;
-  const raceExecArgv = [
-    nodeMajor >= 23 ? '--strip-types' : '--experimental-strip-types',
-    '--import',
-    loaderUrl,
-  ];
+  // `--experimental-strip-types` is accepted by Worker execArgv across all
+  // supported Node versions (≥ 22.6); the unprefixed `--strip-types` flag
+  // is not in the Worker allowlist on Node 24 and causes
+  // ERR_WORKER_INVALID_EXEC_ARGV. On Node ≥ 23.6 type stripping is on by
+  // default, so the flag is a harmless no-op there.
+  const raceExecArgv = ['--experimental-strip-types', '--import', loaderUrl];
   const spawnSaveWorker = (workerData: {
     dbPath: string;
     name: string;


### PR DESCRIPTION
## Summary

- Snapshot concurrent-save tests passed `--strip-types` to `Worker` execArgv on Node ≥ 23, but Node 24 removed it from the Worker allowlist — both workers exited with `ERR_WORKER_INVALID_EXEC_ARGV` before posting a message, so `Promise.allSettled` returned two rejections and the two race tests failed locally on `main`.
- Switch unconditionally to `--experimental-strip-types`, which is accepted by Worker execArgv on every supported Node version (≥ 22.6) and is a harmless no-op on Node ≥ 23.6 where type stripping is default-on.

## Test plan

- [x] `npx vitest run tests/unit/snapshot.test.ts` — 29/29 pass locally on Node 24.10
- [x] Re-ran 5× to check for flakiness — all green
- [x] `npx biome check tests/unit/snapshot.test.ts` — clean

Closes #1117