### PR TITLE
feat(embed): add mxbai-large, mxbai-xsmall, bge-m3, and modernbert embedding models

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -113,9 +113,9 @@ jobs:
   # against the npm-installed package and open their own PR.
   embedding-benchmark:
     runs-on: ubuntu-latest
-    # 10 models x 30 min each = 300 min worst-case (caps via TIMEOUT_MS in the
+    # 11 models x 30 min each = 330 min worst-case (caps via TIMEOUT_MS in the
     # script); symbols are sampled to 1500 so typical runtime is ~23 min/model
-    # ≈ 230 min + setup headroom
+    # ≈ 253 min + setup headroom
     timeout-minutes: 360
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -202,7 +202,7 @@ jobs:
 
       - name: Run embedding benchmark
         if: steps.existing.outputs.skip != 'true'
-        timeout-minutes: 280
+        timeout-minutes: 300
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -113,9 +113,10 @@ jobs:
   # against the npm-installed package and open their own PR.
   embedding-benchmark:
     runs-on: ubuntu-latest
-    # 7 models x 30 min each = 210 min worst-case; symbols are sampled to 1500 so
-    # typical runtime is ~23 min/model ≈ 160 min + setup headroom
-    timeout-minutes: 240
+    # 10 models x 30 min each = 300 min worst-case (caps via TIMEOUT_MS in the
+    # script); symbols are sampled to 1500 so typical runtime is ~23 min/model
+    # ≈ 230 min + setup headroom
+    timeout-minutes: 360
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
@@ -201,7 +202,7 @@ jobs:
 
       - name: Run embedding benchmark
         if: steps.existing.outputs.skip != 'true'
-        timeout-minutes: 160
+        timeout-minutes: 280
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -432,6 +432,9 @@ A single trailing semicolon is ignored (falls back to single-query mode). The `-
 | `nomic` | nomic-embed-text-v1 | 768 | ~137 MB | Apache-2.0 | Good quality, 8192 context |
 | `nomic-v1.5` (default) | nomic-embed-text-v1.5 | 768 | ~137 MB | Apache-2.0 | **Improved nomic, Matryoshka dimensions** |
 | `bge-large` | bge-large-en-v1.5 | 1024 | ~335 MB | MIT | Best general retrieval, top MTEB scores |
+| `mxbai-xsmall` | mxbai-embed-xsmall-v1 | 384 | ~50 MB | Apache-2.0 | Tiny + long context (4096), Matryoshka dimensions |
+| `mxbai-large` | mxbai-embed-large-v1 | 1024 | ~400 MB | Apache-2.0 | Top MTEB BERT-large, Matryoshka dimensions |
+| `bge-m3` | bge-m3 | 1024 | ~600 MB | MIT | **Multilingual** (100+ languages), 8192 context |
 
 The model used during `embed` is stored in the database, so `search` auto-detects it — no need to pass `--model` when searching.
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ A single trailing semicolon is ignored (falls back to single-query mode). The `-
 | `mxbai-xsmall` | mxbai-embed-xsmall-v1 | 384 | ~50 MB | Apache-2.0 | Tiny + long context (4096), Matryoshka dimensions |
 | `mxbai-large` | mxbai-embed-large-v1 | 1024 | ~400 MB | Apache-2.0 | Top MTEB BERT-large, Matryoshka dimensions |
 | `bge-m3` | bge-m3 | 1024 | ~600 MB | MIT | **Multilingual** (100+ languages), 8192 context |
+| `modernbert` | modernbert-embed-base | 768 | ~150 MB | Apache-2.0 | ModernBERT architecture, 8192 ctx, English |
 
 The model used during `embed` is stored in the database, so `search` auto-detects it — no need to pass `--model` when searching.
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ A single trailing semicolon is ignored (falls back to single-query mode). The `-
 
 #### Available Models
 
+Per-model retrieval quality (Hit@N) and timing are measured on every release — see [EMBEDDING-BENCHMARKS.md](generated/benchmarks/EMBEDDING-BENCHMARKS.md).
+
 | Flag | Model | Dimensions | Size | License | Notes |
 |---|---|---|---|---|---|
 | `minilm` | all-MiniLM-L6-v2 | 384 | ~23 MB | Apache-2.0 | Fastest, good for quick iteration |
@@ -430,10 +432,10 @@ A single trailing semicolon is ignored (falls back to single-query mode). The `-
 | `jina-base` | jina-embeddings-v2-base-en | 768 | ~137 MB | Apache-2.0 | High quality, 8192 token context |
 | `jina-code` | jina-embeddings-v2-base-code | 768 | ~137 MB | Apache-2.0 | Best for code search, trained on code+text |
 | `nomic` | nomic-embed-text-v1 | 768 | ~137 MB | Apache-2.0 | Good quality, 8192 context |
