### PR TITLE
fix(native/cpp): strip reference modifier from parameter names

### DIFF
--- a/crates/codegraph-core/src/extractors/cpp.rs
+++ b/crates/codegraph-core/src/extractors/cpp.rs
@@ -100,8 +100,7 @@ fn next_cpp_declarator_child<'a>(node: &Node<'a>) -> Option<Node<'a>> {
                 | "pointer_declarator"
                 | "reference_declarator"
                 | "array_declarator"
-                | "parenthesized_declarator"
-                | "function_declarator" => return Some(child),
+                | "parenthesized_declarator" => return Some(child),
                 _ => {}
             }
         }

--- a/crates/codegraph-core/src/extractors/cpp.rs
+++ b/crates/codegraph-core/src/extractors/cpp.rs
@@ -71,7 +71,14 @@ fn unwrap_cpp_declarator(node: &Node, source: &[u8]) -> String {
         match current.kind() {
             "pointer_declarator" | "reference_declarator" | "array_declarator"
             | "parenthesized_declarator" => {
-                if let Some(inner) = current.child_by_field_name("declarator") {
+                // tree-sitter-cpp's `reference_declarator` rule does not expose a
+                // `declarator` field, so `child_by_field_name` returns None and
+                // the full node text (`& name`) leaks out. Fall back to scanning
+                // children for the next nested declarator or identifier.
+                let inner = current
+                    .child_by_field_name("declarator")
+                    .or_else(|| next_cpp_declarator_child(&current));
+                if let Some(inner) = inner {
                     current = inner;
                 } else {
                     break;
@@ -82,6 +89,24 @@ fn unwrap_cpp_declarator(node: &Node, source: &[u8]) -> String {
         }
     }
     node_text(&current, source).to_string()
+}
+
+fn next_cpp_declarator_child<'a>(node: &Node<'a>) -> Option<Node<'a>> {
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            match child.kind() {
+                "identifier"
+                | "field_identifier"
+                | "pointer_declarator"
+                | "reference_declarator"
+                | "array_declarator"
+                | "parenthesized_declarator"
+                | "function_declarator" => return Some(child),
+                _ => {}
+            }
+        }
+    }
+    None
 }
 
 fn extract_cpp_function_name(node: &Node, source: &[u8]) -> Option<String> {
@@ -432,5 +457,27 @@ mod tests {
         let s = parse_cpp("#include <iostream>\n#include \"mylib.hpp\"");
         assert_eq!(s.imports.len(), 2);
         assert!(s.imports[0].c_include.unwrap());
+    }
+
+    #[test]
+    fn reference_parameter_name_strips_ampersand() {
+        // tree-sitter-cpp's `reference_declarator` does not expose a `declarator`
+        // field, so the unwrap helper has to scan children for the underlying
+        // identifier — otherwise the parameter name comes back as `& action`.
+        let s = parse_cpp("void log_action(const std::string& action) {}");
+        let func = s.definitions.iter().find(|d| d.name == "log_action").unwrap();
+        let params = func.children.as_ref().expect("function has children");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, "action");
+        assert_eq!(params[0].kind, "parameter");
+    }
+
+    #[test]
+    fn rvalue_reference_parameter_name_strips_ampersand() {
+        let s = parse_cpp("void take(int&& x) {}");
+        let func = s.definitions.iter().find(|d| d.name == "take").unwrap();
+        let params = func.children.as_ref().expect("function has children");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, "x");
     }
 }


### PR DESCRIPTION
## Summary

- Native C++ extractor was emitting parameter nodes named `& action` for `const std::string& action`, while WASM emitted `action`. Same source line, divergent node name → divergent `contains` and `parameter_of` edges across engines.
- Root cause: tree-sitter-cpp's `reference_declarator` rule (covering both `&` and `&&`) doesn't expose a `declarator` field, so `child_by_field_name("declarator")` returns `None` and `unwrap_cpp_declarator` falls through to emitting the full node text. `pointer_declarator` doesn't have this problem because its grammar rule does set the field.
- Fix: when the field lookup misses inside `unwrap_cpp_declarator`, scan children for the next nested declarator or identifier. Applies transitively to parameters, fields, type-map entries, and function-name extraction since they all route through this helper.

This was surfaced by the cross-engine edge comparison in the v3.10.1-dev.80 dogfood report (suggestion 10.2) and accounts for the C++ portion of the `parameter_of -35` / `contains -51` deltas observed there.

## Test plan

- [x] New regression tests `reference_parameter_name_strips_ampersand` and `rvalue_reference_parameter_name_strips_ampersand` fail on `main` (`left: "& action"`, `left: "&& x"`) and pass with the fix
- [x] `cargo test -p codegraph-core --lib` — 312/312 pass
- [ ] On CI: native build picks up the change and cross-engine C++ `contains` / `parameter_of` deltas in `tests/benchmarks/resolution/fixtures/cpp` drop to zero

Closes #1187