### PR TITLE
fix(extractors): align Java/Kotlin/CUDA contains parity across engines

### DIFF
--- a/crates/codegraph-core/src/extractors/cuda.rs
+++ b/crates/codegraph-core/src/extractors/cuda.rs
@@ -217,6 +217,12 @@ fn extract_cuda_fields(body: &Node, source: &[u8]) -> Vec<Definition> {
         if let Some(child) = body.child(i) {
             if child.kind() == "field_declaration" {
                 if let Some(decl) = child.child_by_field_name("declarator") {
+                    // Skip method declarations — a `field_declaration` whose
+                    // declarator (after unwrapping pointer/reference/array)
+                    // is a `function_declarator` is a method signature in a
+                    // header, not a data field. Mirrors the WASM
+                    // `isCudaMethodDeclarator` guard so both engines agree.
+                    if is_cuda_method_declarator(&decl) { continue; }
                     let name = unwrap_cuda_declarator(&decl, source);
                     if !name.is_empty() {
                         fields.push(child_def(name, "property", start_line(&child)));
@@ -226,6 +232,26 @@ fn extract_cuda_fields(body: &Node, source: &[u8]) -> Vec<Definition> {
         }
     }
     fields
+}
+
+fn is_cuda_method_declarator(node: &Node) -> bool {
+    let mut current = *node;
+    loop {
+        match current.kind() {
+            "pointer_declarator"
+            | "reference_declarator"
+            | "array_declarator"
+            | "parenthesized_declarator" => {
+                if let Some(inner) = current.child_by_field_name("declarator") {
+                    current = inner;
+                } else {
+                    return false;
+                }
+            }
+            "function_declarator" => return true,
+            _ => return false,
+        }
+    }
 }
 
 fn extract_cuda_enum_constants(node: &Node, source: &[u8]) -> Vec<Definition> {

--- a/crates/codegraph-core/src/extractors/java.rs
+++ b/crates/codegraph-core/src/extractors/java.rs
@@ -193,6 +193,16 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    // Skip interface methods — already emitted by handle_interface_decl without
+    // parameters. Re-emitting them here would duplicate the definition and add
+    // spurious `contains` edges to parameters of body-less declarations.
+    // Mirrors C# handle_method_decl (csharp.rs) and the WASM Java extractor's
+    // `node.parent?.parent?.type === 'interface_declaration'` guard.
+    if let Some(parent) = node.parent() {
+        if let Some(grand) = parent.parent() {
+            if grand.kind() == "interface_declaration" { return; }
+        }
+    }
     if let Some(name_node) = node.child_by_field_name("name") {
         let parent_class = find_java_parent_class(node, source);
         let name = node_text(&name_node, source);

--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -135,7 +135,13 @@ fn extract_kotlin_class_properties(node: &Node, source: &[u8]) -> Vec<Definition
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
                 if child.kind() == "property_declaration" {
-                    let name = child.child_by_field_name("name")
+                    // Kotlin grammar nests the name as
+                    //   property_declaration > variable_declaration > simple_identifier
+                    // so drill through variable_declaration first (mirrors the
+                    // WASM `collectKotlinProperties` extractor).
+                    let name = find_child(&child, "variable_declaration")
+                        .and_then(|vd| find_child(&vd, "simple_identifier"))
+                        .or_else(|| child.child_by_field_name("name"))
                         .or_else(|| find_child(&child, "simple_identifier"))
                         .map(|n| node_text(&n, source).to_string());
                     if let Some(name) = name {

--- a/src/extractors/cuda.ts
+++ b/src/extractors/cuda.ts
@@ -284,20 +284,41 @@ function extractCudaClassFields(classNode: TreeSitterNode): SubDeclaration[] {
     const member = body.child(i);
     if (!member || member.type !== 'field_declaration') continue;
     const nameNode = member.childForFieldName('declarator');
-    if (nameNode) {
-      const name =
-        nameNode.type === 'identifier'
-          ? nameNode.text
-          : (findChild(nameNode, 'identifier')?.text ?? nameNode.text);
-      fields.push({
-        name,
-        kind: 'property',
-        line: member.startPosition.row + 1,
-        visibility: extractModifierVisibility(member),
-      });
-    }
+    if (!nameNode) continue;
+    // Skip method declarations — a `field_declaration` whose declarator
+    // (after unwrapping pointer/reference/array) is a `function_declarator`
+    // is a method signature in a header, not a data field. Native and WASM
+    // previously diverged on how to format these (native stripped the `*`
+    // from pointer-return types, WASM kept it), and both produced
+    // method-signature-shaped "property" entries that are not real fields.
+    if (isCudaMethodDeclarator(nameNode)) continue;
+    const name =
+      nameNode.type === 'identifier'
+        ? nameNode.text
+        : (findChild(nameNode, 'identifier')?.text ?? nameNode.text);
+    fields.push({
+      name,
+      kind: 'property',
+      line: member.startPosition.row + 1,
+      visibility: extractModifierVisibility(member),
+    });
   }
   return fields;
+}
+
+const CUDA_DECLARATOR_WRAPPERS = new Set([
+  'pointer_declarator',
+  'reference_declarator',
+  'array_declarator',
+  'parenthesized_declarator',
+]);
+
+function isCudaMethodDeclarator(node: TreeSitterNode): boolean {
+  let current: TreeSitterNode | null = node;
+  while (current && CUDA_DECLARATOR_WRAPPERS.has(current.type)) {
+    current = current.childForFieldName('declarator');
+  }
+  return current?.type === 'function_declarator';
 }
 
 function extractCudaEnumEntries(enumNode: TreeSitterNode): SubDeclaration[] {

--- a/src/extractors/kotlin.ts
+++ b/src/extractors/kotlin.ts
@@ -147,11 +147,13 @@ function collectKotlinMethods(node: TreeSitterNode, className: string, ctx: Extr
     if (!child || child.type !== 'function_declaration') continue;
     const methName = findChild(child, 'simple_identifier');
     if (methName) {
+      const params = extractKotlinParameters(child);
       ctx.definitions.push({
         name: `${className}.${methName.text}`,
         kind: 'method',
         line: child.startPosition.row + 1,
         endLine: child.endPosition.row + 1,
+        children: params.length > 0 ? params : undefined,
         visibility: extractModifierVisibility(child),
       });
     }
@@ -214,11 +216,13 @@ function handleKotlinObjectDecl(node: TreeSitterNode, ctx: ExtractorOutput): voi
       if (child && child.type === 'function_declaration') {
         const methName = findChild(child, 'simple_identifier');
         if (methName) {
+          const params = extractKotlinParameters(child);
           ctx.definitions.push({
             name: `${nameNode.text}.${methName.text}`,
             kind: 'method',
             line: child.startPosition.row + 1,
             endLine: child.endPosition.row + 1,
+            children: params.length > 0 ? params : undefined,
             visibility: extractModifierVisibility(child),
           });
         }

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -11,9 +11,11 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import {
   createParsers,
   extractCSharpSymbols,
+  extractCudaSymbols,
   extractGoSymbols,
   extractHCLSymbols,
   extractJavaSymbols,
+  extractKotlinSymbols,
   extractPHPSymbols,
   extractPythonSymbols,
   extractRubySymbols,
@@ -30,31 +32,19 @@ function wasmExtract(code, filePath) {
   const parser = getParser(parsers, filePath);
   if (!parser) return null;
   const tree = parser.parse(code);
-  const isHCL = filePath.endsWith('.tf') || filePath.endsWith('.hcl');
-  const isPython = filePath.endsWith('.py');
-  const isGo = filePath.endsWith('.go');
-  const isRust = filePath.endsWith('.rs');
-  const isJava = filePath.endsWith('.java');
-  const isCSharp = filePath.endsWith('.cs');
-  const isRuby = filePath.endsWith('.rb');
-  const isPHP = filePath.endsWith('.php');
-  return isHCL
-    ? extractHCLSymbols(tree, filePath)
-    : isPython
-      ? extractPythonSymbols(tree, filePath)
-      : isGo
-        ? extractGoSymbols(tree, filePath)
-        : isRust
-          ? extractRustSymbols(tree, filePath)
-          : isJava
-            ? extractJavaSymbols(tree, filePath)
-            : isCSharp
-              ? extractCSharpSymbols(tree, filePath)
-              : isRuby
-                ? extractRubySymbols(tree, filePath)
-                : isPHP
-                  ? extractPHPSymbols(tree, filePath)
-                  : extractSymbols(tree, filePath);
+  if (filePath.endsWith('.tf') || filePath.endsWith('.hcl'))
+    return extractHCLSymbols(tree, filePath);
+  if (filePath.endsWith('.py')) return extractPythonSymbols(tree, filePath);
+  if (filePath.endsWith('.go')) return extractGoSymbols(tree, filePath);
+  if (filePath.endsWith('.rs')) return extractRustSymbols(tree, filePath);
+  if (filePath.endsWith('.java')) return extractJavaSymbols(tree, filePath);
+  if (filePath.endsWith('.cs')) return extractCSharpSymbols(tree, filePath);
+  if (filePath.endsWith('.rb')) return extractRubySymbols(tree, filePath);
+  if (filePath.endsWith('.php')) return extractPHPSymbols(tree, filePath);
+  if (filePath.endsWith('.kt')) return extractKotlinSymbols(tree, filePath);
+  if (filePath.endsWith('.cu') || filePath.endsWith('.cuh'))
+    return extractCudaSymbols(tree, filePath);
+  return extractSymbols(tree, filePath);
 }
 
 function nativeExtract(code, filePath) {
@@ -244,6 +234,55 @@ interface Printable { void print(); }
 class Document implements Printable {
     public void print() { System.out.println("doc"); }
 }
+`,
+    },
+    {
+      // Regression guard for #1189: native Java extractor used to double-emit
+      // interface methods (once from handle_interface_decl without children,
+      // once from the recursive handle_method_decl with parameter children),
+      // producing spurious `contains` edges to parameters of body-less
+      // declarations. Mirrors the C# fix in #1194.
+      name: 'Java — interface methods have no parameter children',
+      file: 'IFace.java',
+      code: `
+interface UserRepository {
+    String findById(String id);
+    void save(String id, String data);
+    boolean delete(String id);
+}
+`,
+    },
+    {
+      // Regression guard for #1189: WASM Kotlin extractor previously omitted
+      // parameter children from class/object methods (`collectKotlinMethods`
+      // built definitions without children), while native correctly extracted
+      // them. The two engines now agree.
+      name: 'Kotlin — class method parameters are children in both engines',
+      file: 'Repo.kt',
+      code: `
+class Repository {
+    private val storeRef = 0
+    fun save(item: String): Boolean { return true }
+    fun findByName(name: String): String? { return null }
+}
+`,
+    },
+    {
+      // Regression guard for #1189: CUDA grammar models a class-body member
+      // list as `field_declaration`s, so method declarations in `.cuh`
+      // headers used to be emitted as `property` children with the full
+      // signature as their name. Native stripped the `*` from pointer-return
+      // types while WASM kept it, producing 2+2 mismatched `contains` edges
+      // on the fixture. Both engines now skip method declarations during
+      // field extraction.
+      name: 'CUDA — class headers do not emit methods as property children',
+      file: 'svc.cuh',
+      code: `
+class UserRepository {
+public:
+    void save(const char *id, const char *name);
+    const char *findById(const char *id);
+};
 `,
     },
     {


### PR DESCRIPTION
## Summary

Three more per-language divergences from the v3.10.1-dev.80 dogfood report's residual `contains` gap, refs #1189.

- **Java native** — `handle_method_decl` did not skip methods inside an `interface_declaration`, so each interface method was emitted twice: once by `handle_interface_decl` (no children, matches WASM) and once again by the recursive walk's `handle_method_decl` (with parameter children). The duplicate inflated `contains` and `parameter_of` edge counts. Added the same `parent.parent == "interface_declaration"` guard the C# native extractor uses (introduced in #1194). 4 native-only contains edges in the fixture.

- **Kotlin WASM** — `collectKotlinMethods` and the object-body method loop in `handleKotlinObjectDecl` emitted class/object methods with no parameter children, while native correctly extracted them. WASM now calls `extractKotlinParameters` for each method and attaches the result as children. 8 native-only contains edges in the fixture.

- **Kotlin native** — `extract_kotlin_class_properties` looked for a `simple_identifier` directly inside `property_declaration`, but tree-sitter-kotlin nests the name as `property_declaration > variable_declaration > simple_identifier`. The lookup now drills through `variable_declaration` first (mirrors WASM's `collectKotlinProperties`). 1 WASM-only contains edge in the fixture.

- **CUDA both engines** — the tree-sitter-cuda grammar models a class body as a list of `field_declaration`s, so method declarations in `.cuh` headers were being emitted as `property` children whose name is the full method signature. Native stripped the pointer `*` while WASM kept it, producing 2 + 2 mismatched contains edges on the fixture. Both engines now detect when a field's declarator (after unwrapping pointer/reference/array/parenthesized wrappers) is a `function_declarator` and skip the entry — these are method declarations, not data fields. This also clears the unrelated "method-signature-as-property-name" bug for CUDA headers.

## Verification

- Cross-engine contains-edge diff on `tests/benchmarks/resolution/fixtures/{java,kotlin,cuda}/*` is now zero in both directions.
- `npx vitest run tests/engines/parity.test.ts` — 13 passed, 4 skipped (Java interface, Kotlin class methods, and CUDA header cases newly added as regression guards).
- `npx vitest run tests/parsers/ tests/engines/` — 567 passed.
- `npx vitest run tests/integration/ tests/graph/ tests/benchmarks/resolution/` — 975 passed.
- `cargo test --release --lib -- extractors::java extractors::kotlin extractors::cuda` — 78 passed.

## Test plan

- [x] Java interface method declarations get parameter children only via `handle_interface_decl` (no double emission).
- [x] Kotlin class/object methods carry parameter children in both engines.
- [x] Kotlin native `property_declaration` extraction sees the `variable_declaration` name.
- [x] CUDA `field_declaration`s whose declarator is a `function_declarator` are skipped in both engines.
- [x] All existing parity, parser, integration, and resolution tests pass.

Refs #1189 (Java, Kotlin, CUDA). Remaining: Objective-C, Ruby (single-edge case).