-| `nomic-v1.5` (default) | nomic-embed-text-v1.5 | 768 | ~137 MB | Apache-2.0 | **Improved nomic, Matryoshka dimensions** |
+| `nomic-v1.5` (default) | nomic-embed-text-v1.5 | 768 | ~137 MB | Apache-2.0 | Matryoshka MRL training (unused — codegraph stores full 768d); v1 scores higher on our benchmark |
 | `bge-large` | bge-large-en-v1.5 | 1024 | ~335 MB | MIT | Best general retrieval, top MTEB scores |
-| `mxbai-xsmall` | mxbai-embed-xsmall-v1 | 384 | ~50 MB | Apache-2.0 | Tiny + long context (4096), Matryoshka dimensions |
-| `mxbai-large` | mxbai-embed-large-v1 | 1024 | ~400 MB | Apache-2.0 | Top MTEB BERT-large, Matryoshka dimensions |
+| `mxbai-xsmall` | mxbai-embed-xsmall-v1 | 384 | ~50 MB | Apache-2.0 | Tiny + long context (4096) |
+| `mxbai-large` | mxbai-embed-large-v1 | 1024 | ~400 MB | Apache-2.0 | Top MTEB BERT-large |
 | `bge-m3` | bge-m3 | 1024 | ~600 MB | MIT | **Multilingual** (100+ languages), 8192 context |
 | `modernbert` | modernbert-embed-base | 768 | ~150 MB | Apache-2.0 | ModernBERT architecture, 8192 ctx, English |
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Per-model retrieval quality (Hit@N) and timing are measured on every release —
 | `nomic-v1.5` (default) | nomic-embed-text-v1.5 | 768 | ~137 MB | Apache-2.0 | Matryoshka MRL training (unused — codegraph stores full 768d); v1 scores higher on our benchmark |
 | `bge-large` | bge-large-en-v1.5 | 1024 | ~335 MB | MIT | Best general retrieval, top MTEB scores |
 | `mxbai-xsmall` | mxbai-embed-xsmall-v1 | 384 | ~50 MB | Apache-2.0 | Tiny + long context (4096) |
-| `mxbai-large` | mxbai-embed-large-v1 | 1024 | ~400 MB | Apache-2.0 | Top MTEB BERT-large |
+| `mxbai-large` | mxbai-embed-large-v1 | 1024 | ~400 MB | Apache-2.0 | Top MTEB BERT-large, Matryoshka dimensions, 512 ctx |
 | `bge-m3` | bge-m3 | 1024 | ~600 MB | MIT | **Multilingual** (100+ languages), 8192 context |
 | `modernbert` | modernbert-embed-base | 768 | ~150 MB | Apache-2.0 | ModernBERT architecture, 8192 ctx, English |
 

--- a/docs/examples/CLI.md
+++ b/docs/examples/CLI.md
@@ -712,6 +712,9 @@ Available embedding models:
   nomic         768d  8192 ctx  Good local quality (~137MB). 8192 context.
   nomic-v1.5    768d  8192 ctx  Improved nomic (~137MB). Matryoshka dimensions, 8192 context.
   bge-large    1024d  512 ctx   Best general retrieval (~335MB). Top MTEB scores.
