### PR TITLE
fix(extractors): drill through function_declarator for parameter names (#1206)

### DIFF
--- a/crates/codegraph-core/src/extractors/c.rs
+++ b/crates/codegraph-core/src/extractors/c.rs
@@ -66,12 +66,18 @@ fn match_c_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
     }
 }
 
-/// Walk pointer_declarator / array_declarator chains to reach the identifier.
+/// Walk pointer_declarator / array_declarator / function_declarator chains to
+/// reach the identifier. `function_declarator` is unwrapped so that
+/// function-type parameters like `void process(int callback(int))` yield the
+/// bare name (`callback`) instead of the full declarator text.
 fn unwrap_declarator(node: &Node, source: &[u8]) -> String {
     let mut current = *node;
     loop {
         match current.kind() {
-            "pointer_declarator" | "array_declarator" | "parenthesized_declarator" => {
+            "pointer_declarator"
+            | "array_declarator"
+            | "parenthesized_declarator"
+            | "function_declarator" => {
                 if let Some(inner) = current.child_by_field_name("declarator") {
                     current = inner;
                 } else {
@@ -381,5 +387,19 @@ mod tests {
         let s = parse_c("void f() { printf(\"hello\"); }");
         let call = s.calls.iter().find(|c| c.name == "printf").unwrap();
         assert_eq!(call.name, "printf");
+    }
+
+    #[test]
+    fn function_type_parameter_unwraps_to_bare_identifier() {
+        // `int callback(int)` as a parameter parses as a `function_declarator`
+        // whose inner declarator is the identifier. `unwrap_declarator` must
+        // drill through it so the parameter name is `callback`, not the raw
+        // declarator text `callback(int)`. Follow-up #1206.
+        let s = parse_c("void process(int callback(int)) {}");
+        let process = s.definitions.iter().find(|d| d.name == "process").unwrap();
+        let children = process.children.as_ref().expect("function has children");
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "callback");
+        assert_eq!(children[0].kind, "parameter");
     }
 }

--- a/crates/codegraph-core/src/extractors/cpp.rs
+++ b/crates/codegraph-core/src/extractors/cpp.rs
@@ -70,11 +70,13 @@ fn unwrap_cpp_declarator(node: &Node, source: &[u8]) -> String {
     loop {
         match current.kind() {
             "pointer_declarator" | "reference_declarator" | "array_declarator"
-            | "parenthesized_declarator" => {
+            | "parenthesized_declarator" | "function_declarator" => {
                 // tree-sitter-cpp's `reference_declarator` rule does not expose a
                 // `declarator` field, so `child_by_field_name` returns None and
                 // the full node text (`& name`) leaks out. Fall back to scanning
                 // children for the next nested declarator or identifier.
+                // `function_declarator` is unwrapped so that function-type
+                // parameters like `void f(int cb(int))` yield the bare name.
                 let inner = current
                     .child_by_field_name("declarator")
                     .or_else(|| next_cpp_declarator_child(&current));
@@ -100,7 +102,8 @@ fn next_cpp_declarator_child<'a>(node: &Node<'a>) -> Option<Node<'a>> {
                 | "pointer_declarator"
                 | "reference_declarator"
                 | "array_declarator"
-                | "parenthesized_declarator" => return Some(child),
+                | "parenthesized_declarator"
+                | "function_declarator" => return Some(child),
                 _ => {}
             }
         }
@@ -478,5 +481,19 @@ mod tests {
         let params = func.children.as_ref().expect("function has children");
         assert_eq!(params.len(), 1);
         assert_eq!(params[0].name, "x");
+    }
+
+    #[test]
+    fn function_type_parameter_unwraps_to_bare_identifier() {
+        // `int callback(int)` as a parameter parses as a `function_declarator`
+        // whose inner declarator is the identifier. `unwrap_cpp_declarator`
+        // must drill through it so the parameter name is `callback`, not the
+        // raw declarator text `callback(int)`. Follow-up #1206.
+        let s = parse_cpp("void process(int callback(int)) {}");
+        let process = s.definitions.iter().find(|d| d.name == "process").unwrap();
+        let params = process.children.as_ref().expect("function has children");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, "callback");
+        assert_eq!(params[0].kind, "parameter");
     }
 }

--- a/crates/codegraph-core/src/extractors/cuda.rs
+++ b/crates/codegraph-core/src/extractors/cuda.rs
@@ -143,7 +143,8 @@ fn unwrap_cuda_declarator(node: &Node, source: &[u8]) -> String {
             "pointer_declarator"
             | "reference_declarator"
             | "array_declarator"
-            | "parenthesized_declarator" => {
+            | "parenthesized_declarator"
+            | "function_declarator" => {
                 if let Some(inner) = current.child_by_field_name("declarator") {
                     current = inner;
                 } else {
@@ -724,6 +725,20 @@ mod tests {
     fn extracts_typedef_alias() {
         let s = parse_cuda("typedef unsigned int uint32_t;");
         assert!(s.definitions.iter().any(|d| d.name == "uint32_t" && d.kind == "type"));
+    }
+
+    #[test]
+    fn function_type_parameter_unwraps_to_bare_identifier() {
+        // `int callback(int)` as a parameter parses as a `function_declarator`
+        // whose inner declarator is the identifier. `unwrap_cuda_declarator`
+        // must drill through it so the parameter name is `callback`, not the
+        // raw declarator text `callback(int)`. Follow-up #1206.
+        let s = parse_cuda("void process(int callback(int)) {}");
+        let process = s.definitions.iter().find(|d| d.name == "process").unwrap();
+        let params = process.children.as_ref().expect("function has children");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, "callback");
+        assert_eq!(params[0].kind, "parameter");
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/objc.rs
+++ b/crates/codegraph-core/src/extractors/objc.rs
@@ -613,7 +613,10 @@ fn unwrap_c_declarator(node: &Node, source: &[u8]) -> String {
     let mut current = *node;
     loop {
         match current.kind() {
-            "pointer_declarator" | "array_declarator" | "parenthesized_declarator" => {
+            "pointer_declarator"
+            | "array_declarator"
+            | "parenthesized_declarator"
+            | "function_declarator" => {
                 if let Some(inner) = current.child_by_field_name("declarator") {
                     current = inner;
                 } else {
@@ -765,5 +768,19 @@ mod tests {
         let kids = foo.children.as_ref().unwrap();
         let prop = kids.iter().find(|k| k.kind == "property").unwrap();
         assert_eq!(prop.name, "name");
+    }
+
+    #[test]
+    fn function_type_parameter_unwraps_to_bare_identifier() {
+        // `int callback(int)` as a parameter parses as a `function_declarator`
+        // whose inner declarator is the identifier. `unwrap_c_declarator` must
+        // drill through it so the parameter name is `callback`, not the raw
+        // declarator text `callback(int)`. Follow-up #1206.
+        let s = parse_objc("void process(int callback(int)) {}");
+        let process = s.definitions.iter().find(|d| d.name == "process").unwrap();
+        let params = process.children.as_ref().expect("function has children");
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0].name, "callback");
+        assert_eq!(params[0].kind, "parameter");
     }
 }

--- a/src/extractors/c.ts
+++ b/src/extractors/c.ts
@@ -159,6 +159,31 @@ function handleCCallExpression(node: TreeSitterNode, ctx: ExtractorOutput): void
 
 // ── Child extraction helpers ────────────────────────────────────────────────
 
+const C_DECLARATOR_WRAPPERS = new Set([
+  'pointer_declarator',
+  'array_declarator',
+  'parenthesized_declarator',
+  'function_declarator',
+]);
+
+/**
+ * Drill through pointer/array/parenthesized/function declarator wrappers to
+ * recover the bare identifier. Mirrors `unwrap_declarator` in the native C
+ * extractor so both engines agree on the name for parameters such as
+ * `void process(int callback(int))` (function-type parameter → `callback`) or
+ * `int *func(int)` (pointer-returning function → `func`).
+ */
+function unwrapCDeclaratorName(node: TreeSitterNode): string {
+  let current: TreeSitterNode | null = node;
+  while (current && C_DECLARATOR_WRAPPERS.has(current.type)) {
+    current = current.childForFieldName('declarator');
+  }
+  if (current?.type === 'identifier' || current?.type === 'field_identifier') {
+    return current.text;
+  }
+  return current?.text ?? node.text;
+}
+
 function extractCParameters(paramListNode: TreeSitterNode | null): SubDeclaration[] {
   const params: SubDeclaration[] = [];
   if (!paramListNode) return params;
@@ -167,10 +192,7 @@ function extractCParameters(paramListNode: TreeSitterNode | null): SubDeclaratio
     if (!param || param.type !== 'parameter_declaration') continue;
     const nameNode = param.childForFieldName('declarator');
     if (nameNode) {
-      const name =
-        nameNode.type === 'identifier'
-          ? nameNode.text
-          : (findChild(nameNode, 'identifier')?.text ?? nameNode.text);
+      const name = unwrapCDeclaratorName(nameNode);
       params.push({ name, kind: 'parameter', line: param.startPosition.row + 1 });
     }
   }
@@ -186,10 +208,7 @@ function extractStructFields(structNode: TreeSitterNode): SubDeclaration[] {
     if (!member || member.type !== 'field_declaration') continue;
     const nameNode = member.childForFieldName('declarator');
     if (nameNode) {
-      const name =
-        nameNode.type === 'identifier'
-          ? nameNode.text
-          : (findChild(nameNode, 'identifier')?.text ?? nameNode.text);
+      const name = unwrapCDeclaratorName(nameNode);
       fields.push({ name, kind: 'property', line: member.startPosition.row + 1 });
     }
   }

--- a/src/extractors/cpp.ts
+++ b/src/extractors/cpp.ts
@@ -239,6 +239,54 @@ function findCppParentClass(node: TreeSitterNode): string | null {
   return null;
 }
 
+const CPP_DECLARATOR_WRAPPERS = new Set([
+  'pointer_declarator',
+  'reference_declarator',
+  'array_declarator',
+  'parenthesized_declarator',
+  'function_declarator',
+]);
+
+/**
+ * Drill through pointer/reference/array/parenthesized/function declarator
+ * wrappers to recover the bare identifier. Mirrors `unwrap_cpp_declarator` in
+ * the native C++ extractor. tree-sitter-cpp's `reference_declarator` does not
+ * expose a `declarator` field, so the loop falls back to scanning children
+ * for the next nested declarator or identifier.
+ */
+function unwrapCppDeclaratorName(node: TreeSitterNode): string {
+  let current: TreeSitterNode | null = node;
+  while (current && CPP_DECLARATOR_WRAPPERS.has(current.type)) {
+    const named = current.childForFieldName('declarator');
+    if (named) {
+      current = named;
+      continue;
+    }
+    const fallback = nextCppDeclaratorChild(current);
+    if (!fallback) break;
+    current = fallback;
+  }
+  if (current?.type === 'identifier' || current?.type === 'field_identifier') {
+    return current.text;
+  }
+  return current?.text ?? node.text;
+}
+
+function nextCppDeclaratorChild(node: TreeSitterNode): TreeSitterNode | null {
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (!child) continue;
+    if (
+      child.type === 'identifier' ||
+      child.type === 'field_identifier' ||
+      CPP_DECLARATOR_WRAPPERS.has(child.type)
+    ) {
+      return child;
+    }
+  }
+  return null;
+}
+
 function extractCppParameters(paramListNode: TreeSitterNode | null): SubDeclaration[] {
   const params: SubDeclaration[] = [];
   if (!paramListNode) return params;
@@ -247,10 +295,7 @@ function extractCppParameters(paramListNode: TreeSitterNode | null): SubDeclarat
     if (!param || param.type !== 'parameter_declaration') continue;
     const nameNode = param.childForFieldName('declarator');
     if (nameNode) {
-      const name =
-        nameNode.type === 'identifier'
-          ? nameNode.text
-          : (findChild(nameNode, 'identifier')?.text ?? nameNode.text);
+      const name = unwrapCppDeclaratorName(nameNode);
       params.push({ name, kind: 'parameter', line: param.startPosition.row + 1 });
     }
   }
@@ -267,10 +312,7 @@ function extractCppClassFields(classNode: TreeSitterNode): SubDeclaration[] {
     if (!member || member.type !== 'field_declaration') continue;
     const nameNode = member.childForFieldName('declarator');
     if (nameNode) {
-      const name =
-        nameNode.type === 'identifier'
-          ? nameNode.text
-          : (findChild(nameNode, 'identifier')?.text ?? nameNode.text);
+      const name = unwrapCppDeclaratorName(nameNode);
       fields.push({
         name,
         kind: 'property',

--- a/src/extractors/cuda.ts
+++ b/src/extractors/cuda.ts
@@ -325,11 +325,13 @@ function isCudaMethodDeclarator(node: TreeSitterNode): boolean {
 }
 
 /**
- * Resolve the identifier of a class field's declarator by walking through any
- * combination of pointer/reference/array/parenthesized wrappers and (for
- * function-pointer fields) a `function_declarator`. Method declarations are
- * filtered before this is called, so a `function_declarator` here always
- * wraps a function-pointer field.
+ * Resolve the identifier of a declarator by walking through any combination of
+ * pointer/reference/array/parenthesized wrappers and `function_declarator`
+ * nodes. Used by both class-field extraction (where `function_declarator`
+ * indicates a function-pointer field after method declarations have been
+ * filtered out) and parameter extraction (where `function_declarator` wraps a
+ * bare function-type parameter name like `callback` in
+ * `void process(int callback(int))`).
  */
 function extractCudaFieldName(decl: TreeSitterNode): string {
   let current: TreeSitterNode | null = decl;

--- a/src/extractors/cuda.ts
+++ b/src/extractors/cuda.ts
@@ -265,10 +265,10 @@ function extractCudaParameters(paramListNode: TreeSitterNode | null): SubDeclara
     if (!param || param.type !== 'parameter_declaration') continue;
     const nameNode = param.childForFieldName('declarator');
     if (nameNode) {
-      const name =
-        nameNode.type === 'identifier'
-          ? nameNode.text
-          : (findChild(nameNode, 'identifier')?.text ?? nameNode.text);
+      // Reuse the field-name drill helper so function-type parameters like
+      // `void process(int callback(int))` yield the bare name `callback`
+      // instead of the raw declarator text, matching the native unwrap path.
+      const name = extractCudaFieldName(nameNode);
       params.push({ name, kind: 'parameter', line: param.startPosition.row + 1 });
     }
   }

--- a/src/extractors/objc.ts
+++ b/src/extractors/objc.ts
@@ -531,14 +531,17 @@ const OBJC_DECLARATOR_WRAPPERS = new Set([
   'reference_declarator',
   'array_declarator',
   'parenthesized_declarator',
+  'function_declarator',
 ]);
 
 /**
- * Drill through pointer/array/reference/parenthesized declarator wrappers to
- * recover the bare parameter identifier. Without this the WASM extractor
- * emitted raw declarator text (e.g. `*argv[]`) while native unwrapped to
- * `argv`, producing a cross-engine `contains` divergence on
- * `int main(int argc, const char *argv[])` and similar C-style parameters.
+ * Drill through pointer/array/reference/parenthesized/function declarator
+ * wrappers to recover the bare parameter identifier. Without this the WASM
+ * extractor emitted raw declarator text (e.g. `*argv[]` or `callback(int x)`)
+ * while native unwrapped to `argv` / `callback`, producing cross-engine
+ * `contains` divergence on C-style parameters such as
+ * `int main(int argc, const char *argv[])` and function-type parameters such
+ * as `void process(int callback(int))`.
  */
 function unwrapObjCDeclaratorName(node: TreeSitterNode): string {
   let current: TreeSitterNode | null = node;

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -486,6 +486,46 @@ int main(int argc, const char *argv[]) {
 `,
     },
     {
+      // Regression for follow-up #1206: function-type parameters such as
+      // `int callback(int)` parse the parameter's declarator as a
+      // `function_declarator` wrapping the bare identifier. Pre-fix both
+      // engines emitted the raw declarator text (`callback(int)`) for at
+      // least one of (native C/ObjC/C++/CUDA, WASM ObjC). After the fix all
+      // declarator-unwrap helpers drill through `function_declarator` so
+      // the parameter name is `callback` in every C-family engine.
+      // Skip until next native binary release includes the unwrap fix.
+      skip: true,
+      name: 'C — function-type parameter unwraps to bare identifier',
+      file: 'main.c',
+      code: `
+void process(int callback(int)) {}
+`,
+    },
+    {
+      skip: true,
+      name: 'C++ — function-type parameter unwraps to bare identifier',
+      file: 'main.cpp',
+      code: `
+void process(int callback(int)) {}
+`,
+    },
+    {
+      skip: true,
+      name: 'Objective-C — function-type parameter unwraps to bare identifier',
+      file: 'main.m',
+      code: `
+void process(int callback(int)) {}
+`,
+    },
+    {
+      skip: true,
+      name: 'CUDA — function-type parameter unwraps to bare identifier',
+      file: 'main.cu',
+      code: `
+void process(int callback(int)) {}
+`,
+    },
+    {
       name: 'PHP — classes and use',
       file: 'test.php',
       // Known gap: PHP WASM grammar not always available in CI/worktrees

--- a/tests/parsers/c.test.ts
+++ b/tests/parsers/c.test.ts
@@ -64,6 +64,19 @@ describe('C parser', () => {
     expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'printf' }));
   });
 
+  it('unwraps function-type parameter to bare identifier', () => {
+    // `int callback(int)` as a parameter parses as a `function_declarator`
+    // whose inner `declarator` is the identifier. Drill through it so the
+    // parameter name is `callback`, not `callback(int)`.
+    const symbols = parseC(`void process(int callback(int)) {}`);
+    const process = symbols.definitions.find((d) => d.name === 'process');
+    expect(process).toBeDefined();
+    expect(process.children).toBeDefined();
+    expect(process.children.length).toBe(1);
+    expect(process.children[0].name).toBe('callback');
+    expect(process.children[0].kind).toBe('parameter');
+  });
+
   it('extracts calls with receiver', () => {
     const symbols = parseC(`void f() { obj->method(); }`);
     const call = symbols.calls.find((c) => c.name === 'method');

--- a/tests/parsers/c.test.ts
+++ b/tests/parsers/c.test.ts
@@ -71,10 +71,10 @@ describe('C parser', () => {
     const symbols = parseC(`void process(int callback(int)) {}`);
     const process = symbols.definitions.find((d) => d.name === 'process');
     expect(process).toBeDefined();
-    expect(process.children).toBeDefined();
-    expect(process.children.length).toBe(1);
-    expect(process.children[0].name).toBe('callback');
-    expect(process.children[0].kind).toBe('parameter');
+    expect(process?.children).toBeDefined();
+    expect(process?.children?.length).toBe(1);
+    expect(process?.children?.[0]?.name).toBe('callback');
+    expect(process?.children?.[0]?.kind).toBe('parameter');
   });
 
   it('extracts calls with receiver', () => {

--- a/tests/parsers/cpp.test.ts
+++ b/tests/parsers/cpp.test.ts
@@ -73,4 +73,17 @@ describe('C++ parser', () => {
     const symbols = parseCpp(`void f() { std::cout << "hello"; bar(); }`);
     expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'bar' }));
   });
+
+  it('unwraps function-type parameter to bare identifier', () => {
+    // `int callback(int)` as a parameter parses as a `function_declarator`
+    // whose inner `declarator` is the identifier. Drill through it so the
+    // parameter name is `callback`, not `callback(int)`.
+    const symbols = parseCpp(`void process(int callback(int)) {}`);
+    const process = symbols.definitions.find((d) => d.name === 'process');
+    expect(process).toBeDefined();
+    expect(process.children).toBeDefined();
+    expect(process.children.length).toBe(1);
+    expect(process.children[0].name).toBe('callback');
+    expect(process.children[0].kind).toBe('parameter');
+  });
 });

--- a/tests/parsers/cpp.test.ts
+++ b/tests/parsers/cpp.test.ts
@@ -81,9 +81,9 @@ describe('C++ parser', () => {
     const symbols = parseCpp(`void process(int callback(int)) {}`);
     const process = symbols.definitions.find((d) => d.name === 'process');
     expect(process).toBeDefined();
-    expect(process.children).toBeDefined();
-    expect(process.children.length).toBe(1);
-    expect(process.children[0].name).toBe('callback');
-    expect(process.children[0].kind).toBe('parameter');
+    expect(process?.children).toBeDefined();
+    expect(process?.children?.length).toBe(1);
+    expect(process?.children?.[0]?.name).toBe('callback');
+    expect(process?.children?.[0]?.kind).toBe('parameter');
   });
 });

--- a/tests/parsers/cuda.test.ts
+++ b/tests/parsers/cuda.test.ts
@@ -55,6 +55,20 @@ public:
     expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'cudaMalloc' }));
   });
 
+  it('unwraps function-type parameter to bare identifier', () => {
+    // `int callback(int)` as a parameter parses as a `function_declarator`
+    // whose inner `declarator` is the identifier. Drill through it so the
+    // parameter name is `callback`, not `callback(int)`. Matches
+    // `unwrap_cuda_declarator` in `crates/codegraph-core/src/extractors/cuda.rs`.
+    const symbols = parseCuda(`void process(int callback(int)) {}`);
+    const process = symbols.definitions.find((d) => d.name === 'process');
+    expect(process).toBeDefined();
+    expect(process?.children).toBeDefined();
+    expect(process?.children?.length).toBe(1);
+    expect(process?.children?.[0]?.name).toBe('callback');
+    expect(process?.children?.[0]?.kind).toBe('parameter');
+  });
+
   it('keeps function-pointer class fields and skips real methods', () => {
     // Regression for follow-up #1204: a `field_declaration` whose declarator
     // is a `function_declarator` wrapping a `parenthesized_declarator` is a

--- a/tests/parsers/objc.test.ts
+++ b/tests/parsers/objc.test.ts
@@ -130,6 +130,21 @@ describe('Objective-C parser', () => {
     );
   });
 
+  it('unwraps function-type parameter to bare identifier', () => {
+    // `int callback(int)` as a parameter parses as a `function_declarator`
+    // whose inner `declarator` is the identifier. The unwrap helper must
+    // drill through it so the parameter name is `callback`, not
+    // `callback(int)`. Matches `unwrap_c_declarator` in
+    // `crates/codegraph-core/src/extractors/objc.rs`.
+    const symbols = parseObjC(`void process(int callback(int)) {}`);
+    const process = symbols.definitions.find((d) => d.name === 'process');
+    expect(process).toBeDefined();
+    expect(process?.children).toBeDefined();
+    expect(process?.children?.length).toBe(1);
+    expect(process?.children?.[0]?.name).toBe('callback');
+    expect(process?.children?.[0]?.kind).toBe('parameter');
+  });
+
   it('extracts @property names nested under struct_declarator', () => {
     // The v3 grammar does not expose `name` as a named field on
     // `property_declaration`; the identifier nests under


### PR DESCRIPTION
## Summary

- Follow-up #1206: function-type parameters like `void process(int callback(int))` previously came back as the raw declarator text (`callback(int)`) from native C/Obj-C/C++/CUDA and WASM Obj-C, because every `unwrap_*_declarator` helper stopped at `function_declarator`.
- Add `function_declarator` to every C-family declarator-unwrap helper in both engines so the parameter name resolves to the inner identifier — mirrors the pattern in `extract_cpp_func_name_from_declarator`.
- Replace the fragile `findChild(nameNode, 'identifier')` lookup in WASM C/C++/CUDA with proper drill-through helpers (`unwrapCDeclaratorName`, `unwrapCppDeclaratorName`, reused `extractCudaFieldName`) so they match native on nested cases too.

CUDA was included for consistency: it shares the C++ grammar and `unwrap_cuda_declarator` had the same bug — leaving it would have introduced a new parity gap.

Closes #1206

## Test plan

- [x] Native Rust extractor tests added — C/C++/Obj-C/CUDA `function_type_parameter_unwraps_to_bare_identifier` (4 new, all pass: `cargo test --lib function_type_parameter_unwraps_to_bare_identifier`)
- [x] WASM parser tests added — `c.test.ts`, `cpp.test.ts`, `objc.test.ts`, `cuda.test.ts` (4 new, all pass: `npx vitest run tests/parsers/{c,cpp,objc,cuda}.test.ts`)
- [x] Parity test cases added for C, C++, Obj-C, CUDA — marked `skip: true` pending the next native binary release (mirrors the pattern used by #1204/#1207)
- [x] Full Rust suite: 324 passed
- [x] Full WASM suite: no new failures introduced; existing failures are pre-existing (stale prebuilt native binary, F# parser issues — unrelated to this PR)