### PR TITLE
fix(native/kotlin): strip navigation_suffix wrapper from call name

### DIFF
--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -437,6 +437,5 @@ mod tests {
             .find(|c| !c.name.starts_with('.') && c.receiver.is_some())
             .expect("non-dot call with a receiver");
         assert_eq!(c_call.name, "c");
-        assert!(!c_call.name.starts_with('.'));
     }
 }

--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -315,11 +315,22 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         });
                     }
                     "navigation_expression" => {
-                        // obj.method()
-                        let name = fn_node.child_by_field_name("member")
+                        // tree-sitter-kotlin-sg wraps the member in a
+                        // `navigation_suffix` (children: `.` + simple_identifier),
+                        // so take the inner identifier — using the suffix's own
+                        // text would include the leading dot.
+                        let count = fn_node.child_count();
+                        let last = if count > 0 { fn_node.child(count - 1) } else { None };
+                        let name = fn_node
+                            .child_by_field_name("member")
                             .or_else(|| {
-                                let count = fn_node.child_count();
-                                if count > 0 { fn_node.child(count - 1) } else { None }
+                                last.and_then(|n| {
+                                    if n.kind() == "navigation_suffix" {
+                                        find_child(&n, "simple_identifier")
+                                    } else {
+                                        Some(n)
+                                    }
+                                })
                             })
                             .map(|n| node_text(&n, source).to_string())
                             .unwrap_or_else(|| node_text(&fn_node, source).to_string());
@@ -396,5 +407,36 @@ mod tests {
         let s = parse_kotlin("object Singleton { val x = 1 }");
         let obj = s.definitions.iter().find(|d| d.name == "Singleton").unwrap();
         assert_eq!(obj.kind, "class");
+    }
+
+    #[test]
+    fn navigation_expression_call_name_has_no_leading_dot() {
+        // Regression for #1200: tree-sitter-kotlin-sg models the callee of
+        // `store.add(item)` as `navigation_expression > navigation_suffix > .` +
+        // `simple_identifier`. The native extractor previously emitted the call
+        // name as `.add` (text of the whole suffix) instead of `add`.
+        let s = parse_kotlin(
+            "class Repository {\n    private val store = mutableListOf<String>()\n    fun save(item: String): Boolean { return store.add(item) }\n}",
+        );
+        let add_call = s
+            .calls
+            .iter()
+            .find(|c| c.receiver.as_deref() == Some("store"))
+            .expect("navigation_expression call with receiver=store");
+        assert_eq!(add_call.name, "add");
+    }
+
+    #[test]
+    fn chained_navigation_expression_resolves_inner_member() {
+        // Chained access: `a.b.c()` — the inner navigation_expression should
+        // resolve to member `c`, not `.c`.
+        let s = parse_kotlin("fun f() { a.b.c() }");
+        let c_call = s
+            .calls
+            .iter()
+            .find(|c| !c.name.starts_with('.') && c.receiver.is_some())
+            .expect("non-dot call with a receiver");
+        assert_eq!(c_call.name, "c");
+        assert!(!c_call.name.starts_with('.'));
     }
 }


### PR DESCRIPTION
## Summary

The native Kotlin extractor was emitting `call_expression` whose callee is a `navigation_expression` (e.g. `store.add(item)`) with a leading-dot name (`.add`), while WASM emitted the bare member name (`add`). This inflated Kotlin `calls` edge counts and broke receiver-typed resolution.

Root cause: `tree-sitter-kotlin-sg` v0.4 wraps the member in a `navigation_suffix` node whose children are the literal `.` token and a `simple_identifier`. The previous fallback to the last child of `navigation_expression` returned the `navigation_suffix` itself, so its full text (`.add`) was used as the call name.

Fix: when the last child is a `navigation_suffix`, drill into it to find the inner `simple_identifier`. Mirrors the WASM extractor's behavior on `tree-sitter-kotlin` v0.3.

## Verification

- `cargo test --release --lib -- extractors::kotlin` — 7 passed (including two new regression tests: bare `store.add(item)` and chained `a.b.c()`).

## Test plan

- [x] `navigation_expression` callee with single dot resolves to bare member name (no leading dot).
- [x] Chained `a.b.c()` resolves outer call name to `c`.
- [x] Existing Kotlin extractor tests still pass.

## Notes

- Depends on #1199 (Java/Kotlin/CUDA contains parity) only by topic — there are no file conflicts. This PR touches only the `navigation_expression` arm of `match_kotlin_node` in `crates/codegraph-core/src/extractors/kotlin.rs`; #1199 touches `extract_kotlin_class_properties` in the same file.
- A Kotlin parity case for `parity.test.ts` exercising navigation_expression can be a follow-up after #1199 lands (which adds the first Kotlin entries to that test file).

Closes #1200