### PR TITLE
fix(extractors): recursively walk Haskell pattern parameters

### DIFF
--- a/crates/codegraph-core/src/extractors/haskell.rs
+++ b/crates/codegraph-core/src/extractors/haskell.rs
@@ -59,18 +59,12 @@ fn extract_haskell_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
             "patterns" | "parameter" => {
                 for j in 0..child.child_count() {
                     if let Some(pat) = child.child(j) {
-                        if pat.kind() == "variable" || pat.kind() == "identifier" {
-                            params.push(child_def(
-                                node_text(&pat, source).to_string(),
-                                "parameter",
-                                start_line(&pat),
-                            ));
-                        }
+                        collect_haskell_pattern_bindings(&pat, source, &mut params);
                     }
                 }
             }
             "variable" if i > 0 => {
-                // Pattern parameter after the function name
+                // Pattern parameter after the function name (no enclosing `patterns` node)
                 params.push(child_def(
                     node_text(&child, source).to_string(),
                     "parameter",
@@ -81,6 +75,50 @@ fn extract_haskell_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
         }
     }
     params
+}
+
+// Walk a pattern node and emit each bound variable (and `_` for wildcards) as a parameter.
+// Container patterns — parens, constructor application, infix (cons), tuple, list, as, strict,
+// irrefutable, qualified — are transparent: descend into their children. `record` is special:
+// only the right-hand-side of each `field_pattern` is bound (the field name is not).
+// Literals, bare constructors, and operators do not bind.
+fn collect_haskell_pattern_bindings(node: &Node, source: &[u8], out: &mut Vec<Definition>) {
+    match node.kind() {
+        "variable" | "identifier" => {
+            out.push(child_def(
+                node_text(node, source).to_string(),
+                "parameter",
+                start_line(node),
+            ));
+        }
+        "wildcard" => {
+            out.push(child_def("_".to_string(), "parameter", start_line(node)));
+        }
+        "parens" | "apply" | "infix" | "tuple" | "list" | "strict" | "irrefutable" | "as"
+        | "qualified" => {
+            for i in 0..node.child_count() {
+                if let Some(c) = node.child(i) {
+                    collect_haskell_pattern_bindings(&c, source, out);
+                }
+            }
+        }
+        "record" => {
+            for i in 0..node.child_count() {
+                let Some(fp) = node.child(i) else { continue };
+                if fp.kind() != "field_pattern" {
+                    continue;
+                }
+                for j in 0..fp.child_count() {
+                    if let Some(g) = fp.child(j) {
+                        if g.kind() != "field_name" {
+                            collect_haskell_pattern_bindings(&g, source, out);
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 fn handle_haskell_bind(node: &Node, source: &[u8], symbols: &mut FileSymbols) {

--- a/src/extractors/haskell.ts
+++ b/src/extractors/haskell.ts
@@ -81,17 +81,58 @@ function extractHaskellParams(funcNode: TreeSitterNode): SubDeclaration[] {
     if (child.type === 'patterns' || child.type === 'parameter') {
       for (let j = 0; j < child.childCount; j++) {
         const pat = child.child(j);
-        if (pat && (pat.type === 'variable' || pat.type === 'identifier')) {
-          params.push({ name: pat.text, kind: 'parameter', line: pat.startPosition.row + 1 });
-        }
+        if (pat) collectHaskellPatternBindings(pat, params);
       }
     }
     if (child.type === 'variable' && i > 0) {
-      // Pattern parameters after the function name
+      // Pattern parameters after the function name (no enclosing `patterns` node)
       params.push({ name: child.text, kind: 'parameter', line: child.startPosition.row + 1 });
     }
   }
   return params;
+}
+
+// Walk a pattern node and emit each bound variable (and `_` for wildcards) as a parameter.
+// Container patterns — parens, constructor application, infix (cons), tuple, list, as, strict,
+// irrefutable, qualified — are transparent: descend into their children. `record` is special:
+// only the right-hand-side of each `field_pattern` is bound (the field name is not).
+// Literals, bare constructors, and operators do not bind.
+function collectHaskellPatternBindings(node: TreeSitterNode, out: SubDeclaration[]): void {
+  switch (node.type) {
+    case 'variable':
+    case 'identifier':
+      out.push({ name: node.text, kind: 'parameter', line: node.startPosition.row + 1 });
+      return;
+    case 'wildcard':
+      out.push({ name: '_', kind: 'parameter', line: node.startPosition.row + 1 });
+      return;
+    case 'parens':
+    case 'apply':
+    case 'infix':
+    case 'tuple':
+    case 'list':
+    case 'strict':
+    case 'irrefutable':
+    case 'as':
+    case 'qualified':
+      for (let i = 0; i < node.childCount; i++) {
+        const c = node.child(i);
+        if (c) collectHaskellPatternBindings(c, out);
+      }
+      return;
+    case 'record':
+      for (let i = 0; i < node.childCount; i++) {
+        const fp = node.child(i);
+        if (!fp || fp.type !== 'field_pattern') continue;
+        for (let j = 0; j < fp.childCount; j++) {
+          const g = fp.child(j);
+          if (g && g.type !== 'field_name') collectHaskellPatternBindings(g, out);
+        }
+      }
+      return;
+    default:
+      return;
+  }
 }
 
 function handleHaskellBind(node: TreeSitterNode, ctx: ExtractorOutput): void {

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -235,6 +235,30 @@ getUser uid store = lookup uid store
 `,
     },
     {
+      // Both engines must walk pattern-matched parameters recursively:
+      // constructor application (Just x), tuple (a, b), cons (x:xs), list [a, b],
+      // as-pattern xs@(...), and wildcards (_). See #1198.
+      name: 'Haskell — destructuring, wildcard, and constructor patterns',
+      file: 'Patterns.hs',
+      code: `module Patterns where
+
+fromJust (Just x) = x
+fromJust Nothing = error "Nothing"
+
+fstPair (a, b) = a
+sndPair (a, b) = b
+
+headList (x:xs) = x
+firstTwo [a, b] = a
+
+keepHead xs@(x:_) = (xs, x)
+
+ignoreFirst _ y = y
+
+deepUnpack (Just (a, b)) = (a, b)
+`,
+    },
+    {
       // Regression guard: WASM previously emitted `self`/`cls` as `parameter`
       // children of methods, but native skipped them — inflating contains and
       // parameter_of counts on every method. WASM now skips them too. See #1189.
@@ -349,6 +373,49 @@ module "vpc" {
       expect(nativeResult).toEqual(wasmResult);
     });
   }
+
+  // Explicit content guard for Haskell pattern destructuring (#1198). The
+  // structural parity loop above would pass even if both engines silently
+  // skipped constructor/tuple/list/wildcard patterns in tandem. Lock the
+  // expected bound names so a regression on either side is visible.
+  it('Haskell engines must extract bound names from destructuring patterns', () => {
+    const code = `module Patterns where
+
+fromJust (Just x) = x
+
+fstPair (a, b) = a
+
+headList (x:xs) = x
+
+firstTwo [a, b] = a
+
+keepHead xs@(x:_) = (xs, x)
+
+ignoreFirst _ y = y
+
+deepUnpack (Just (a, b)) = (a, b)
+`;
+    const expected: Record<string, string[]> = {
+      fromJust: ['x'],
+      fstPair: ['a', 'b'],
+      headList: ['x', 'xs'],
+      firstTwo: ['a', 'b'],
+      keepHead: ['xs', 'x', '_'],
+      ignoreFirst: ['_', 'y'],
+      deepUnpack: ['a', 'b'],
+    };
+    const check = (label: string, symbols: any) => {
+      const fns = (symbols?.definitions ?? []).filter((d: any) => d.kind === 'function');
+      for (const [fnName, want] of Object.entries(expected)) {
+        const fn = fns.find((d: any) => d.name === fnName);
+        expect(fn, `${label}: missing function ${fnName}`).toBeTruthy();
+        const got = (fn.children ?? []).map((c: any) => c.name);
+        expect(got, `${label}: ${fnName} params`).toEqual(want);
+      }
+    };
+    check('wasm', wasmExtract(code, 'Patterns.hs'));
+    if (hasNative) check('native', nativeExtract(code, 'Patterns.hs'));
+  });
 
   // Explicit guard for the WASM Python fix in #1189. The structural parity
   // loop above strips `self` from both sides via normalize(), so a regression


### PR DESCRIPTION
## Summary

- Both Haskell extractors (WASM `extractHaskellParams` and native `extract_haskell_params`) previously descended one level into `patterns` and accepted only `variable`/`identifier`, silently dropping every pattern-matched parameter — constructor application (`Just x`), tuple (`a, b`), cons (`x:xs`), list (`[a, b]`), as-pattern (`xs@(...)`), and wildcards (`_`).
- Replaced that with a recursive `collect…PatternBindings` helper in both engines that treats `parens`, `apply`, `infix`, `tuple`, `list`, `as`, `strict`, `irrefutable`, and `qualified` as transparent containers; emits the right-hand-side of each `record` `field_pattern` (skipping `field_name`); and emits `_` for `wildcard` to match how other languages report unbound positions.
- Added one structural parity case (`Patterns.hs`) and a content-pinning assertion that locks the exact bound names so a future tandem regression on either engine fails loudly — the existing structural loop on its own would still pass if both sides silently skipped patterns together.

## Test plan

- [x] `CODEGRAPH_PARITY=1 npx vitest run tests/engines/parity.test.ts` — new Haskell case + content guard pass, all 16 existing parity tests still pass.
- [x] `CODEGRAPH_PARITY=1 npm test` — full suite: 2752 passed, 24 skipped, 0 failed.
- [x] `CODEGRAPH_PARITY=1 npx vitest run tests/benchmarks/resolution` — Haskell resolution benchmark still passes (205/205).
- [x] `npm run build` + `npm run lint` — only pre-existing warnings, none introduced by this change.
- [x] `npx codegraph build` + `npx codegraph stats` — graph rebuilds clean on self-analysis.

Closes #1198