### PR TITLE
fix(bench/embed): drop stale HF_TOKEN gate on jina-code

### DIFF
--- a/scripts/embedding-benchmark.ts
+++ b/scripts/embedding-benchmark.ts
@@ -154,7 +154,6 @@ const dbPath = path.join(root, '.codegraph', 'graph.db');
 const { MODELS } = await import(srcImport(srcDir, 'domain/search/index.js'));
 
 const TIMEOUT_MS = 1_800_000; // 30 min — with symbol sampling, embed (~18 min) + search (~5 min) fits comfortably
-const hasHfToken = !!process.env.HF_TOKEN;
 const modelKeys = Object.keys(MODELS);
 const results = {};
 let symbolCount = 0;
@@ -162,11 +161,6 @@ let symbolCount = 0;
 const scriptPath = fileURLToPath(import.meta.url);
 
 for (const key of modelKeys) {
-	if (key === 'jina-code' && !hasHfToken) {
-		console.error(`Skipping ${key} (HF_TOKEN not set)`);
-		continue;
-	}
-
 	const data = await forkWorker(scriptPath, MODEL_WORKER_KEY, key, process.argv.slice(2), TIMEOUT_MS);
 	if (data) {
 		results[key] = data.result;


### PR DESCRIPTION
## Summary
- `scripts/embedding-benchmark.ts` skipped `jina-code` whenever `HF_TOKEN` was unset, leaving dogfood reports (e.g. v3.10.1-dev.80) carrying a misleading "requires HF_TOKEN" note.
- PR #1053 already repointed the alias at the public `jinaai/jina-embeddings-v2-base-code` (Apache-2.0) and dropped the README caveat — this gate in the bench harness was missed.
- Removed the 6-line gate so `jina-code` is benchmarked alongside the other models.

The generic 401/`gated` error handler in `src/domain/search/models.ts:240` is unchanged — it stays in place as a fallback for any future gated model.

## Test plan
- [ ] `npm run bench:embed` runs `jina-code` through the worker without `HF_TOKEN` set and produces a row in the output JSON
- [ ] No type-check regressions (`npx tsc --noEmit` clean)