+  mxbai-xsmall  384d  4096 ctx  Tiny model with long context (~50MB). 4096 ctx, Matryoshka dimensions.
+  mxbai-large  1024d  512 ctx   Top MTEB BERT-large (~400MB). Matryoshka dimensions, public mirror.
+  bge-m3       1024d  8192 ctx  Multilingual, multi-task (~600MB). 100+ languages, 8192 context.
 ```
 
 ---

--- a/docs/examples/CLI.md
+++ b/docs/examples/CLI.md
@@ -710,10 +710,10 @@ Available embedding models:
   jina-base     768d  8192 ctx  Good quality (~137MB). General text, 8192 token context.
   jina-code     768d  8192 ctx  Code-aware (~137MB). Trained on code+text, best for code search.
   nomic         768d  8192 ctx  Good local quality (~137MB). 8192 context.
-  nomic-v1.5    768d  8192 ctx  Improved nomic (~137MB). Matryoshka dimensions, 8192 context.
+  nomic-v1.5    768d  8192 ctx  Matryoshka MRL trained (~137MB). 8192 context. Codegraph stores full 768d (no truncation); v1 scores higher on our benchmark.
   bge-large    1024d  512 ctx   Best general retrieval (~335MB). Top MTEB scores.
-  mxbai-xsmall  384d  4096 ctx  Tiny model with long context (~50MB). 4096 ctx, Matryoshka dimensions.
-  mxbai-large  1024d  512 ctx   Top MTEB BERT-large (~400MB). Matryoshka dimensions, public mirror.
+  mxbai-xsmall  384d  4096 ctx  Tiny model with long context (~50MB). 4096 ctx.
+  mxbai-large  1024d  512 ctx   Top MTEB BERT-large (~400MB). Public mirror.
   bge-m3       1024d  8192 ctx  Multilingual, multi-task (~600MB). 100+ languages, 8192 context.
   modernbert    768d  8192 ctx  ModernBERT base (~150MB). Newer architecture, 8192 ctx, English.
 ```

--- a/docs/examples/CLI.md
+++ b/docs/examples/CLI.md
@@ -713,7 +713,7 @@ Available embedding models:
   nomic-v1.5    768d  8192 ctx  Matryoshka MRL trained (~137MB). 8192 context. Codegraph stores full 768d (no truncation); v1 scores higher on our benchmark.
   bge-large    1024d  512 ctx   Best general retrieval (~335MB). Top MTEB scores.
   mxbai-xsmall  384d  4096 ctx  Tiny model with long context (~50MB). 4096 ctx.
-  mxbai-large  1024d  512 ctx   Top MTEB BERT-large (~400MB). Public mirror.
+  mxbai-large  1024d  512 ctx   Top MTEB BERT-large, Matryoshka dimensions (~400MB). 512 ctx.
   bge-m3       1024d  8192 ctx  Multilingual, multi-task (~600MB). 100+ languages, 8192 context.
   modernbert    768d  8192 ctx  ModernBERT base (~150MB). Newer architecture, 8192 ctx, English.
 ```

--- a/docs/examples/CLI.md
+++ b/docs/examples/CLI.md
@@ -715,6 +715,7 @@ Available embedding models:
   mxbai-xsmall  384d  4096 ctx  Tiny model with long context (~50MB). 4096 ctx, Matryoshka dimensions.
   mxbai-large  1024d  512 ctx   Top MTEB BERT-large (~400MB). Matryoshka dimensions, public mirror.
   bge-m3       1024d  8192 ctx  Multilingual, multi-task (~600MB). 100+ languages, 8192 context.
+  modernbert    768d  8192 ctx  ModernBERT base (~150MB). Newer architecture, 8192 ctx, English.
 ```
 
 ---

--- a/docs/guides/ai-agent-guide.md
+++ b/docs/guides/ai-agent-guide.md
@@ -562,7 +562,7 @@ codegraph embed . --model jina-code
 | | |
 |---|---|
 | **MCP tool** | (use via CLI) |
-| **Key flags** | `-m, --model` (minilm, jina-small, jina-base, jina-code, nomic, nomic-v1.5, bge-large, mxbai-xsmall, mxbai-large, bge-m3) |
+| **Key flags** | `-m, --model` (minilm, jina-small, jina-base, jina-code, nomic, nomic-v1.5, bge-large, mxbai-xsmall, mxbai-large, bge-m3, modernbert) |
 | **When to use** | Initial setup, or after adding many new functions |
 
 #### `export` — Export graph

--- a/docs/guides/ai-agent-guide.md
+++ b/docs/guides/ai-agent-guide.md
@@ -562,7 +562,7 @@ codegraph embed . --model jina-code
 | | |
 |---|---|
 | **MCP tool** | (use via CLI) |
