### PR TITLE
fix(build): accept -d/--db to point at a graph.db outside cwd

### DIFF
--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -7,6 +7,7 @@ export const command: CommandDefinition = {
   name: 'build [dir]',
   description: 'Parse repo and build graph in .codegraph/graph.db',
   options: [
+    ['-d, --db <path>', 'Path to graph.db'],
     ['--no-incremental', 'Force full rebuild (ignore file hashes)'],
     ['--no-ast', 'Skip AST node extraction (calls, new, string, regex, throw, await)'],
     ['--no-complexity', 'Skip complexity metrics computation'],
@@ -23,6 +24,7 @@ export const command: CommandDefinition = {
       engine: engine as EngineMode,
       dataflow: opts.dataflow as boolean,
       cfg: opts.cfg as boolean,
+      dbPath: opts.db ? path.resolve(opts.db as string) : undefined,
     });
   },
 };

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -167,7 +167,9 @@ function loadAliases(ctx: PipelineContext): void {
 
 function setupPipeline(ctx: PipelineContext): void {
   ctx.rootDir = path.resolve(ctx.rootDir);
-  ctx.dbPath = path.join(ctx.rootDir, '.codegraph', 'graph.db');
+  ctx.dbPath = ctx.opts.dbPath
+    ? path.resolve(ctx.opts.dbPath)
+    : path.join(ctx.rootDir, '.codegraph', 'graph.db');
 
   // Detect whether native engine is available.
   const enginePref = ctx.opts.engine || 'auto';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1072,6 +1072,10 @@ export interface BuildGraphOpts {
    */
   exclude?: string[];
   skipRegistry?: boolean;
+  /**
+   * Absolute path to the graph.db file. Defaults to `<rootDir>/.codegraph/graph.db`.
+   */
+  dbPath?: string;
 }
 
 /** Build timing result from buildGraph. */

--- a/tests/builder/pipeline.test.ts
+++ b/tests/builder/pipeline.test.ts
@@ -81,4 +81,17 @@ describe('buildGraph pipeline', () => {
     const { buildGraph: fromBarrel } = await import('../../src/domain/graph/builder.js');
     expect(fromBarrel).toBe(buildGraph);
   });
+
+  it('writes the DB to opts.dbPath when provided', async () => {
+    const customDbPath = path.join(tmpDir, 'custom', 'graph.db');
+    await buildGraph(tmpDir, { incremental: false, dbPath: customDbPath });
+
+    expect(fs.existsSync(customDbPath)).toBe(true);
+
+    const Database = (await import('better-sqlite3')).default;
+    const db = new Database(customDbPath, { readonly: true });
+    const nodeCount = (db.prepare('SELECT COUNT(*) as c FROM nodes').get() as { c: number }).c;
+    expect(nodeCount).toBeGreaterThan(0);
+    db.close();
+  });
 });


### PR DESCRIPTION
## Summary

Every other DB-scoped command (`stats`, `query`, `where`, `watch`, `fn-impact`, `audit`, ...) accepts `-d, --db <path>`. `build` did not — it rejected the flag with `error: unknown option '--db'`, forcing dogfooding and multi-repo workflows to either `cd` into the source directory or clobber the default `.codegraph/graph.db`.

Add the option, plumb it through `BuildGraphOpts.dbPath` into `setupPipeline`, and fall back to `<rootDir>/.codegraph/graph.db` when absent. Mirrors PR #987's wire-up for `watch --db` — same rationale, same shape.

Closes #1177

## Test plan

- [x] `codegraph build --help` shows `-d, --db <path>`
- [x] `codegraph build <dir> --db <path>` writes the graph to the specified DB and not to the default location
- [x] `codegraph build <dir>` (no `--db`) behaves exactly as before
- [x] New unit test in `tests/builder/pipeline.test.ts` covers `opts.dbPath`
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (no new warnings)
- [x] All 60 builder + integration build tests pass