### PR TITLE
fix(cli): accept -d/--db on build to match every other DB-scoped command

### DIFF
--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -7,6 +7,7 @@ export const command: CommandDefinition = {
   name: 'build [dir]',
   description: 'Parse repo and build graph in .codegraph/graph.db',
   options: [
+    ['-d, --db <path>', 'Path to graph.db (default: <dir>/.codegraph/graph.db)'],
     ['--no-incremental', 'Force full rebuild (ignore file hashes)'],
     ['--no-ast', 'Skip AST node extraction (calls, new, string, regex, throw, await)'],
     ['--no-complexity', 'Skip complexity metrics computation'],
@@ -23,6 +24,7 @@ export const command: CommandDefinition = {
       engine: engine as EngineMode,
       dataflow: opts.dataflow as boolean,
       cfg: opts.cfg as boolean,
+      dbPath: opts.db ? path.resolve(opts.db as string) : undefined,
     });
   },
 };

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -167,7 +167,9 @@ function loadAliases(ctx: PipelineContext): void {
 
 function setupPipeline(ctx: PipelineContext): void {
   ctx.rootDir = path.resolve(ctx.rootDir);
-  ctx.dbPath = path.join(ctx.rootDir, '.codegraph', 'graph.db');
+  ctx.dbPath = ctx.opts.dbPath
+    ? path.resolve(ctx.opts.dbPath)
+    : path.join(ctx.rootDir, '.codegraph', 'graph.db');
 
   // Detect whether native engine is available.
   const enginePref = ctx.opts.engine || 'auto';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1072,6 +1072,12 @@ export interface BuildGraphOpts {
    */
   exclude?: string[];
   skipRegistry?: boolean;
+  /**
+   * Override the graph.db location. Resolved absolute. When omitted, the
+   * pipeline writes to `<rootDir>/.codegraph/graph.db` — same default as
+   * `findDbPath` for every other DB-scoped command.
+   */
+  dbPath?: string;
 }
 
 /** Build timing result from buildGraph. */

--- a/tests/integration/build.test.ts
+++ b/tests/integration/build.test.ts
@@ -153,6 +153,48 @@ describe('buildGraph', () => {
   });
 });
 
+describe('buildGraph with custom dbPath (issue #1177)', () => {
+  let customDir: string, customDbPath: string;
+
+  beforeAll(async () => {
+    customDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-custom-db-'));
+    for (const [name, content] of Object.entries(FIXTURE_FILES)) {
+      fs.writeFileSync(path.join(customDir, name), content);
+    }
+    customDbPath = path.join(os.tmpdir(), `codegraph-custom-${Date.now()}.db`);
+    await buildGraph(customDir, { skipRegistry: true, dbPath: customDbPath });
+  });
+
+  afterAll(() => {
+    if (customDir) fs.rmSync(customDir, { recursive: true, force: true });
+    if (customDbPath && fs.existsSync(customDbPath)) {
+      fs.rmSync(customDbPath, { force: true });
+      // Clean up sidecar WAL/SHM files
+      for (const ext of ['-wal', '-shm', '.lock']) {
+        const sidecar = `${customDbPath}${ext}`;
+        if (fs.existsSync(sidecar)) fs.rmSync(sidecar, { force: true });
+      }
+    }
+  });
+
+  test('writes DB to the custom path, not <rootDir>/.codegraph/graph.db', () => {
+    expect(fs.existsSync(customDbPath)).toBe(true);
+    expect(fs.existsSync(path.join(customDir, '.codegraph', 'graph.db'))).toBe(false);
+  });
+
+  test('custom DB contains expected nodes and edges', () => {
+    const db = new Database(customDbPath, { readonly: true });
+    const files = db
+      .prepare("SELECT file FROM nodes WHERE kind = 'file'")
+      .all()
+      .map((r) => r.file);
+    db.close();
+    expect(files).toContain('math.js');
+    expect(files).toContain('utils.js');
+    expect(files).toContain('index.js');
+  });
+});
+
 describe('three-tier incremental builds', () => {
   let incrDir: string, incrDbPath: string;
 


### PR DESCRIPTION
## Summary

- `codegraph build [dir] --db <path>` was rejected with `error: unknown option '--db'`, even though every other DB-scoped command (`stats`, `query`, `where`, `watch`, `snapshot`, …) honors it. The asymmetry blocked dogfooding workflows that need an isolated DB and surprised users who reasonably expected the flag to work on the **most** DB-scoped command.
- Adds `-d, --db <path>` to `build`, plumbs it through `BuildGraphOpts.dbPath`, and lets `setupPipeline` resolve it absolute (falling back to `<rootDir>/.codegraph/graph.db`). Mirrors `watch`'s pattern from #987 verbatim.
- Native orchestrator path is unaffected — `NativeDatabase.openReadWrite(ctx.dbPath)` already drives the Rust side off the same `ctx.dbPath`, so the override flows through both engines.

Closes #1177.

## Test plan

- [x] `npx vitest run tests/integration/build.test.ts` — 21/21 pass, including 2 new tests in the `buildGraph with custom dbPath (issue #1177)` block (verifies DB lands at the custom path AND that `<rootDir>/.codegraph/graph.db` is NOT created).
- [x] `npx vitest run tests/integration/cli.test.ts` — 29/29 pass.
- [x] `tsc --noEmit` clean.
- [x] End-to-end: `codegraph build <dir> --db /tmp/custom.db` writes there; `--help` shows the new flag with default annotation.

## Notes

The change journal still writes to `<rootDir>/.codegraph/journal.ndjson` regardless of `--db`, matching `watch`'s existing precedent — `--db` overrides the DB location only, not the project's `.codegraph/` directory. If full isolation is needed for dogfooding workflows, that's a small follow-up (the journal path is computed independently in `journal.rs` and `journal.ts`).