### PR TITLE
fix(extractors): align HCL/Dart/Scala contains parity across engines

### DIFF
--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -94,17 +94,26 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..body.child_count() {
         if let Some(member) = body.child(i) {
-            match member.kind() {
+            // tree-sitter-dart 0.0.4 wraps method/function signatures in
+            // `class_member_definition` (a single-child container). Drill in
+            // before matching; newer grammar versions place the signatures
+            // directly under `class_body`.
+            let sig = if member.kind() == "class_member_definition" {
+                member.child(0).unwrap_or(member)
+            } else {
+                member
+            };
+            match sig.kind() {
                 "method_signature" | "function_signature" => {
-                    if let Some(fn_name) = extract_dart_fn_name(&member, source) {
+                    if let Some(fn_name) = extract_dart_fn_name(&sig, source) {
                         symbols.definitions.push(Definition {
                             name: format!("{}.{}", class_name, fn_name),
                             kind: "method".to_string(),
-                            line: start_line(&member),
-                            end_line: Some(end_line(&member)),
+                            line: start_line(&sig),
+                            end_line: Some(end_line(&sig)),
                             decorators: None,
-                            complexity: compute_all_metrics(&member, source, "dart"),
-                            cfg: build_function_cfg(&member, "dart", source),
+                            complexity: compute_all_metrics(&sig, source, "dart"),
+                            cfg: build_function_cfg(&sig, "dart", source),
                             children: None,
                         });
                     }
@@ -266,3 +275,4 @@ fn is_inside_class(node: &Node) -> bool {
     }
     false
 }
+

--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -94,12 +94,17 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..body.child_count() {
         if let Some(member) = body.child(i) {
-            // tree-sitter-dart 0.0.4 wraps method/function signatures in
-            // `class_member_definition` (a single-child container). Drill in
-            // before matching; newer grammar versions place the signatures
-            // directly under `class_body`.
+            // tree-sitter-dart 0.0.4 wraps method/function signatures in a
+            // `class_member_definition` container; newer grammar versions
+            // place the signatures directly under `class_body`. Either way,
+            // search the subtree for the first `method_signature` /
+            // `function_signature` so leading anonymous nodes, metadata, or
+            // modifier keywords don't cause us to silently drop the method.
             let sig = if member.kind() == "class_member_definition" {
-                member.child(0).unwrap_or(member)
+                match find_dart_signature_child(&member) {
+                    Some(s) => s,
+                    None => continue,
+                }
             } else {
                 member
             };
@@ -122,6 +127,17 @@ fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symb
             }
         }
     }
+}
+
+fn find_dart_signature_child<'a>(node: &Node<'a>) -> Option<Node<'a>> {
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if matches!(child.kind(), "method_signature" | "function_signature") {
+                return Some(child);
+            }
+        }
+    }
+    None
 }
 
 fn extract_dart_fn_name(node: &Node, source: &[u8]) -> Option<String> {

--- a/crates/codegraph-core/src/extractors/hcl.rs
+++ b/crates/codegraph-core/src/extractors/hcl.rs
@@ -46,6 +46,35 @@ fn resolve_block_name(block_type: &str, strings: &[String]) -> String {
     }
 }
 
