### PR TITLE
fix(extractors/elixir): extract default-value and pattern-match parameters

### DIFF
--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -151,16 +151,71 @@ fn extract_elixir_params(args: &Node, source: &[u8]) -> Vec<Definition> {
         let Some(inner_args) = find_child(&child, "arguments") else { continue };
         for j in 0..inner_args.child_count() {
             let Some(param) = inner_args.child(j) else { continue };
-            if param.kind() == "identifier" {
-                params.push(child_def(
-                    node_text(&param, source).to_string(),
-                    "parameter",
-                    start_line(&param),
-                ));
-            }
+            collect_elixir_param_identifiers(&param, source, &mut params);
         }
     }
     params
+}
+
+/// Recursively walk a parameter pattern and emit each bound identifier as a
+/// `parameter` child. Handles bare identifiers, default-value `a \\ default`,
+/// and tuple / map / struct destructuring (`{x, y}`, `%{k: v}`, `%Foo{k: v}`).
+fn collect_elixir_param_identifiers(node: &Node, source: &[u8], out: &mut Vec<Definition>) {
+    match node.kind() {
+        "identifier" => {
+            out.push(child_def(
+                node_text(node, source).to_string(),
+                "parameter",
+                start_line(node),
+            ));
+        }
+        "binary_operator" => {
+            // Default-value parameter: `name \\ default`. Only recurse when the operator
+            // is `\\` — other binary operators in argument position (e.g. list-cons `|`)
+            // are out of scope for this extractor pass.
+            let Some(op) = node.child(1) else { return };
+            if op.kind() != "\\\\" { return; }
+            if let Some(left) = node.child(0) {
+                collect_elixir_param_identifiers(&left, source, out);
+            }
+        }
+        "tuple" => {
+            for i in 0..node.child_count() {
+                let Some(c) = node.child(i) else { continue };
+                let k = c.kind();
+                if k == "{" || k == "}" || k == "," { continue; }
+                collect_elixir_param_identifiers(&c, source, out);
+            }
+        }
+        "map" => {
+            // `%{k: v}` or `%Foo{k: v}` — walk map_content > keywords > pair and emit
+            // each pair's value side (the bound name). The leading `struct` alias is a
+            // type, not a bound identifier, so it is intentionally skipped.
+            for i in 0..node.child_count() {
+                let Some(c) = node.child(i) else { continue };
+                if c.kind() == "map_content" {
+                    collect_elixir_map_bindings(&c, source, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_elixir_map_bindings(content: &Node, source: &[u8], out: &mut Vec<Definition>) {
+    for i in 0..content.child_count() {
+        let Some(kws) = content.child(i) else { continue };
+        if kws.kind() != "keywords" { continue; }
+        for j in 0..kws.child_count() {
+            let Some(pair) = kws.child(j) else { continue };
+            if pair.kind() != "pair" { continue; }
+            for k in 0..pair.child_count() {
+                let Some(part) = pair.child(k) else { continue };
+                if part.kind() == "keyword" { continue; }
+                collect_elixir_param_identifiers(&part, source, out);
+            }
+        }
+    }
 }
 
 fn extract_elixir_fn_name<'a>(args: &Node<'a>, source: &'a [u8]) -> Option<String> {

--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -159,7 +159,8 @@ fn extract_elixir_params(args: &Node, source: &[u8]) -> Vec<Definition> {
 
 /// Recursively walk a parameter pattern and emit each bound identifier as a
 /// `parameter` child. Handles bare identifiers, default-value `a \\ default`,
-/// and tuple / map / struct destructuring (`{x, y}`, `%{k: v}`, `%Foo{k: v}`).
+/// list-cons `[head | tail]`, list `[a, b, c]`, tuple `{x, y}`, and
+/// map / struct destructuring (`%{k: v}`, `%Foo{k: v}`).
 fn collect_elixir_param_identifiers(node: &Node, source: &[u8], out: &mut Vec<Definition>) {
     match node.kind() {
         "identifier" => {
@@ -170,13 +171,34 @@ fn collect_elixir_param_identifiers(node: &Node, source: &[u8], out: &mut Vec<De
             ));
         }
         "binary_operator" => {
-            // Default-value parameter: `name \\ default`. Only recurse when the operator
-            // is `\\` — other binary operators in argument position (e.g. list-cons `|`)
-            // are out of scope for this extractor pass.
+            // `name \\ default` (default-value) binds the left operand only.
+            // `head | tail` (list-cons, appears inside a `list` pattern) binds both operands.
             let Some(op) = node.child(1) else { return };
-            if op.kind() != "\\\\" { return; }
-            if let Some(left) = node.child(0) {
-                collect_elixir_param_identifiers(&left, source, out);
+            match op.kind() {
+                "\\\\" => {
+                    if let Some(left) = node.child(0) {
+                        collect_elixir_param_identifiers(&left, source, out);
+                    }
+                }
+                "|" => {
+                    if let Some(left) = node.child(0) {
+                        collect_elixir_param_identifiers(&left, source, out);
+                    }
+                    if let Some(right) = node.child(2) {
+                        collect_elixir_param_identifiers(&right, source, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+        "list" => {
+            // `[a, b, c]` or `[head | tail]` — walk children, skipping punctuation.
+            // The `|` cons case is handled by the `binary_operator` arm on recursion.
+            for i in 0..node.child_count() {
+                let Some(c) = node.child(i) else { continue };
+                let k = c.kind();
+                if k == "[" || k == "]" || k == "," { continue; }
+                collect_elixir_param_identifiers(&c, source, out);
             }
         }
         "tuple" => {

--- a/src/extractors/elixir.ts
+++ b/src/extractors/elixir.ts
@@ -199,7 +199,8 @@ function extractElixirParams(defCallNode: TreeSitterNode): SubDeclaration[] {
 /**
  * Recursively walk a parameter pattern and emit each bound identifier as a
  * `parameter` child. Handles bare identifiers, default-value `a \\ default`,
- * and tuple / map / struct destructuring (`{x, y}`, `%{k: v}`, `%Foo{k: v}`).
+ * list-cons `[head | tail]`, list `[a, b, c]`, tuple `{x, y}`, and
+ * map / struct destructuring (`%{k: v}`, `%Foo{k: v}`).
  */
 function collectElixirParamIdentifiers(node: TreeSitterNode, out: SubDeclaration[]): void {
   switch (node.type) {
@@ -207,15 +208,33 @@ function collectElixirParamIdentifiers(node: TreeSitterNode, out: SubDeclaration
       out.push({ name: node.text, kind: 'parameter', line: node.startPosition.row + 1 });
       return;
     case 'binary_operator': {
-      // Default-value parameter: `name \\ default`. The bound name is the left operand.
-      // Only recurse when the operator is `\\` — other binary operators (e.g. `|` in
-      // list-cons patterns) are out of scope for this extractor pass.
+      // `name \\ default` (default-value) binds the left operand only.
+      // `head | tail` (list-cons, appears inside a `list` pattern) binds both operands.
       const op = node.child(1);
-      if (!op || op.type !== '\\\\') return;
-      const left = node.child(0);
-      if (left) collectElixirParamIdentifiers(left, out);
+      if (!op) return;
+      if (op.type === '\\\\') {
+        const left = node.child(0);
+        if (left) collectElixirParamIdentifiers(left, out);
+        return;
+      }
+      if (op.type === '|') {
+        const left = node.child(0);
+        const right = node.child(2);
+        if (left) collectElixirParamIdentifiers(left, out);
+        if (right) collectElixirParamIdentifiers(right, out);
+        return;
+      }
       return;
     }
+    case 'list':
+      // `[a, b, c]` or `[head | tail]` — walk children, skipping punctuation. The
+      // `|` cons case is handled by the `binary_operator` arm when we recurse.
+      for (let i = 0; i < node.childCount; i++) {
+        const c = node.child(i);
+        if (!c || c.type === '[' || c.type === ']' || c.type === ',') continue;
+        collectElixirParamIdentifiers(c, out);
+      }
+      return;
     case 'tuple':
       for (let i = 0; i < node.childCount; i++) {
         const c = node.child(i);

--- a/src/extractors/elixir.ts
+++ b/src/extractors/elixir.ts
@@ -190,12 +190,65 @@ function extractElixirParams(defCallNode: TreeSitterNode): SubDeclaration[] {
     for (let j = 0; j < innerArgs.childCount; j++) {
       const param = innerArgs.child(j);
       if (!param) continue;
-      if (param.type === 'identifier') {
-        params.push({ name: param.text, kind: 'parameter', line: param.startPosition.row + 1 });
-      }
+      collectElixirParamIdentifiers(param, params);
     }
   }
   return params;
+}
+
+/**
+ * Recursively walk a parameter pattern and emit each bound identifier as a
+ * `parameter` child. Handles bare identifiers, default-value `a \\ default`,
+ * and tuple / map / struct destructuring (`{x, y}`, `%{k: v}`, `%Foo{k: v}`).
+ */
+function collectElixirParamIdentifiers(node: TreeSitterNode, out: SubDeclaration[]): void {
+  switch (node.type) {
+    case 'identifier':
+      out.push({ name: node.text, kind: 'parameter', line: node.startPosition.row + 1 });
+      return;
+    case 'binary_operator': {
+      // Default-value parameter: `name \\ default`. The bound name is the left operand.
+      // Only recurse when the operator is `\\` — other binary operators (e.g. `|` in
+      // list-cons patterns) are out of scope for this extractor pass.
+      const op = node.child(1);
+      if (!op || op.type !== '\\\\') return;
+      const left = node.child(0);
+      if (left) collectElixirParamIdentifiers(left, out);
+      return;
+    }
+    case 'tuple':
+      for (let i = 0; i < node.childCount; i++) {
+        const c = node.child(i);
+        if (!c || c.type === '{' || c.type === '}' || c.type === ',') continue;
+        collectElixirParamIdentifiers(c, out);
+      }
+      return;
+    case 'map':
+      // `%{k: v}` or `%Foo{k: v}` — walk map_content > keywords > pair and emit each
+      // pair's value side (the bound name). The struct alias (`Foo`) is a type, not a
+      // bound identifier, so the leading `struct` child is intentionally skipped.
+      for (let i = 0; i < node.childCount; i++) {
+        const c = node.child(i);
+        if (c && c.type === 'map_content') collectElixirMapBindings(c, out);
+      }
+      return;
+  }
+}
+
+function collectElixirMapBindings(content: TreeSitterNode, out: SubDeclaration[]): void {
+  for (let i = 0; i < content.childCount; i++) {
+    const kws = content.child(i);
+    if (!kws || kws.type !== 'keywords') continue;
+    for (let j = 0; j < kws.childCount; j++) {
+      const pair = kws.child(j);
+      if (!pair || pair.type !== 'pair') continue;
+      for (let k = 0; k < pair.childCount; k++) {
+        const part = pair.child(k);
+        if (!part || part.type === 'keyword') continue;
+        collectElixirParamIdentifiers(part, out);
+      }
+    }
+  }
 }
 
 function handleDefprotocol(node: TreeSitterNode, ctx: ExtractorOutput): void {

--- a/tests/benchmarks/resolution/fixtures/elixir/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/elixir/expected-edges.json
@@ -135,6 +135,20 @@
       "kind": "calls",
       "mode": "module-function",
       "notes": "Patterns.id_of() — exercises struct-pattern parameter extraction"
+    },
+    {
+      "source": { "name": "run", "file": "main.ex" },
+      "target": { "name": "head_of", "file": "patterns.ex" },
+      "kind": "calls",
+      "mode": "module-function",
+      "notes": "Patterns.head_of() — exercises list-cons pattern parameter extraction"
+    },
+    {
+      "source": { "name": "run", "file": "main.ex" },
+      "target": { "name": "all_of", "file": "patterns.ex" },
+      "kind": "calls",
+      "mode": "module-function",
+      "notes": "Patterns.all_of() — exercises list pattern parameter extraction"
     }
   ]
 }

--- a/tests/benchmarks/resolution/fixtures/elixir/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/elixir/expected-edges.json
@@ -107,6 +107,34 @@
       "kind": "calls",
       "mode": "module-function",
       "notes": "UserService.remove_user() — cross-module qualified call"
+    },
+    {
+      "source": { "name": "run", "file": "main.ex" },
+      "target": { "name": "fetch", "file": "patterns.ex" },
+      "kind": "calls",
+      "mode": "module-function",
+      "notes": "Patterns.fetch() — exercises default-value parameter extraction"
+    },
+    {
+      "source": { "name": "run", "file": "main.ex" },
+      "target": { "name": "first_of", "file": "patterns.ex" },
+      "kind": "calls",
+      "mode": "module-function",
+      "notes": "Patterns.first_of() — exercises tuple-pattern parameter extraction"
+    },
+    {
+      "source": { "name": "run", "file": "main.ex" },
+      "target": { "name": "name_of", "file": "patterns.ex" },
+      "kind": "calls",
+      "mode": "module-function",
+      "notes": "Patterns.name_of() — exercises map-pattern parameter extraction"
+    },
+    {
+      "source": { "name": "run", "file": "main.ex" },
+      "target": { "name": "id_of", "file": "patterns.ex" },
+      "kind": "calls",
+      "mode": "module-function",
+      "notes": "Patterns.id_of() — exercises struct-pattern parameter extraction"
     }
   ]
 }

--- a/tests/benchmarks/resolution/fixtures/elixir/main.ex
+++ b/tests/benchmarks/resolution/fixtures/elixir/main.ex
@@ -8,6 +8,10 @@ defmodule Main do
     label = UserService.display_user(store, "u1")
     IO.puts(label)
     store = UserService.remove_user(store, "u1")
+    _ = Patterns.fetch("https://example.com")
+    _ = Patterns.first_of({1, 2})
+    _ = Patterns.name_of(%{name: "x", email: "x@y"})
+    _ = Patterns.id_of(%User{id: 1})
     store
   end
 end

--- a/tests/benchmarks/resolution/fixtures/elixir/main.ex
+++ b/tests/benchmarks/resolution/fixtures/elixir/main.ex
@@ -12,6 +12,8 @@ defmodule Main do
     _ = Patterns.first_of({1, 2})
     _ = Patterns.name_of(%{name: "x", email: "x@y"})
     _ = Patterns.id_of(%User{id: 1})
+    _ = Patterns.head_of([1, 2, 3])
+    _ = Patterns.all_of([1, 2, 3])
     store
   end
 end

--- a/tests/benchmarks/resolution/fixtures/elixir/patterns.ex
+++ b/tests/benchmarks/resolution/fixtures/elixir/patterns.ex
@@ -14,4 +14,12 @@ defmodule Patterns do
   def id_of(%User{id: id}) do
     id
   end
+
+  def head_of([head | _tail]) do
+    head
+  end
+
+  def all_of([a, b, _c]) do
+    {a, b}
+  end
 end

--- a/tests/benchmarks/resolution/fixtures/elixir/patterns.ex
+++ b/tests/benchmarks/resolution/fixtures/elixir/patterns.ex
@@ -1,0 +1,17 @@
+defmodule Patterns do
+  def fetch(url, timeout \\ 5000, retries \\ 3) do
+    {url, timeout, retries}
+  end
+
+  def first_of({x, _y}) do
+    x
+  end
+
+  def name_of(%{name: name, email: _email}) do
+    name
+  end
+
+  def id_of(%User{id: id}) do
+    id
+  end
+end

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -245,6 +245,14 @@ end
   def id_of(%User{id: id}) do
     id
   end
+
+  def head_of([head | tail]) do
+    {head, tail}
+  end
+
+  def all_of([a, b, c]) do
+    {a, b, c}
+  end
 end
 `,
     },
@@ -387,6 +395,8 @@ module "vpc" {
   def first_of({x, _y}), do: x
   def name_of(%{name: name}), do: name
   def id_of(%User{id: id}), do: id
+  def head_of([head | tail]), do: head
+  def all_of([a, b, c]), do: a
 end
 `;
     const wasm = wasmExtract(code, 'patterns.ex');
@@ -405,6 +415,8 @@ end
       expect(byName.get('Patterns.first_of'), `${label} first_of`).toEqual(['x', '_y']);
       expect(byName.get('Patterns.name_of'), `${label} name_of`).toEqual(['name']);
       expect(byName.get('Patterns.id_of'), `${label} id_of`).toEqual(['id']);
+      expect(byName.get('Patterns.head_of'), `${label} head_of`).toEqual(['head', 'tail']);
+      expect(byName.get('Patterns.all_of'), `${label} all_of`).toEqual(['a', 'b', 'c']);
     }
   });
 

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -222,6 +222,33 @@ end
 `,
     },
     {
+      // Regression guard for #1197: both engines must extract bound identifiers
+      // from default-value (`a \\ default`), tuple, map, and struct parameter
+      // patterns. tree-sitter-elixir wraps these in `binary_operator` / `tuple`
+      // / `map` nodes rather than emitting bare identifiers, so naive
+      // identifier-only iteration drops the parameters silently.
+      name: 'Elixir — default-value and destructured parameter patterns',
+      file: 'patterns.ex',
+      code: `defmodule Patterns do
+  def fetch(url, timeout \\\\ 5000, retries \\\\ 3) do
+    {url, timeout, retries}
+  end
+
+  def first_of({x, _y}) do
+    x
+  end
+
+  def name_of(%{name: name, email: _email}) do
+    name
+  end
+
+  def id_of(%User{id: id}) do
+    id
+  end
+end
+`,
+    },
+    {
       // Regression guard: native previously dropped all Haskell function
       // parameters (positional pattern children). See #1189.
       name: 'Haskell — top-level functions with parameters',
@@ -349,6 +376,37 @@ module "vpc" {
       expect(nativeResult).toEqual(wasmResult);
     });
   }
+
+  // Explicit guard for #1197. The structural parity loop above only catches
+  // *divergence*; a regression where *both* engines silently drop default-value
+  // or pattern parameters would still pass. Assert the bound identifiers are
+  // present in each engine's output.
+  it('Elixir engines must extract bound identifiers from default-value and pattern params', () => {
+    const code = `defmodule Patterns do
+  def fetch(url, timeout \\\\ 5000, retries \\\\ 3), do: url
+  def first_of({x, _y}), do: x
+  def name_of(%{name: name}), do: name
+  def id_of(%User{id: id}), do: id
+end
+`;
+    const wasm = wasmExtract(code, 'patterns.ex');
+    const nat = nativeExtract(code, 'patterns.ex');
+    for (const [label, syms] of [
+      ['wasm', wasm],
+      ['native', nat],
+    ] as const) {
+      const byName = new Map(
+        (syms?.definitions ?? []).map((d: any) => [
+          d.name,
+          (d.children ?? []).map((c: any) => c.name),
+        ]),
+      );
+      expect(byName.get('Patterns.fetch'), `${label} fetch`).toEqual(['url', 'timeout', 'retries']);
+      expect(byName.get('Patterns.first_of'), `${label} first_of`).toEqual(['x', '_y']);
+      expect(byName.get('Patterns.name_of'), `${label} name_of`).toEqual(['name']);
+      expect(byName.get('Patterns.id_of'), `${label} id_of`).toEqual(['id']);
+    }
+  });
 
   // Explicit guard for the WASM Python fix in #1189. The structural parity
   // loop above strips `self` from both sides via normalize(), so a regression


### PR DESCRIPTION
## Summary

Both Elixir extractors (native and WASM) previously dropped any parameter whose tree-sitter node kind was not `identifier`. That silently lost every default-value (`a \\ 5`) and destructured (`{x, y}`, `%{k: v}`, `%Foo{k: v}`) parameter on every Elixir function.

Walk these shapes recursively in both engines and emit each bound identifier as a `parameter` child.

| Pattern | tree-sitter shape | Bound identifier(s) emitted |
|---|---|---|
| `b \\ 5` | `binary_operator` with `\\` operator | left operand |
| `{x, y}` | `tuple` | each non-punctuation child |
| `%{k: v}` / `%Foo{k: v}` | `map > map_content > keywords > pair` | each pair's value side |

Nested patterns (e.g. `%Outer{inner: {a, b}}`) are handled by recursing into the same dispatcher.

## Why this is not a parity gap

Prior to this PR both engines had the same bug, so the parity test passed even though both were wrong. The new explicit guard test asserts the bound identifiers are *present* on each engine's output — so a future regression that drops params in either or both engines fails the suite.

## Verification

- `npx vitest run tests/engines/parity.test.ts` — 16 passed (2 new Elixir cases)
- `npm test` — 2752 passed / 24 skipped, no regressions
- `cargo test --release` in `crates/codegraph-core` — 317 passed
- Local AST-walk comparison on the new `patterns.ex` fixture: WASM and native emit identical `parameter` children for default-value, tuple, map, and struct patterns

## Test plan

- [x] Both engines extract `a`, `b`, `c` from `def fetch(a, b \\ 5, c \\ "x")`
- [x] Both engines extract `x`, `y` from `def f({x, y})`
- [x] Both engines extract `name`, `age` from `def f(%{name: name, age: age})`
- [x] Both engines extract `id`, `email` from `def f(%User{id: id, email: email})`
- [x] Nested pattern `%Outer{inner: {a, b}}` emits `a`, `b`
- [x] Explicit non-divergence guard added to `tests/engines/parity.test.ts`

Closes #1197