### PR TITLE
fix(native/csharp): align extractor with WASM on three engine-parity divergences

### DIFF
--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -114,14 +114,17 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             let Some(child) = body.child(i) else { continue };
             if child.kind() != "method_declaration" { continue; }
             if let Some(meth_name) = child.child_by_field_name("name") {
+                // Interface method declarations have no body — skip CFG and complexity
+                // to mirror the WASM extractor and avoid producing meaningless metrics
+                // for body-less declarations.
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", iface_name, node_text(&meth_name, source)),
                     kind: "method".to_string(),
                     line: start_line(&child),
                     end_line: Some(end_line(&child)),
                     decorators: None,
-                    complexity: compute_all_metrics(&child, source, "csharp"),
-                    cfg: build_function_cfg(&child, "csharp", source),
+                    complexity: None,
+                    cfg: None,
                     children: None,
                 });
             }
@@ -365,6 +368,12 @@ fn extract_csharp_enum_members(node: &Node, source: &[u8]) -> Vec<Definition> {
 /// is a known interface in the same file. At extraction time we cannot distinguish
 /// base classes from interfaces in the base_list, so we fix it up here using the
 /// definitions collected during the walk.
+///
+/// Known limitation (mirrors the WASM `reclassifyCSharpImplements`): this pass only
+/// inspects interfaces declared in the current file. Classes that implement an
+/// interface declared in a different file will keep the entry as `extends` and will
+/// surface as inheritance edges rather than implementation edges. Cross-file
+/// reclassification would require a project-wide post-build pass.
 fn reclassify_csharp_implements(symbols: &mut FileSymbols) {
     let interfaces: HashSet<String> = symbols
         .definitions

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -3,6 +3,7 @@ use super::SymbolExtractor;
 use crate::cfg::build_function_cfg;
 use crate::complexity::compute_all_metrics;
 use crate::types::*;
+use std::collections::HashSet;
 use tree_sitter::{Node, Tree};
 
 pub struct CSharpExtractor;
@@ -11,6 +12,7 @@ impl SymbolExtractor for CSharpExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_csharp_node);
+        reclassify_csharp_implements(&mut symbols);
         walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &CSHARP_AST_CONFIG);
         walk_tree(&tree.root_node(), source, &mut symbols, match_csharp_type_map);
         symbols
@@ -166,6 +168,14 @@ fn handle_method_or_ctor(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
 }
 
 fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    // Skip interface methods — already emitted by handle_interface_decl without
+    // parameters. Re-emitting them here would duplicate the definition and add
+    // spurious `contains` edges to parameters of body-less declarations.
+    if let Some(parent) = node.parent() {
+        if let Some(grand) = parent.parent() {
+            if grand.kind() == "interface_declaration" { return; }
+        }
+    }
     handle_method_or_ctor(node, source, symbols);
 }
 
@@ -183,12 +193,12 @@ fn handle_property_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
     symbols.definitions.push(Definition {
         name: full_name,
-        kind: "method".to_string(),
+        kind: "property".to_string(),
         line: start_line(node),
         end_line: Some(end_line(node)),
         decorators: None,
-        complexity: compute_all_metrics(node, source, "csharp"),
-        cfg: build_function_cfg(node, "csharp", source),
+        complexity: None,
+        cfg: None,
         children: None,
     });
 }
@@ -350,6 +360,26 @@ fn extract_csharp_enum_members(node: &Node, source: &[u8]) -> Vec<Definition> {
 }
 
 // ── Existing helpers ────────────────────────────────────────────────────────
