### PR TITLE
fix(extractors): align Elixir/Haskell/Python contains parity across engines

### DIFF
--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -125,6 +125,8 @@ fn handle_def_function(node: &Node, source: &[u8], symbols: &mut FileSymbols, _k
         None => fn_name,
     };
 
+    let params = extract_elixir_params(&args, source);
+
     // Note: visibility (public/private) is determined by keyword but the
     // Definition struct does not yet have a visibility field. When it does,
     // wire `keyword == "defp"` → private, else → public.
@@ -137,8 +139,28 @@ fn handle_def_function(node: &Node, source: &[u8], symbols: &mut FileSymbols, _k
         decorators: None,
         complexity: compute_all_metrics(node, source, "elixir"),
         cfg: build_function_cfg(node, "elixir", source),
-        children: None,
+        children: opt_children(params),
     });
+}
+
+fn extract_elixir_params(args: &Node, source: &[u8]) -> Vec<Definition> {
+    let mut params = Vec::new();
+    for i in 0..args.child_count() {
+        let Some(child) = args.child(i) else { continue };
+        if child.kind() != "call" { continue; }
+        let Some(inner_args) = find_child(&child, "arguments") else { continue };
+        for j in 0..inner_args.child_count() {
+            let Some(param) = inner_args.child(j) else { continue };
+            if param.kind() == "identifier" {
+                params.push(child_def(
+                    node_text(&param, source).to_string(),
+                    "parameter",
+                    start_line(&param),
+                ));
+            }
+        }
+    }
+    params
 }
 
 fn extract_elixir_fn_name<'a>(args: &Node<'a>, source: &'a [u8]) -> Option<String> {

--- a/crates/codegraph-core/src/extractors/haskell.rs
+++ b/crates/codegraph-core/src/extractors/haskell.rs
@@ -37,6 +37,8 @@ fn handle_haskell_function(node: &Node, source: &[u8], symbols: &mut FileSymbols
         None => return,
     };
 
