### PR TITLE
ci: isolate dropped-language-gap.test.ts as a regression canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,18 @@ jobs:
           CODEGRAPH_PARITY: '1'
         run: npx vitest run tests/engines/ tests/integration/build-parity.test.ts --reporter=verbose
 
+      # Isolated regression canary for #1147 — runs only the dropped-language-gap
+      # suite so a failure surfaces under a clear step name and can't be masked
+      # by pollution from neighbouring tests in the larger `test` job. The gap
+      # repair path (#1083) is load-bearing for engine parity but easy to break
+      # silently — the bug shape is "node row never re-inserted", which only
+      # this test exercises directly.
+      - name: Dropped-language gap regression guard (#1147)
+        shell: bash
+        env:
+          CODEGRAPH_PARITY: '1'
+        run: npx vitest run tests/integration/dropped-language-gap.test.ts --reporter=verbose
+
   rust-check:
     runs-on: ubuntu-latest
     name: Rust compile check


### PR DESCRIPTION
## Summary
- Add an isolated CI step in the engine-parity job that runs only `tests/integration/dropped-language-gap.test.ts` with `CODEGRAPH_PARITY=1`, on all three OS runners.
- The broader `test` job already runs this file as part of `npm test`, but a failure there gets buried in 500+ test names. The standalone step gives the gap-repair canary its own visible status check on every PR.

## Why
Issue #1147 reported that both tests in `dropped-language-gap.test.ts` fail on `main` (commit c7e600a). I could not reproduce locally or via CI history:
- Local run on `origin/main` (a029d43): both tests pass.
- Local run on `c7e600a` (in a temporary worktree using the same `node_modules` + grammars): both tests pass.
- CI on c7e600a, on PR #1123 (where the tests were added), and on the most recent completed main run (81150e4): all green, including the `Engine parity` matrix on Linux/macOS/Windows.
- The only `pipeline.ts` diff between c7e600a and `origin/main` is #1148's removal of a duplicate `if (missingAbs.length === 0) return;` — pure dead-code removal, semantically identical, so it can't change test outcome.

Rather than close the issue purely on "I can't reproduce", this PR adds an isolated guard so any future regression of the gap-repair path (#1083) — exactly the bug shape #1147 described, "node row never re-inserted" — surfaces under its own clear name and rules out test pollution from other files in the larger suite as a cause.

## Test plan
- [x] `npx vitest run tests/integration/dropped-language-gap.test.ts --reporter=verbose` passes locally with `CODEGRAPH_PARITY=1` (matches the new step exactly).
- [x] YAML lint clean (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [ ] Verify the new `Dropped-language gap regression guard (#1147)` step shows up green on the parity matrix in this PR's CI.

Refs #1147