+
+/// Post-walk pass: reclassify `extends` entries as `implements` when the target
+/// is a known interface in the same file. At extraction time we cannot distinguish
+/// base classes from interfaces in the base_list, so we fix it up here using the
+/// definitions collected during the walk.
+fn reclassify_csharp_implements(symbols: &mut FileSymbols) {
+    let interfaces: HashSet<String> = symbols
+        .definitions
+        .iter()
+        .filter(|d| d.kind == "interface")
+        .map(|d| d.name.clone())
+        .collect();
+    for cls in symbols.classes.iter_mut() {
+        if let Some(ext) = cls.extends.as_ref() {
+            if interfaces.contains(ext) {
+                cls.implements = cls.extends.take();
+            }
+        }
+    }
+}
 
 fn extract_csharp_base_types(
     node: &Node,

--- a/tests/integration/build-parity.test.ts
+++ b/tests/integration/build-parity.test.ts
@@ -93,7 +93,10 @@ for (const fixture of PARITY_FIXTURES) {
       await buildGraph(wasmDir, { engine: 'wasm', incremental: false, skipRegistry: true });
       // Build with native
       await buildGraph(nativeDir, { engine: 'native', incremental: false, skipRegistry: true });
-    }, 60_000);
+      // 120s budget: each fixture runs WASM + native sequentially, so the per-fixture
+      // wall time roughly doubles. Sized for the heaviest current fixture (C#
+      // Repository) on a resource-constrained CI runner.
+    }, 120_000);
 
     afterAll(() => {
       // Cleanup

--- a/tests/integration/build-parity.test.ts
+++ b/tests/integration/build-parity.test.ts
@@ -19,7 +19,14 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 
-const FIXTURE_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'sample-project');
+const FIXTURES_ROOT = path.join(import.meta.dirname, '..');
+const PARITY_FIXTURES: Array<{ label: string; dir: string }> = [
+  { label: 'sample-project (JS)', dir: path.join(FIXTURES_ROOT, 'fixtures', 'sample-project') },
+  {
+    label: 'csharp Repository',
+    dir: path.join(FIXTURES_ROOT, 'benchmarks', 'resolution', 'fixtures', 'csharp'),
+  },
+];
 
 const hasNative = isNativeAvailable();
 // In the dedicated parity CI job (CODEGRAPH_PARITY=1), never silently skip —
@@ -69,54 +76,56 @@ function readGraph(dbPath) {
   return { nodes, edges, roles, astNodes };
 }
 
-describeOrSkip('Build parity: native vs WASM', () => {
-  let wasmDir: string;
-  let nativeDir: string;
+for (const fixture of PARITY_FIXTURES) {
+  describeOrSkip(`Build parity: native vs WASM — ${fixture.label}`, () => {
+    let wasmDir: string;
+    let nativeDir: string;
 
-  beforeAll(async () => {
-    // Create two temp copies of the fixture
-    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-parity-'));
-    wasmDir = path.join(tmpBase, 'wasm');
-    nativeDir = path.join(tmpBase, 'native');
-    copyDirSync(FIXTURE_DIR, wasmDir);
-    copyDirSync(FIXTURE_DIR, nativeDir);
+    beforeAll(async () => {
+      // Create two temp copies of the fixture
+      const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-parity-'));
+      wasmDir = path.join(tmpBase, 'wasm');
+      nativeDir = path.join(tmpBase, 'native');
+      copyDirSync(fixture.dir, wasmDir);
+      copyDirSync(fixture.dir, nativeDir);
 
-    // Build with WASM
-    await buildGraph(wasmDir, { engine: 'wasm', incremental: false, skipRegistry: true });
-    // Build with native
-    await buildGraph(nativeDir, { engine: 'native', incremental: false, skipRegistry: true });
-  }, 60_000);
+      // Build with WASM
+      await buildGraph(wasmDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+      // Build with native
+      await buildGraph(nativeDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
 
-  afterAll(() => {
-    // Cleanup
-    try {
-      if (wasmDir) fs.rmSync(path.dirname(wasmDir), { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
+    afterAll(() => {
+      // Cleanup
+      try {
+        if (wasmDir) fs.rmSync(path.dirname(wasmDir), { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('produces identical nodes', () => {
+      const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
+      const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
+      expect(nativeGraph.nodes).toEqual(wasmGraph.nodes);
+    });
+
+    it('produces identical edges', () => {
+      const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
+      const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
+      expect(nativeGraph.edges).toEqual(wasmGraph.edges);
+    });
+
+    it('produces identical roles', () => {
+      const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
+      const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
+      expect(nativeGraph.roles).toEqual(wasmGraph.roles);
+    });
+
+    it('produces identical ast_nodes', () => {
+      const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
+      const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
+      expect(nativeGraph.astNodes).toEqual(wasmGraph.astNodes);
+    });
   });
-
-  it('produces identical nodes', () => {
-    const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
-    const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
-    expect(nativeGraph.nodes).toEqual(wasmGraph.nodes);
-  });
-
-  it('produces identical edges', () => {
-    const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
-    const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
-    expect(nativeGraph.edges).toEqual(wasmGraph.edges);
-  });
-
-  it('produces identical roles', () => {
-    const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
-    const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
-    expect(nativeGraph.roles).toEqual(wasmGraph.roles);
-  });
-
-  it('produces identical ast_nodes', () => {
-    const wasmGraph = readGraph(path.join(wasmDir, '.codegraph', 'graph.db'));
-    const nativeGraph = readGraph(path.join(nativeDir, '.codegraph', 'graph.db'));
-    expect(nativeGraph.astNodes).toEqual(wasmGraph.astNodes);
-  });
-});
+}


### PR DESCRIPTION
## Summary

Aligns the native C# extractor with the WASM extractor on three independent parity divergences observed on the `tests/benchmarks/resolution/fixtures/csharp` fixture:

- **Auto-properties classified as `property`** (not `method`) and skip CFG/complexity for them.
- **Skip parameter `contains` / `parameter_of` edges for interface method declarations** — body-less, mirrors the WASM extractor's `parent.parent === 'interface_declaration'` guard.
- **Reclassify base-list entries as `implements`** in a post-walk pass when the target is a known interface in the same file (tree-sitter's `base_list` doesn't tag `:Iface` vs `:BaseClass`, so we resolve it after definitions are collected — same shape as the existing WASM `reclassifyCSharpImplements`).

Adds the C# Repository fixture to the build-parity integration test so this gap can't reappear silently.

Closes #1188

## Test plan

- [x] `CODEGRAPH_PARITY=1 npx vitest run tests/integration/build-parity.test.ts` — 8/8 pass (sample-project JS + csharp Repository × nodes/edges/roles/ast_nodes)
- [x] `npx vitest run tests/parsers/csharp.test.ts tests/parsers/dataflow-csharp.test.ts` — 18/18 pass
- [x] `npx vitest run tests/integration/` — 591/591 pass
- [x] `npx vitest run tests/parsers/` — 503/503 pass