-| **Key flags** | `-m, --model` (minilm, jina-small, jina-base, jina-code, nomic, nomic-v1.5, bge-large) |
+| **Key flags** | `-m, --model` (minilm, jina-small, jina-base, jina-code, nomic, nomic-v1.5, bge-large, mxbai-xsmall, mxbai-large, bge-m3) |
 | **When to use** | Initial setup, or after adding many new functions |
 
 #### `export` — Export graph

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -91,7 +91,7 @@ export const MODELS: Record<string, ModelConfig> = {
     name: 'nomic-ai/nomic-embed-text-v1.5',
     dim: 768,
     contextWindow: 8192,
-    desc: 'Improved nomic (~137MB). Matryoshka dimensions, 8192 context.',
+    desc: 'Matryoshka MRL trained (~137MB). 8192 context. Codegraph stores full 768d (no truncation); v1 scores higher on our benchmark.',
     quantized: false,
   },
   'bge-large': {
@@ -105,14 +105,14 @@ export const MODELS: Record<string, ModelConfig> = {
     name: 'mixedbread-ai/mxbai-embed-xsmall-v1',
     dim: 384,
     contextWindow: 4096,
-    desc: 'Tiny model with long context (~50MB). 4096 ctx, Matryoshka dimensions.',
+    desc: 'Tiny model with long context (~50MB). 4096 ctx.',
     quantized: false,
   },
   'mxbai-large': {
     name: 'mixedbread-ai/mxbai-embed-large-v1',
     dim: 1024,
     contextWindow: 512,
-    desc: 'Top MTEB BERT-large (~400MB). Matryoshka dimensions, public mirror.',
+    desc: 'Top MTEB BERT-large (~400MB). Public mirror.',
     quantized: false,
   },
   'bge-m3': {

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -41,6 +41,8 @@ export interface ModelConfig {
   contextWindow: number;
   desc: string;
   quantized: boolean;
+  /** Pooling strategy passed to the transformers pipeline. Defaults to 'mean'. */
+  pooling?: 'mean' | 'cls';
 }
 
 // Lazy-load transformers (heavy, optional module)
@@ -107,13 +109,15 @@ export const MODELS: Record<string, ModelConfig> = {
     contextWindow: 4096,
     desc: 'Tiny model with long context (~50MB). 4096 ctx.',
     quantized: false,
+    pooling: 'cls',
   },
   'mxbai-large': {
     name: 'mixedbread-ai/mxbai-embed-large-v1',
     dim: 1024,
     contextWindow: 512,
-    desc: 'Top MTEB BERT-large (~400MB). Public mirror.',
+    desc: 'Top MTEB BERT-large, Matryoshka dimensions (~400MB). 512 ctx.',
     quantized: false,
+    pooling: 'cls',
   },
   'bge-m3': {
     name: 'Xenova/bge-m3',
@@ -306,7 +310,7 @@ export async function embed(
     const batch = texts.slice(i, i + batchSize);
     const output =
       (await // biome-ignore lint/complexity/noBannedTypes: dynamically loaded extractor is untyped
-      (ext as Function)(batch, { pooling: 'mean', normalize: true })) as {
+      (ext as Function)(batch, { pooling: config.pooling ?? 'mean', normalize: true })) as {
         data: number[];
       };
 

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -101,6 +101,27 @@ export const MODELS: Record<string, ModelConfig> = {
     desc: 'Best general retrieval (~335MB). Top MTEB scores.',
     quantized: false,
   },
+  'mxbai-xsmall': {
+    name: 'mixedbread-ai/mxbai-embed-xsmall-v1',
+    dim: 384,
+    contextWindow: 4096,
+    desc: 'Tiny model with long context (~50MB). 4096 ctx, Matryoshka dimensions.',
+    quantized: false,
+  },
+  'mxbai-large': {
+    name: 'mixedbread-ai/mxbai-embed-large-v1',
+    dim: 1024,
+    contextWindow: 512,
+    desc: 'Top MTEB BERT-large (~400MB). Matryoshka dimensions, public mirror.',
+    quantized: false,
+  },
+  'bge-m3': {
+    name: 'Xenova/bge-m3',
+    dim: 1024,
+    contextWindow: 8192,
+    desc: 'Multilingual, multi-task (~600MB). 100+ languages, 8192 context.',
+    quantized: false,
+  },
 };
 
 export const EMBEDDING_STRATEGIES: readonly string[] = ['structured', 'source'];
@@ -115,6 +136,9 @@ const BATCH_SIZE_MAP: Record<string, number> = {
   nomic: 8,
   'nomic-v1.5': 8,
   'bge-large': 4,
+  'mxbai-xsmall': 32,
+  'mxbai-large': 4,
+  'bge-m3': 4,
 };
 const DEFAULT_BATCH_SIZE = 32;
 

--- a/src/domain/search/models.ts
+++ b/src/domain/search/models.ts
@@ -122,6 +122,13 @@ export const MODELS: Record<string, ModelConfig> = {
     desc: 'Multilingual, multi-task (~600MB). 100+ languages, 8192 context.',
     quantized: false,
   },
+  modernbert: {
+    name: 'nomic-ai/modernbert-embed-base',
+    dim: 768,
+    contextWindow: 8192,
+    desc: 'ModernBERT base (~150MB). Newer architecture, 8192 ctx, English.',
+    quantized: false,
+  },
 };
 
 export const EMBEDDING_STRATEGIES: readonly string[] = ['structured', 'source'];
@@ -139,6 +146,7 @@ const BATCH_SIZE_MAP: Record<string, number> = {
   'mxbai-xsmall': 32,
   'mxbai-large': 4,
   'bge-m3': 4,
+  modernbert: 8,
 };
 const DEFAULT_BATCH_SIZE = 32;
 


### PR DESCRIPTION
## Summary

Adds three new embedding model options to the registry. All are publicly accessible (no `HF_TOKEN`), have ONNX weights for `@huggingface/transformers`, and target distinct use cases.

| Key | HF model | Dim | Ctx | Size | License | Use case |
|---|---|---|---|---|---|---|
| `mxbai-xsmall` | `mixedbread-ai/mxbai-embed-xsmall-v1` | 384 | 4096 | ~50 MB | Apache-2.0 | Tiny + **16× longer context** than `minilm` |
| `mxbai-large` | `mixedbread-ai/mxbai-embed-large-v1` | 1024 | 512 | ~400 MB | Apache-2.0 | Top HF transformers.js feature-extraction leaderboard (~4.75M dl/mo) |
| `bge-m3` | `Xenova/bge-m3` | 1024 | 8192 | ~600 MB | MIT | **Multilingual** (100+ languages), useful for non-English comments/identifiers |

## Hardware fit

All three sit within the existing registry's hardware envelope. If a user's machine handles `bge-large` (1024d, ~335 MB), it will handle all three. None of them require a GPU.

## Benchmark workflow coverage

`scripts/embedding-benchmark.ts` already iterates ${'`'}Object.keys(MODELS)${'`'}, so the three new entries are picked up automatically by the post-publish embedding benchmark workflow.

Timeouts bumped in ${'`'}benchmark.yml${'`'} to account for the larger registry:
- Job ${'`'}timeout-minutes${'`'}: 240 → 360
- Embed step ${'`'}timeout-minutes${'`'}: 160 → 280

Expected typical runtime with 10 models is ~230 min (was ~160 min for seven), worst case ~300 min (capped by the script's per-model ${'`'}TIMEOUT_MS${'`'}).

## Candidates considered but not added

- **${'`'}nomic-ai/nomic-embed-text-v2-moe${'`'}**: no ONNX, requires ${'`'}trust_remote_code${'`'} due to custom MoE architecture.
- **${'`'}Qwen/Qwen3-Embedding-0.6B${'`'}**: original repo lacks ONNX. The ${'`'}onnx-community/Qwen3-Embedding-0.6B-ONNX${'`'} mirror exists, but fp32 weights are ~2.5 GB — significantly heavier than the existing registry. Could be revisited if/when we expose ${'`'}dtype: 'q8'${'`'} runtime configuration.
- **${'`'}nomic-ai/modernbert-embed-base${'`'}**: ONNX tagged on the HF page but the model card was truncated when I tried to verify dim and context length. Worth a follow-up.
- **${'`'}jinaai/jina-embeddings-v3${'`'}**: page was too large to fetch; documented to need ${'`'}trust_remote_code${'`'} for task adapters, which transformers.js cannot apply directly.

## Test plan

- [x] ${'`'}npx tsc --noEmit${'`'} clean
- [x] ${'`'}npx vitest run tests/search/${'`'} 75/75 pass
- [x] ${'`'}npx biome check src/domain/search/models.ts${'`'} clean
- [ ] First post-publish benchmark run should produce data for all 10 models — confirm in next ${'`'}EMBEDDING-BENCHMARKS.md${'`'} update PR
- [ ] Manual smoke test: ${'`'}codegraph embed --model mxbai-large${'`'}, ${'`'}--model mxbai-xsmall${'`'}, ${'`'}--model bge-m3${'`'} each succeed end-to-end on a small fixture