+/// Extract attribute children (e.g. `type`, `default`) from a block's body as
+/// `property` sub-declarations. Mirrors WASM `extractHclAttributes`.
+fn extract_block_attributes(node: &Node, source: &[u8]) -> Vec<Definition> {
+    let mut attrs = Vec::new();
+    let body = match node.children(&mut node.walk()).find(|c| c.kind() == "body") {
+        Some(b) => b,
+        None => return attrs,
+    };
+    for i in 0..body.child_count() {
+        let attr = match body.child(i) {
+            Some(a) if a.kind() == "attribute" => a,
+            _ => continue,
+        };
+        if let Some(key) = attr.child_by_field_name("key").or_else(|| attr.child(0)) {
+            attrs.push(Definition {
+                name: node_text(&key, source).to_string(),
+                kind: "property".to_string(),
+                line: start_line(&attr),
+                end_line: None,
+                decorators: None,
+                complexity: None,
+                cfg: None,
+                children: None,
+            });
+        }
+    }
+    attrs
+}
+
 /// Extract module source imports from a module block's body.
 fn extract_module_source(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let body = node.children(&mut node.walk()).find(|c| c.kind() == "body");
@@ -80,6 +109,12 @@ fn match_hcl_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth:
             let block_type = &identifiers[0];
             let name = resolve_block_name(block_type, &strings);
             if !name.is_empty() {
+                let children = if block_type == "variable" || block_type == "output" {
+                    let attrs = extract_block_attributes(node, source);
+                    if attrs.is_empty() { None } else { Some(attrs) }
+                } else {
+                    None
+                };
                 symbols.definitions.push(Definition {
                     name,
                     kind: block_type.clone(),
@@ -88,7 +123,7 @@ fn match_hcl_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth:
                     decorators: None,
                     complexity: None,
                     cfg: None,
-                    children: None,
+                    children,
                 });
                 if block_type == "module" {
                     extract_module_source(node, source, symbols);

--- a/src/extractors/scala.ts
+++ b/src/extractors/scala.ts
@@ -1,5 +1,6 @@
 import type {
   Call,
+  Definition,
   ExtractorOutput,
   SubDeclaration,
   TreeSitterNode,
@@ -59,52 +60,37 @@ function walkScalaNode(node: TreeSitterNode, ctx: ExtractorOutput): void {
 // ── Walk-path per-node-type handlers ────────────────────────────────────────
 
 function handleScalaClassDef(node: TreeSitterNode, ctx: ExtractorOutput): void {
-  const nameNode = node.childForFieldName('name');
-  if (!nameNode) return;
-  const name = nameNode.text;
-  const children = extractScalaBodyMembers(node, name, ctx);
-
-  ctx.definitions.push({
-    name,
-    kind: 'class',
-    line: node.startPosition.row + 1,
-    endLine: nodeEndLine(node),
-    children: children.length > 0 ? children : undefined,
-  });
-
-  extractScalaInheritance(node, name, ctx);
+  emitScalaTypeDef(node, ctx, 'class');
 }
 
 function handleScalaTraitDef(node: TreeSitterNode, ctx: ExtractorOutput): void {
-  const nameNode = node.childForFieldName('name');
-  if (!nameNode) return;
-  const name = nameNode.text;
-  const children = extractScalaBodyMembers(node, name, ctx);
-
-  ctx.definitions.push({
-    name,
-    kind: 'interface',
-    line: node.startPosition.row + 1,
-    endLine: nodeEndLine(node),
-    children: children.length > 0 ? children : undefined,
-  });
-
-  extractScalaInheritance(node, name, ctx);
+  emitScalaTypeDef(node, ctx, 'interface');
 }
 
 function handleScalaObjectDef(node: TreeSitterNode, ctx: ExtractorOutput): void {
+  emitScalaTypeDef(node, ctx, 'class');
+}
+
+function emitScalaTypeDef(
+  node: TreeSitterNode,
+  ctx: ExtractorOutput,
+  kind: 'class' | 'interface',
+): void {
   const nameNode = node.childForFieldName('name');
   if (!nameNode) return;
   const name = nameNode.text;
-  const children = extractScalaBodyMembers(node, name, ctx);
+  const { children, methods } = collectScalaBodyMembers(node, name);
 
+  // Push the type def before its methods so the definition order follows
+  // source-line order (matches native, which walks depth-first).
   ctx.definitions.push({
     name,
-    kind: 'class',
+    kind,
     line: node.startPosition.row + 1,
     endLine: nodeEndLine(node),
     children: children.length > 0 ? children : undefined,
   });
+  for (const m of methods) ctx.definitions.push(m);
 
   extractScalaInheritance(node, name, ctx);
 }
@@ -224,14 +210,14 @@ function extractScalaInheritance(node: TreeSitterNode, name: string, ctx: Extrac
 
 // ── Body member extraction ──────────────────────────────────────────────────
 
-function extractScalaBodyMembers(
+function collectScalaBodyMembers(
   parentNode: TreeSitterNode,
   parentName: string,
-  ctx: ExtractorOutput,
-): SubDeclaration[] {
+): { children: SubDeclaration[]; methods: Definition[] } {
   const children: SubDeclaration[] = [];
+  const methods: Definition[] = [];
   const body = findChild(parentNode, 'template_body');
-  if (!body) return children;
+  if (!body) return { children, methods };
 
   for (let i = 0; i < body.childCount; i++) {
     const member = body.child(i);
@@ -240,12 +226,14 @@ function extractScalaBodyMembers(
     if (member.type === 'function_definition') {
       const methName = member.childForFieldName('name');
       if (methName) {
-        ctx.definitions.push({
+        const params = extractScalaParameters(member);
+        methods.push({
           name: `${parentName}.${methName.text}`,
           kind: 'method',
           line: member.startPosition.row + 1,
           endLine: member.endPosition.row + 1,
           visibility: extractModifierVisibility(member),
+          children: params.length > 0 ? params : undefined,
         });
       }
     } else if (member.type === 'val_definition' || member.type === 'var_definition') {
@@ -264,7 +252,7 @@ function extractScalaBodyMembers(
     }
   }
 
-  return children;
+  return { children, methods };
 }
 
 // ── Parameter extraction ────────────────────────────────────────────────────

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -11,6 +11,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import {
   createParsers,
   extractCSharpSymbols,
+  extractDartSymbols,
   extractGoSymbols,
   extractHCLSymbols,
   extractJavaSymbols,
@@ -18,6 +19,7 @@ import {
   extractPythonSymbols,
   extractRubySymbols,
   extractRustSymbols,
+  extractScalaSymbols,
   extractSymbols,
   getParser,
 } from '../../src/domain/parser.js';
@@ -30,31 +32,18 @@ function wasmExtract(code, filePath) {
   const parser = getParser(parsers, filePath);
   if (!parser) return null;
   const tree = parser.parse(code);
-  const isHCL = filePath.endsWith('.tf') || filePath.endsWith('.hcl');
-  const isPython = filePath.endsWith('.py');
-  const isGo = filePath.endsWith('.go');
-  const isRust = filePath.endsWith('.rs');
-  const isJava = filePath.endsWith('.java');
-  const isCSharp = filePath.endsWith('.cs');
-  const isRuby = filePath.endsWith('.rb');
-  const isPHP = filePath.endsWith('.php');
-  return isHCL
-    ? extractHCLSymbols(tree, filePath)
-    : isPython
-      ? extractPythonSymbols(tree, filePath)
-      : isGo
-        ? extractGoSymbols(tree, filePath)
-        : isRust
-          ? extractRustSymbols(tree, filePath)
-          : isJava
-            ? extractJavaSymbols(tree, filePath)
-            : isCSharp
-              ? extractCSharpSymbols(tree, filePath)
-              : isRuby
-                ? extractRubySymbols(tree, filePath)
-                : isPHP
-                  ? extractPHPSymbols(tree, filePath)
-                  : extractSymbols(tree, filePath);
+  if (filePath.endsWith('.tf') || filePath.endsWith('.hcl'))
+    return extractHCLSymbols(tree, filePath);
+  if (filePath.endsWith('.py')) return extractPythonSymbols(tree, filePath);
+  if (filePath.endsWith('.go')) return extractGoSymbols(tree, filePath);
+  if (filePath.endsWith('.rs')) return extractRustSymbols(tree, filePath);
+  if (filePath.endsWith('.java')) return extractJavaSymbols(tree, filePath);
+  if (filePath.endsWith('.cs')) return extractCSharpSymbols(tree, filePath);
+  if (filePath.endsWith('.rb')) return extractRubySymbols(tree, filePath);
+  if (filePath.endsWith('.php')) return extractPHPSymbols(tree, filePath);
+  if (filePath.endsWith('.dart')) return extractDartSymbols(tree, filePath);
+  if (filePath.endsWith('.scala')) return extractScalaSymbols(tree, filePath);
+  return extractSymbols(tree, filePath);
 }
 
 function nativeExtract(code, filePath) {
@@ -287,16 +276,45 @@ class Controller {
 `,
     },
     {
-      name: 'HCL — resources and modules',
-      file: 'main.tf',
-      // Known native gap: native engine does not support HCL
-      skip: true,
+      // Regression guard for #1189: native must extract `type`/`default`
+      // attributes as `property` children of `variable` and `output` blocks,
+      // matching WASM. Pre-fix native produced 0 children here.
+      name: 'HCL — variable and output attributes as property children',
+      file: 'vars.tf',
       code: `
-resource "aws_instance" "web" {
-  ami = "abc-123"
+variable "storage_type" {
+  type    = string
+  default = "memory"
 }
-module "vpc" {
-  source = "./modules/vpc"
+output "endpoint" {
+  value = "http://localhost"
+}
+`,
+    },
+    {
+      // Regression guard for #1189: native uses tree-sitter-dart 0.0.4 which
+      // wraps method/function signatures inside a `class_member_definition`
+      // node. Pre-fix native emitted only the class definition with no method
+      // children; this case probes that wrapper is unwrapped during extraction.
+      name: 'Dart — class methods extracted through class_member_definition wrapper',
+      file: 'repo.dart',
+      code: `
+class UserRepository {
+  void save(int id) {}
+  int findById(int id) { return 0; }
+}
+`,
+    },
+    {
+      // Regression guard for #1189: WASM must extract method parameters as
+      // `parameter` children for class/trait/object methods. Pre-fix WASM
+      // emitted the method definition without children, while native did.
+      name: 'Scala — method parameters as children of class methods',
+      file: 'Svc.scala',
+      code: `
+class UserService {
+  def createUser(id: String, name: String): String = name
+  def removeUser(id: String): Boolean = true
 }
 `,
     },

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -389,6 +389,23 @@ class UserService {
 }
 `,
     },
+    {
+      // Regression guard for the refactor in #1196: `handleScalaObjectDef`
+      // previously skipped `extractScalaInheritance`, leaving WASM blind to
+      // `object Foo extends Bar`. Routing object_definition through
+      // `emitScalaTypeDef` now tracks inheritance for objects; assert both
+      // engines agree on the resulting `classes[].extends` entry.
+      name: 'Scala — object with extends produces inheritance entry',
+      file: 'Obj.scala',
+      code: `
+trait Greeter {
+  def greet: String
+}
+object DefaultGreeter extends Greeter {
+  def greet: String = "hi"
+}
+`,
+    },
   ];
 
   for (const { name, file, code, skip } of cases) {

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -276,6 +276,22 @@ class Controller {
 `,
     },
     {
+      // Regression guard for the original HCL parity case (resources and
+      // module blocks). Native now has a full HCL extractor, so this no
+      // longer needs to be skipped — keep it active as a regression guard
+      // for the `resource` / `module` extraction paths.
+      name: 'HCL — resources and modules',
+      file: 'main.tf',
+      code: `
+resource "aws_instance" "web" {
+  ami = "abc-123"
+}
+module "vpc" {
+  source = "./modules/vpc"
+}
+`,
+    },
+    {
       // Regression guard for #1189: native must extract `type`/`default`
       // attributes as `property` children of `variable` and `output` blocks,
       // matching WASM. Pre-fix native produced 0 children here.


### PR DESCRIPTION
## Summary

Three more per-language divergences from the v3.10.1-dev.80 dogfood report's residual `contains` gap, refs #1189.

- **HCL native** — `handle_hcl_block` emitted `variable`/`output` definitions without attribute children → added `extract_block_attributes` that pulls each attribute key as a `property` child (mirrors WASM `extractHclAttributes`). 12 missing contains edges in the fixture.
- **Dart native** — `extract_dart_class_methods` iterated `class_body` children looking for `method_signature`/`function_signature` directly, but `tree-sitter-dart 0.0.4` (the version pinned by the Rust crate) wraps each signature in a `class_member_definition`. The fix unwraps that container before matching. 10 missing contains edges in the fixture.
- **Scala WASM** — `extractScalaBodyMembers` emitted class/trait/object methods with no parameter children, while native correctly extracted them via `handle_scala_function_definition`. WASM now passes the parameter list as `children`, matching native. 11 missing contains edges in the fixture.
- **Scala WASM emission order** also realigned: the class/trait/object handlers previously pushed methods *before* the parent type, while native pushes the parent first (source order). Refactored through `emitScalaTypeDef` + `collectScalaBodyMembers` so WASM matches native's depth-first source-line order — required for the new parity assertion to pass.

## Verification

- `npx vitest run tests/engines/parity.test.ts` — 13 passed, 3 skipped (HCL case un-skipped; Dart/Scala cases newly added).
- `npx vitest run tests/parsers/ tests/engines/` — 567 passed.
- `npx vitest run tests/integration/ tests/graph/ tests/benchmarks/resolution/` — 971 passed.
- Cross-engine contains-edge diff on `tests/benchmarks/resolution/fixtures/{hcl,dart,scala}/*` is now zero in both directions.

## Test plan

- [x] HCL `variable`/`output` blocks produce `property` children in both engines.
- [x] Dart class methods extracted by native via the `class_member_definition` unwrap path.
- [x] Scala class/trait/object method `parameter` children present in both engines.
- [x] Scala definition emission order matches native (parent before members).
- [x] All existing parity, parser, integration, and resolution tests pass.

Closes #1189 partially (HCL, Dart, Scala). Remaining: Java, Kotlin, Objective-C, CUDA, Ruby (single-edge case).