### PR TITLE
fix(db): stop findDbPath walk at cwd when no git ceiling

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -292,6 +292,14 @@ export function findDbPath(customPath?: string): string {
       debug(`findDbPath: stopped at git ceiling ${ceiling}`);
       break;
     }
+    // Outside a git repo, cwd is the first (and only) directory we'll check.
+    // Walking past it risks attaching to a stale .codegraph/ in an unrelated
+    // parent — e.g. /private/tmp/.codegraph/ leaking into every /tmp/foo/ run,
+    // or $HOME/.codegraph/ leaking into every scratch dir under $HOME.
+    if (!ceiling) {
+      debug(`findDbPath: no git ceiling, stopping at ${dir}`);
+      break;
+    }
     const parent = path.dirname(dir);
     if (parent === dir) break;
     dir = parent;

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -350,6 +350,33 @@ describe('findDbPath with git ceiling', () => {
       fs.rmSync(emptyDir, { recursive: true, force: true });
     }
   });
+
+  it('does not pick up stale parent .codegraph/ when no git repo exists', () => {
+    // Regression for the Phase 0 footgun (dogfood report 10.6): when no git
+    // repo wraps cwd, findDbPath used to walk all the way to `/`, latching
+    // onto stale .codegraph/ from unrelated parents (e.g. /private/tmp/).
+    const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-stale-parent-'));
+    fs.mkdirSync(path.join(parentDir, '.codegraph'), { recursive: true });
+    fs.writeFileSync(path.join(parentDir, '.codegraph', 'graph.db'), '');
+    const innerDir = path.join(parentDir, 'inner');
+    fs.mkdirSync(innerDir, { recursive: true });
+    const origCwd = process.cwd;
+    process.cwd = () => innerDir;
+    _resetRepoRootCache();
+    execFileSyncSpy.mockImplementationOnce(() => {
+      throw new Error('not a git repo');
+    });
+    try {
+      const result = findDbPath();
+      // Must NOT return the stale parent's DB.
+      expect(result).not.toBe(path.join(parentDir, '.codegraph', 'graph.db'));
+      // Falls back to the default path at cwd.
+      expect(result).toBe(path.join(innerDir, '.codegraph', 'graph.db'));
+    } finally {
+      process.cwd = origCwd;
+      fs.rmSync(parentDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('openReadonlyOrFail', () => {


### PR DESCRIPTION
## Summary

- `findDbPath` no longer walks past cwd when not in a git repo, preventing stale `.codegraph/` in unrelated parents (e.g. `/private/tmp/`, `$HOME/`) from being silently picked up.
- Surfaced as the "Phase 0 footgun" in the v3.10.1-dev.80 dogfood report (§10.6): running codegraph from `/tmp/dogfood-…` attached to a stale `/private/tmp/.codegraph/graph.db` left over from a previous unrelated session.
- Git-rooted case is unchanged — the git toplevel still acts as the ceiling.

## Trade-off

Users running codegraph from a subdirectory of a non-git "project" used to auto-discover a parent `.codegraph/`. They now need to `cd` to the project root, `git init`, or pass `-d/--db`. This aligns with codegraph's git-centric design and removes the silent-attachment footgun.

## Test plan

- [x] `npx vitest run tests/unit/db.test.ts` — 26 passed (including new regression test "does not pick up stale parent .codegraph/ when no git repo exists" and all existing git-ceiling tests)
- [x] `npx vitest run tests/unit/db.test.ts tests/unit/snapshot.test.ts` — 55 passed
- [x] `npx vitest run tests/integration/structure.test.ts tests/integration/cli.test.ts` — 45 passed
- [x] `npm run build` — succeeds
- [x] Biome lint clean on changed files
- [x] Manual smoke: from `/tmp/cg-smoke-parent/inner/` with stale `/tmp/cg-smoke-parent/.codegraph/graph.db` → returns `/private/tmp/cg-smoke-parent/inner/.codegraph/graph.db` (not the parent)
- [x] Manual smoke: from inside a git worktree → returns the worktree's `.codegraph/graph.db` (unchanged behavior)