### PR TITLE
refactor(parity): render orchestrator-drop summary as a per-extension table

### DIFF
--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -1018,7 +1018,7 @@ async function backfillNativeDroppedFiles(
     // summary directly to avoid a redundant classification pass.
     const staleByExt = groupByExtension(staleRel);
     info(
-      `Detected ${staleRel.length} deleted WASM-only file(s) the native orchestrator skipped; purging stale rows: ${formatDropExtensionSummary(staleByExt)}`,
+      `Detected ${staleRel.length} deleted WASM-only file(s) across ${staleByExt.size} extension(s) the native orchestrator skipped; purging stale rows:${formatDropExtensionSummary(staleByExt)}`,
     );
     purgeFilesData(dbConn, staleRel);
   }
@@ -1031,13 +1031,15 @@ async function backfillNativeDroppedFiles(
   // the language IS supported by the addon yet the file was dropped anyway.
   const { byReason, totals } = classifyNativeDrops(missingRel);
   if (totals['unsupported-by-native'] > 0) {
+    const buckets = byReason['unsupported-by-native'];
     info(
-      `Native orchestrator skipped ${totals['unsupported-by-native']} file(s) in languages without a Rust extractor; backfilling via WASM: ${formatDropExtensionSummary(byReason['unsupported-by-native'])}`,
+      `Native orchestrator skipped ${totals['unsupported-by-native']} file(s) across ${buckets.size} extension(s) in languages without a Rust extractor; backfilling via WASM:${formatDropExtensionSummary(buckets)}`,
     );
   }
   if (totals['native-extractor-failure'] > 0) {
+    const buckets = byReason['native-extractor-failure'];
     warn(
-      `Native orchestrator dropped ${totals['native-extractor-failure']} file(s) in natively-supported languages — likely a Rust extractor bug. Backfilling via WASM: ${formatDropExtensionSummary(byReason['native-extractor-failure'])}`,
+      `Native orchestrator dropped ${totals['native-extractor-failure']} file(s) across ${buckets.size} extension(s) in natively-supported languages — likely a Rust extractor bug. Backfilling via WASM:${formatDropExtensionSummary(buckets)}`,
     );
   }
   const wasmResults = await parseFilesWasmForBackfill(missingAbs, ctx.rootDir);

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -539,25 +539,36 @@ export function classifyNativeDrops(relPaths: Iterable<string>): NativeDropClass
 }
 
 /**
- * Render `{ ext → paths[] }` as `ext (n: sample.ext, ...)` slices for log lines.
- * Caps at 3 sample paths per extension and 6 extensions total to keep warnings
- * readable when many languages are dropped at once. Extensions are sorted by
- * descending file count so the loudest offender shows up first; ties keep
- * insertion order. Pure function — safe to unit-test independently.
+ * Render `{ ext → paths[] }` as a multi-line tabular breakdown for log lines.
+ * Each extension occupies its own line so a long warning scans like a table
+ * instead of a wall of semicolon-separated slices. Caps at 3 sample paths per
+ * extension and 6 extensions total to keep output bounded when many languages
+ * are dropped at once. Extensions are sorted by descending file count so the
+ * loudest offender shows up first; ties keep insertion order.
+ *
+ * Returns the empty string for empty input, and otherwise a string that
+ * begins with `\n` so callers can append it directly after the header line
+ * (`"Backfilling via WASM:" + formatDropExtensionSummary(...)`).
+ *
+ * Pure function — safe to unit-test independently.
  */
 export function formatDropExtensionSummary(buckets: Map<string, string[]>): string {
   const MAX_EXTS = 6;
   const MAX_SAMPLES = 3;
   const entries = Array.from(buckets.entries()).sort((a, b) => b[1].length - a[1].length);
-  const shown = entries.slice(0, MAX_EXTS).map(([ext, paths]) => {
+  if (entries.length === 0) return '';
+  const shown = entries.slice(0, MAX_EXTS);
+  const extWidth = Math.max(...shown.map(([ext]) => ext.length));
+  const countWidth = Math.max(...shown.map(([, paths]) => String(paths.length).length));
+  const lines = shown.map(([ext, paths]) => {
     const sample = paths.slice(0, MAX_SAMPLES).join(', ');
-    const more = paths.length > MAX_SAMPLES ? `, +${paths.length - MAX_SAMPLES} more` : '';
-    return `${ext} (${paths.length}: ${sample}${more})`;
+    const more = paths.length > MAX_SAMPLES ? ` (+${paths.length - MAX_SAMPLES} more)` : '';
+    return `  ${ext.padEnd(extWidth)}  ${String(paths.length).padStart(countWidth)}  ${sample}${more}`;
   });
   if (entries.length > MAX_EXTS) {
-    shown.push(`+${entries.length - MAX_EXTS} more extension(s)`);
+    lines.push(`  (+${entries.length - MAX_EXTS} more extension(s))`);
   }
-  return shown.join('; ');
+  return `\n${lines.join('\n')}`;
 }
 
 // ── Unified API ──────────────────────────────────────────────────────────────

--- a/tests/parsers/native-drop-classification.test.ts
+++ b/tests/parsers/native-drop-classification.test.ts
@@ -89,25 +89,36 @@ describe('formatDropExtensionSummary', () => {
     expect(formatDropExtensionSummary(new Map())).toBe('');
   });
 
-  it('lists every extension when under the cap', () => {
+  it('renders one indented row per extension prefixed with a leading newline', () => {
     const buckets = new Map<string, string[]>([
       ['.ts', ['a.ts', 'b.ts']],
       ['.py', ['c.py']],
     ]);
-    expect(formatDropExtensionSummary(buckets)).toBe('.ts (2: a.ts, b.ts); .py (1: c.py)');
+    expect(formatDropExtensionSummary(buckets)).toBe('\n  .ts  2  a.ts, b.ts\n  .py  1  c.py');
   });
 
   it('caps samples per extension at 3 and renders +N more', () => {
     const buckets = new Map<string, string[]>([['.ts', ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts']]]);
-    expect(formatDropExtensionSummary(buckets)).toBe('.ts (5: a.ts, b.ts, c.ts, +2 more)');
+    expect(formatDropExtensionSummary(buckets)).toBe('\n  .ts  5  a.ts, b.ts, c.ts (+2 more)');
   });
 
   it('shows exactly MAX_SAMPLES samples without a +N suffix when count equals the cap', () => {
     const buckets = new Map<string, string[]>([['.ts', ['a.ts', 'b.ts', 'c.ts']]]);
-    expect(formatDropExtensionSummary(buckets)).toBe('.ts (3: a.ts, b.ts, c.ts)');
+    expect(formatDropExtensionSummary(buckets)).toBe('\n  .ts  3  a.ts, b.ts, c.ts');
   });
 
-  it('caps extensions at 6 and renders +N more extension(s)', () => {
+  it('right-pads the extension column and right-aligns the count column for tabular layout', () => {
+    const buckets = new Map<string, string[]>([
+      ['.kt', ['a.kt']], // 100 files later — wider count column
+      ['.tsx', new Array(100).fill('x.tsx')],
+    ]);
+    const out = formatDropExtensionSummary(buckets);
+    // `.tsx` (4 chars) sets the ext width; `.kt` is padded to 4 chars.
+    // 100 (3 chars) sets the count width; 1 is right-aligned to 3 chars.
+    expect(out).toBe('\n  .tsx  100  x.tsx, x.tsx, x.tsx (+97 more)\n  .kt     1  a.kt');
+  });
+
+  it('caps extensions at 6 and renders +N more extension(s) on its own row', () => {
     // 8 extensions, all with 1 file — sorted by count is a stable tie so insertion
     // order wins, and the first 6 are shown.
     const buckets = new Map<string, string[]>([
@@ -121,12 +132,12 @@ describe('formatDropExtensionSummary', () => {
       ['.h', ['1.h']],
     ]);
     const out = formatDropExtensionSummary(buckets);
-    expect(out.endsWith('; +2 more extension(s)')).toBe(true);
+    expect(out.endsWith('\n  (+2 more extension(s))')).toBe(true);
     // First 6 extensions are present, the last 2 (.g, .h) are not.
-    expect(out).toContain('.a (1: 1.a)');
-    expect(out).toContain('.f (1: 1.f)');
-    expect(out).not.toContain('.g (');
-    expect(out).not.toContain('.h (');
+    expect(out).toContain('\n  .a  1  1.a');
+    expect(out).toContain('\n  .f  1  1.f');
+    expect(out).not.toContain('  .g  ');
+    expect(out).not.toContain('  .h  ');
   });
 
   it('sorts by descending file count so the loudest offender is first', () => {


### PR DESCRIPTION
## Summary
- The native-orchestrator drop warning lived in a single wall-of-text WARN line that grew unreadable when 30+ extensions were dropped at once (easy to trigger via journal-vs-fresh-build collisions).
- Made the per-extension breakdown scan like a table: header line keeps the count and now also reports the extension total; each extension occupies its own indented row with a right-aligned count column.
- Same cap behaviour as before — 3 sample paths per extension, 6 extensions before a `(+N more extension(s))` row — so the warning stays bounded.

## Example

Before:
```
[codegraph WARN] Native orchestrator dropped 101 file(s) in natively-supported languages — likely a Rust extractor bug. Backfilling via WASM: .tsx (100: x.tsx, x.tsx, x.tsx, +97 more); .kt (1: a.kt)
```

After:
```
[codegraph WARN] Native orchestrator dropped 101 file(s) across 2 extension(s) in natively-supported languages — likely a Rust extractor bug. Backfilling via WASM:
  .tsx  100  x.tsx, x.tsx, x.tsx (+97 more)
  .kt     1  a.kt
```

Applies to all three call sites in `backfillNativeDroppedFiles`: the stale-row purge (`info`), the unsupported-by-native backfill (`info`), and the native-extractor-failure warning (`warn`).

## Test plan
- [x] `npx vitest run tests/parsers/native-drop-classification.test.ts` — 17 passed
- [x] `npx biome check` on changed files — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Reviewer: confirm the tabular layout reads better than the comma-joined slices in real logs