+    let params = extract_haskell_params(node, source);
+
     symbols.definitions.push(Definition {
         name: node_text(&name_node, source).to_string(),
         kind: "function".to_string(),
@@ -45,8 +47,40 @@ fn handle_haskell_function(node: &Node, source: &[u8], symbols: &mut FileSymbols
         decorators: None,
         complexity: compute_all_metrics(node, source, "haskell"),
         cfg: build_function_cfg(node, "haskell", source),
-        children: None,
+        children: opt_children(params),
     });
+}
+
+fn extract_haskell_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
+    let mut params = Vec::new();
+    for i in 0..func_node.child_count() {
+        let Some(child) = func_node.child(i) else { continue };
+        match child.kind() {
+            "patterns" | "parameter" => {
+                for j in 0..child.child_count() {
+                    if let Some(pat) = child.child(j) {
+                        if pat.kind() == "variable" || pat.kind() == "identifier" {
+                            params.push(child_def(
+                                node_text(&pat, source).to_string(),
+                                "parameter",
+                                start_line(&pat),
+                            ));
+                        }
+                    }
+                }
+            }
+            "variable" if i > 0 => {
+                // Pattern parameter after the function name
+                params.push(child_def(
+                    node_text(&child, source).to_string(),
+                    "parameter",
+                    start_line(&child),
+                ));
+            }
+            _ => {}
+        }
+    }
+    params
 }
 
 fn handle_haskell_bind(node: &Node, source: &[u8], symbols: &mut FileSymbols) {

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -122,7 +122,7 @@ function handlePyFunctionDef(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const parentClass = findPythonParentClass(node);
   const fullName = parentClass ? `${parentClass}.${nameNode.text}` : nameNode.text;
   const kind = parentClass ? 'method' : 'function';
-  const fnChildren = extractPythonParameters(node);
+  const fnChildren = extractPythonParameters(node, parentClass !== null);
   ctx.definitions.push({
     name: fullName,
     kind,
@@ -238,7 +238,7 @@ function handlePyImportFrom(node: TreeSitterNode, ctx: ExtractorOutput): void {
 
 // ── Python-specific helpers ─────────────────────────────────────────────────
 
-function extractPythonParameters(fnNode: TreeSitterNode): SubDeclaration[] {
+function extractPythonParameters(fnNode: TreeSitterNode, isMethod: boolean): SubDeclaration[] {
   const params: SubDeclaration[] = [];
   const paramsNode = fnNode.childForFieldName('parameters') || findChild(fnNode, 'parameters');
   if (!paramsNode) return params;
@@ -246,7 +246,9 @@ function extractPythonParameters(fnNode: TreeSitterNode): SubDeclaration[] {
     const child = paramsNode.child(i);
     if (!child) continue;
     const param = extractSinglePyParam(child);
-    if (param) params.push(param);
+    if (!param) continue;
+    if (isMethod && (param.name === 'self' || param.name === 'cls')) continue;
+    params.push(param);
   }
   return params;
 }

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -11,7 +11,9 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import {
   createParsers,
   extractCSharpSymbols,
+  extractElixirSymbols,
   extractGoSymbols,
+  extractHaskellSymbols,
   extractHCLSymbols,
   extractJavaSymbols,
   extractPHPSymbols,
@@ -30,31 +32,19 @@ function wasmExtract(code, filePath) {
   const parser = getParser(parsers, filePath);
   if (!parser) return null;
   const tree = parser.parse(code);
-  const isHCL = filePath.endsWith('.tf') || filePath.endsWith('.hcl');
-  const isPython = filePath.endsWith('.py');
-  const isGo = filePath.endsWith('.go');
-  const isRust = filePath.endsWith('.rs');
-  const isJava = filePath.endsWith('.java');
-  const isCSharp = filePath.endsWith('.cs');
-  const isRuby = filePath.endsWith('.rb');
-  const isPHP = filePath.endsWith('.php');
-  return isHCL
-    ? extractHCLSymbols(tree, filePath)
-    : isPython
-      ? extractPythonSymbols(tree, filePath)
-      : isGo
-        ? extractGoSymbols(tree, filePath)
-        : isRust
-          ? extractRustSymbols(tree, filePath)
-          : isJava
-            ? extractJavaSymbols(tree, filePath)
-            : isCSharp
-              ? extractCSharpSymbols(tree, filePath)
-              : isRuby
-                ? extractRubySymbols(tree, filePath)
-                : isPHP
-                  ? extractPHPSymbols(tree, filePath)
-                  : extractSymbols(tree, filePath);
+  if (filePath.endsWith('.tf') || filePath.endsWith('.hcl'))
+    return extractHCLSymbols(tree, filePath);
+  if (filePath.endsWith('.py')) return extractPythonSymbols(tree, filePath);
+  if (filePath.endsWith('.go')) return extractGoSymbols(tree, filePath);
+  if (filePath.endsWith('.rs')) return extractRustSymbols(tree, filePath);
+  if (filePath.endsWith('.java')) return extractJavaSymbols(tree, filePath);
+  if (filePath.endsWith('.cs')) return extractCSharpSymbols(tree, filePath);
+  if (filePath.endsWith('.rb')) return extractRubySymbols(tree, filePath);
+  if (filePath.endsWith('.php')) return extractPHPSymbols(tree, filePath);
+  if (filePath.endsWith('.ex') || filePath.endsWith('.exs'))
+    return extractElixirSymbols(tree, filePath);
+  if (filePath.endsWith('.hs')) return extractHaskellSymbols(tree, filePath);
+  return extractSymbols(tree, filePath);
 }
 
 function nativeExtract(code, filePath) {
@@ -72,7 +62,8 @@ function normalize(symbols) {
         line: d.line,
         endLine: d.endLine ?? d.end_line ?? null,
         ...(() => {
-          // Native engine doesn't extract implicit `self`/`&self` parameters for Python/Rust
+          // Both engines skip implicit `self`/`&self` parameters for Python/Rust;
+          // this filter is a safety net for any language that hasn't been aligned yet.
           const filtered = (d.children || [])
             .filter((c) => c.name !== 'self')
             .map((c) => ({ name: c.name, kind: c.kind, line: c.line }));
@@ -213,6 +204,55 @@ class Dog(Animal):
 `,
     },
     {
+      // Regression guard: both engines must extract function parameters as
+      // `parameter` children — drives contains / parameter_of edges. Native
+      // previously dropped all Elixir params, leaving WASM-only contains
+      // edges on every function. See #1189.
+      name: 'Elixir — module with parameterised defs',
+      file: 'test.ex',
+      code: `defmodule UserService do
+  def create_user(store, id, name) do
+    UserRepository.save(store, id, name)
+  end
+
+  defp format_user(user) do
+    user.name
+  end
+end
+`,
+    },
+    {
+      // Regression guard: native previously dropped all Haskell function
+      // parameters (positional pattern children). See #1189.
+      name: 'Haskell — top-level functions with parameters',
+      file: 'Service.hs',
+      code: `module Service where
+
+createUser uid name age store =
+  if validateUser name age then Right store else Left "invalid"
+
+getUser uid store = lookup uid store
+`,
+    },
+    {
+      // Regression guard: WASM previously emitted `self`/`cls` as `parameter`
+      // children of methods, but native skipped them — inflating contains and
+      // parameter_of counts on every method. WASM now skips them too. See #1189.
+      name: 'Python — methods must skip implicit self/cls',
+      file: 'pyself.py',
+      code: `class Store:
+    def __init__(self, name):
+        self.name = name
+
+    def get(self, key):
+        return key
+
+    @classmethod
+    def build(cls, name):
+        return cls(name)
+`,
+    },
+    {
       name: 'Go — structs and methods',
       file: 'test.go',
       code: `
@@ -309,4 +349,26 @@ module "vpc" {
       expect(nativeResult).toEqual(wasmResult);
     });
   }
+
+  // Explicit guard for the WASM Python fix in #1189. The structural parity
+  // loop above strips `self` from both sides via normalize(), so a regression
+  // where WASM re-emits self/cls would slip through. Assert it directly.
+  it('Python WASM must skip implicit self/cls in method parameter children', () => {
+    const code = `class Foo:
+    def bar(self, x, y):
+        pass
+
+    @classmethod
+    def baz(cls, name):
+        pass
+`;
+    const wasm = wasmExtract(code, 'test.py');
+    const methods = (wasm?.definitions ?? []).filter((d) => d.kind === 'method');
+    expect(methods.length).toBeGreaterThan(0);
+    for (const m of methods) {
+      const childNames = (m.children ?? []).map((c) => c.name);
+      expect(childNames).not.toContain('self');
+      expect(childNames).not.toContain('cls');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes 3 of the 11 per-language divergences tracked in #1189 (the residual `contains` (-51) / `parameter_of` (-35) gap from the v3.10.1-dev.80 dogfood report).

| Language | Engine with bug | Cause | Fix |
|---|---|---|---|
| **Elixir** | native | `handle_def_function` dropped all parameters | Added `extract_elixir_params` (mirrors WASM). **24** missing edges |
| **Haskell** | native | `handle_haskell_function` dropped all pattern parameters | Added `extract_haskell_params` (mirrors WASM). **24** missing edges |
| **Python** | WASM | `extractPythonParameters` emitted implicit `self`/`cls` as `parameter` children for methods | Skip `self`/`cls` when parent is a class, matching native. **13** spurious edges |

Total: **61 edges aligned across both directions** (Elixir/Haskell were native-missing; Python was WASM-extra).

## Why these three

Largest impact from the issue's surface-area table — Elixir + Haskell + Python = 61 of the 51 reported WASM-only `contains` edges (the dogfood report's number was a pre-aggregate; the per-fixture diff matches the table exactly). One concern per PR — the remaining 8 languages stay in #1189.

## How the divergences were found

Direct AST-walk comparison on `tests/benchmarks/resolution/fixtures/{elixir,haskell,python}/` between the two engines' extractor output, grouping by `parent::child@line`. The Python self-only delta exactly matched 13 `self` parameters across 13 methods in the fixture.

## Verification

- Per-fixture WASM-vs-native diff: all 3 gaps closed (was 24/24/13).
- `tests/engines/parity.test.ts` extended with fixture cases per language and an explicit guard that WASM never emits `self`/`cls` as method-parameter children (the `normalize()` self filter would mask a regression otherwise). All 14 parity cases pass.
- Full vitest suite: 2746 passed / 24 skipped, no regressions.
- `cargo test --release`: 317 passed.

## Test plan

- [x] WASM/native diff zero on Elixir/Haskell/Python fixtures
- [x] `npx vitest run tests/engines/parity.test.ts` — 14 passed
- [x] `npm test` — full suite passes
- [x] `cargo test --release` (codegraph-core) — passes
- [x] Native binary rebuilt locally and exercised end-to-end (`@optave/codegraph-darwin-arm64`)

## Out of scope

Remaining 8 languages in #1189 (Python's 13 was the easy WASM-side win; Terraform, Dart, Ruby, Kotlin, Objective-C, CUDA, Scala, Java remain). The native fixes here ship in the next platform-binary release.