### PR TITLE
fix(watch): align incremental call resolver with full build

### DIFF
--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -186,7 +186,7 @@ function rebuildReverseDepEdges(
     skipBarrel ? null : db,
   );
   const importedNames = buildImportedNamesMap(symbols, rootDir, depRelPath, aliases);
-  edgesAdded += buildCallEdges(stmts, depRelPath, symbols, fileNodeRow, importedNames);
+  edgesAdded += buildCallEdges(db, stmts, depRelPath, symbols, fileNodeRow, importedNames);
   return edgesAdded;
 }
 
@@ -432,6 +432,7 @@ function findCaller(
 }
 
 function resolveCallTargets(
+  db: BetterSqlite3Database,
   stmts: IncrementalStmts,
   call: ExtractorOutput['calls'][number],
   relPath: string,
@@ -445,15 +446,44 @@ function resolveCallTargets(
       id: number;
       file: string;
     }>;
+    // Follow barrel re-exports to the defining file, matching the full-build
+    // resolver — without this, calls to symbols imported through an index/barrel
+    // file resolve to nothing and the edge is dropped (issue #1259).
+    if (targets.length === 0 && isBarrelFile(db, importedFrom)) {
+      const actualSource = resolveBarrelTarget(db, importedFrom, call.name);
+      if (actualSource) {
+        targets = stmts.findNodeInFile.all(call.name, actualSource) as Array<{
+          id: number;
+          file: string;
+        }>;
+      }
+    }
   }
   if (!targets || targets.length === 0) {
     targets = stmts.findNodeInFile.all(call.name, relPath) as Array<{ id: number; file: string }>;
     if (targets.length === 0) {
-      targets = stmts.findNodeByName.all(call.name) as Array<{ id: number; file: string }>;
+      targets = resolveByMethodOrGlobal(stmts, call, relPath, typeMap);
     }
   }
-  // Type-aware resolution: translate variable receiver to declared type
-  if ((!targets || targets.length === 0) && call.receiver && typeMap) {
+  return { targets: targets ?? [], importedFrom };
+}
+
+/**
+ * Last-resort resolution mirroring the full-build resolver
+ * (`stages/build-edges.ts`). The incremental cascade must use identical
+ * semantics or it drifts away from the full graph: a type-aware lookup for
+ * receiver calls, then an unqualified global match that is gated to
+ * receiver-less / this/self/super calls and filtered to confidence >= 0.5.
+ * Without this gate every reverse-dep rebuild fans out low-confidence edges to
+ * every same-named symbol in the graph (issue #1259).
+ */
+function resolveByMethodOrGlobal(
+  stmts: IncrementalStmts,
+  call: ExtractorOutput['calls'][number],
+  relPath: string,
+  typeMap: Map<string, unknown>,
+): Array<{ id: number; file: string }> {
+  if (call.receiver && typeMap) {
     const typeEntry = typeMap.get(call.receiver);
     const typeName = typeEntry
       ? typeof typeEntry === 'string'
@@ -462,13 +492,25 @@ function resolveCallTargets(
       : null;
     if (typeName) {
       const qualified = `${typeName}.${call.name}`;
-      targets = stmts.findNodeByName.all(qualified) as Array<{ id: number; file: string }>;
+      const typed = stmts.findNodeByName.all(qualified) as Array<{ id: number; file: string }>;
+      if (typed.length > 0) return typed;
     }
   }
-  return { targets: targets ?? [], importedFrom };
+  if (
+    !call.receiver ||
+    call.receiver === 'this' ||
+    call.receiver === 'self' ||
+    call.receiver === 'super'
+  ) {
+    return (stmts.findNodeByName.all(call.name) as Array<{ id: number; file: string }>).filter(
+      (t) => computeConfidence(relPath, t.file, null) >= 0.5,
+    );
+  }
+  return [];
 }
 
 function buildCallEdges(
+  db: BetterSqlite3Database,
   stmts: IncrementalStmts,
   relPath: string,
   symbols: ExtractorOutput,
@@ -488,11 +530,17 @@ function buildCallEdges(
           )
         : new Map();
   let edgesAdded = 0;
+  // Dedup within this file's rebuild, mirroring the full-build resolver's
+  // `seenCallEdges` set — a single call site can resolve to the same target
+  // more than once, and `insertEdge` is a plain INSERT (no OR IGNORE). Without
+  // this we write duplicate `calls` rows on every rebuild (issue #1259).
+  const seenCallEdges = new Set<string>();
   for (const call of symbols.calls) {
     if (call.receiver && BUILTIN_RECEIVERS.has(call.receiver)) continue;
 
     const caller = findCaller(call, symbols.definitions, relPath, stmts) || fileNodeRow;
     const { targets, importedFrom } = resolveCallTargets(
+      db,
       stmts,
       call,
       relPath,
@@ -501,7 +549,9 @@ function buildCallEdges(
     );
 
     for (const t of targets) {
-      if (t.id !== caller.id) {
+      const edgeKey = `${caller.id}|${t.id}`;
+      if (t.id !== caller.id && !seenCallEdges.has(edgeKey)) {
+        seenCallEdges.add(edgeKey);
         const confidence = computeConfidence(relPath, t.file, importedFrom ?? null);
         stmts.insertEdge.run(caller.id, t.id, 'calls', confidence, call.dynamic ? 1 : 0);
         edgesAdded++;
@@ -550,7 +600,7 @@ function rebuildEdgesForTargetFile(
   edgesAdded += rebuildDirContainment(db, stmts, relPath);
   edgesAdded += buildImportEdges(stmts, relPath, symbols, rootDir, fileNodeRow.id, aliases, db);
   const importedNames = buildImportedNamesMap(symbols, rootDir, relPath, aliases);
-  edgesAdded += buildCallEdges(stmts, relPath, symbols, fileNodeRow, importedNames);
+  edgesAdded += buildCallEdges(db, stmts, relPath, symbols, fileNodeRow, importedNames);
   return edgesAdded;
 }
 

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -185,7 +185,7 @@ function rebuildReverseDepEdges(
     aliases,
     skipBarrel ? null : db,
   );
-  const importedNames = buildImportedNamesMap(symbols, rootDir, depRelPath, aliases);
+  const importedNames = buildImportedNamesMap(symbols, rootDir, depRelPath, aliases, db);
   edgesAdded += buildCallEdges(db, stmts, depRelPath, symbols, fileNodeRow, importedNames);
   return edgesAdded;
 }
@@ -387,6 +387,7 @@ function buildImportedNamesMap(
   rootDir: string,
   relPath: string,
   aliases: PathAliases,
+  db: BetterSqlite3Database,
 ): Map<string, string> {
   const importedNames = new Map<string, string>();
   for (const imp of symbols.imports) {
@@ -397,7 +398,17 @@ function buildImportedNamesMap(
       aliases,
     );
     for (const name of imp.names) {
-      importedNames.set(name.replace(/^\*\s+as\s+/, ''), resolvedPath);
+      const cleanName = name.replace(/^\*\s+as\s+/, '');
+      // Mirror full-build's `buildImportedNamesMap`: follow barrel re-exports so
+      // `importedNames` maps to the *defining* file, not the barrel. This ensures
+      // `computeConfidence` gets `importedFrom === targetFile` and returns 1.0
+      // instead of the cross-directory fallback (0.3).
+      let targetFile = resolvedPath;
+      if (isBarrelFile(db, resolvedPath)) {
+        const actual = resolveBarrelTarget(db, resolvedPath, cleanName);
+        if (actual) targetFile = actual;
+      }
+      importedNames.set(cleanName, targetFile);
     }
   }
   return importedNames;
@@ -500,7 +511,9 @@ function resolveByMethodOrGlobal(
       : null;
     if (typeName) {
       const qualified = `${typeName}.${call.name}`;
-      const typed = stmts.findNodeByName.all(qualified) as Array<{ id: number; file: string }>;
+      const typed = (
+        stmts.findNodeByName.all(qualified) as Array<{ id: number; file: string; kind?: string }>
+      ).filter((n) => n.kind === 'method');
       if (typed.length > 0) return typed;
     }
   }
@@ -607,7 +620,7 @@ function rebuildEdgesForTargetFile(
   let edgesAdded = buildContainmentEdges(db, stmts, relPath, symbols);
   edgesAdded += rebuildDirContainment(db, stmts, relPath);
   edgesAdded += buildImportEdges(stmts, relPath, symbols, rootDir, fileNodeRow.id, aliases, db);
-  const importedNames = buildImportedNamesMap(symbols, rootDir, relPath, aliases);
+  const importedNames = buildImportedNamesMap(symbols, rootDir, relPath, aliases, db);
   edgesAdded += buildCallEdges(db, stmts, relPath, symbols, fileNodeRow, importedNames);
   return edgesAdded;
 }

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -465,7 +465,15 @@ function resolveCallTargets(
       targets = resolveByMethodOrGlobal(stmts, call, relPath, typeMap);
     }
   }
-  return { targets: targets ?? [], importedFrom };
+  const resolved = targets ?? [];
+  if (resolved.length > 1) {
+    resolved.sort((a, b) => {
+      const confA = computeConfidence(relPath, a.file, importedFrom ?? null);
+      const confB = computeConfidence(relPath, b.file, importedFrom ?? null);
+      return confB - confA;
+    });
+  }
+  return { targets: resolved, importedFrom };
 }
 
 /**
@@ -483,7 +491,7 @@ function resolveByMethodOrGlobal(
   relPath: string,
   typeMap: Map<string, unknown>,
 ): Array<{ id: number; file: string }> {
-  if (call.receiver && typeMap) {
+  if (call.receiver) {
     const typeEntry = typeMap.get(call.receiver);
     const typeName = typeEntry
       ? typeof typeEntry === 'string'

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -38,7 +38,7 @@ function prepareWatcherStatements(db: ReturnType<typeof openDb>): IncrementalStm
       "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
     ),
     findNodeByName: db.prepare(
-      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
     ),
     listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
   };

--- a/tests/integration/issue-1259-watch-call-resolution.test.ts
+++ b/tests/integration/issue-1259-watch-call-resolution.test.ts
@@ -60,7 +60,7 @@ function readEdges(dbPath: string) {
   try {
     return db
       .prepare(
-        `SELECT n1.file AS src_file, n1.name AS src, n2.file AS tgt_file, n2.name AS tgt, e.kind
+        `SELECT n1.file AS src_file, n1.name AS src, n2.file AS tgt_file, n2.name AS tgt, e.kind, e.confidence, e.dynamic
          FROM edges e
          JOIN nodes n1 ON e.source_id = n1.id
          JOIN nodes n2 ON e.target_id = n2.id
@@ -95,7 +95,7 @@ function makeStmts(db: ReturnType<typeof openDb>) {
       "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
     ),
     findNodeByName: db.prepare(
-      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
     ),
     listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
   };

--- a/tests/integration/issue-1259-watch-call-resolution.test.ts
+++ b/tests/integration/issue-1259-watch-call-resolution.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Watch-mode call-resolution parity (#1259).
+ *
+ * The watcher's `rebuildFile` reverse-dep cascade had its own call resolver
+ * (`resolveCallTargets`/`buildCallEdges` in incremental.ts) that diverged from
+ * the authoritative full-build resolver (`stages/build-edges.ts`):
+ *   - global name fallback was unconditional (no receiver gating, no
+ *     confidence >= 0.5 filter) -> fanned out false-positive `calls` edges
+ *   - no dedup -> duplicate `calls` rows on every rebuild
+ *   - import-scoped lookup did not follow barrel re-exports -> dropped edges
+ *
+ * On the codegraph repo a comment-only watch rebuild of a widely-imported file
+ * inflated `calls` edges by ~700. This fixture reproduces all three failure
+ * modes in miniature and asserts the cascade now matches a clean full build.
+ *
+ * Drives `rebuildFile` directly (the watch path), NOT buildGraph's incremental
+ * path — the latter goes through the native orchestrator and never exercised
+ * the buggy JS cascade, which is why the existing parity tests passed.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+// Files are laid out so that an unimported call to a same-named symbol in a
+// distant directory resolves at confidence 0.3 (different grandparent dir) —
+// below the 0.5 global-fallback threshold the full build enforces.
+const FILES: Record<string, string> = {
+  'app/feature/leaf.js': `export function leafVal() {\n  return 42;\n}\n`,
+  'app/feature/consumer.js':
+    `import { leafVal } from './leaf.js';\n` +
+    `import { wrapped } from '../../lib/barrel.js';\n` +
+    `export function run() {\n` +
+    `  leafVal();\n` +
+    `  leafVal();\n` + // duplicate call site -> must dedup to one edge
+    `  wrapped();\n` + // barrel re-export -> must resolve to lib/impl.js
+    `  commonName();\n` + // unimported, distant same-named symbol -> must be dropped (conf 0.3)
+    `  return 0;\n` +
+    `}\n`,
+  'lib/barrel.js': `export { wrapped } from './impl.js';\n`,
+  'lib/impl.js': `export function wrapped() {\n  return 'w';\n}\n`,
+  'extra/deep/dup.js': `export function commonName() {\n  return 'd';\n}\n`,
+};
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function readEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.file AS src_file, n1.name AS src, n2.file AS tgt_file, n2.name AS tgt, e.kind
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         ORDER BY n1.file, n1.name, n2.file, n2.name, e.kind`,
+      )
+      .all();
+  } finally {
+    db.close();
+  }
+}
+
+/** Prepared statements the watcher normally supplies (mirrors watcher.ts). */
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+  };
+}
+
+describe('Watch-mode call resolution parity (#1259)', () => {
+  let fullEdges: ReturnType<typeof readEdges>;
+  let watchEdges: ReturnType<typeof readEdges>;
+  let tmpBase: string;
+
+  beforeAll(async () => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-1259-'));
+    const fullDir = path.join(tmpBase, 'full');
+    const watchDir = path.join(tmpBase, 'watch');
+    writeFixture(fullDir);
+    writeFixture(watchDir);
+
+    // Baseline full build on both copies.
+    await buildGraph(fullDir, { incremental: false, skipRegistry: true });
+    await buildGraph(watchDir, { incremental: false, skipRegistry: true });
+
+    // Comment-only touch on the leaf, which is a reverse-dep of consumer.js.
+    const touch = '\n// watch touch\n';
+    const watchLeaf = path.join(watchDir, 'app/feature/leaf.js');
+    fs.appendFileSync(watchLeaf, touch);
+
+    // Watch path: rebuild via the JS cascade (reverse-dep cascade re-resolves
+    // consumer.js, which is where the resolver divergence manifested).
+    const db = openDb(path.join(watchDir, '.codegraph', 'graph.db'));
+    initSchema(db);
+    await rebuildFile(db, watchDir, watchLeaf, makeStmts(db), { engine: 'auto' }, null);
+    db.close();
+
+    // Same edit + clean full rebuild on the other copy for the parity oracle.
+    fs.appendFileSync(path.join(fullDir, 'app/feature/leaf.js'), touch);
+    await buildGraph(fullDir, { incremental: false, skipRegistry: true });
+
+    fullEdges = readEdges(path.join(fullDir, '.codegraph', 'graph.db'));
+    watchEdges = readEdges(path.join(watchDir, '.codegraph', 'graph.db'));
+  }, 60_000);
+
+  afterAll(() => {
+    try {
+      if (tmpBase) fs.rmSync(tmpBase, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('does not inflate or duplicate calls edges (matches full build count)', () => {
+    const fullCalls = fullEdges.filter((e) => e.kind === 'calls');
+    const watchCalls = watchEdges.filter((e) => e.kind === 'calls');
+    expect(watchCalls.length).toBe(fullCalls.length);
+  });
+
+  it('produces edges identical to a clean full build', () => {
+    if (watchEdges.length !== fullEdges.length) {
+      const key = (e: {
+        src_file: string;
+        src: string;
+        tgt_file: string;
+        tgt: string;
+        kind: string;
+      }) => `${e.src_file}:${e.src} -[${e.kind}]-> ${e.tgt_file}:${e.tgt}`;
+      const fSet = new Set(fullEdges.map(key));
+      const wSet = new Set(watchEdges.map(key));
+      const missing = [...fSet].filter((k) => !wSet.has(k));
+      const extra = [...wSet].filter((k) => !fSet.has(k));
+      expect.fail(
+        `Edge mismatch:\n  Missing in watch: ${missing.join('\n    ') || 'none'}\n  Extra in watch: ${extra.join('\n    ') || 'none'}`,
+      );
+    }
+    expect(watchEdges).toEqual(fullEdges);
+  });
+
+  it('resolves a barrel-re-exported call to its defining file', () => {
+    const barrelCall = fullEdges.find(
+      (e) => e.kind === 'calls' && e.src === 'run' && e.tgt === 'wrapped',
+    );
+    expect(barrelCall?.tgt_file).toContain('lib/impl.js');
+    expect(watchEdges).toContainEqual(barrelCall);
+  });
+
+  it('drops the unimported distant same-named call (confidence < 0.5)', () => {
+    const fanout = watchEdges.filter((e) => e.kind === 'calls' && e.tgt === 'commonName');
+    expect(fanout).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The watcher's `rebuildFile` reverse-dependency cascade had its own call
resolver (`resolveCallTargets`/`buildCallEdges` in `incremental.ts`) that had
drifted from the authoritative full-build resolver in
`stages/build-edges.ts`. On the codegraph repo, a **comment-only** watch
rebuild of a widely-imported file (`src/shared/kinds.ts`) inflated `calls`
edges by ~700 — the graph grew from **10178** distinct call edges to **10780
distinct + 97 duplicate** rows, and `build --no-incremental` reset it back to
10178. This is the underlying cause of the net-edge-delta noise behind
#1220/#1245 and the regression-guard exemptions in #1248/#1255.

Three divergences are fixed so the cascade matches a clean full build exactly:

1. **Gated global fallback** — the unconditional `findNodeByName(call.name)`
   fan-out (every same-named symbol in the graph) is replaced by the
   full-build semantics: type-aware lookup, then a global match gated to
   receiver-less / `this`/`self`/`super` calls and filtered to
   `computeConfidence >= 0.5`.
2. **Dedup** — `buildCallEdges` now dedups within a file rebuild via a
   `seenCallEdges` set (`insertEdge` is a plain INSERT with no OR IGNORE).
3. **Barrel resolution** — the import-scoped branch now follows barrel
   re-exports (`isBarrelFile`/`resolveBarrelTarget`) so calls to symbols
   imported through an index/barrel file resolve to the defining file instead
   of being dropped.

After the fix, a comment-only watch rebuild leaves `calls` at exact parity
(10178 total / 10178 distinct, zero duplicates).

## Found during
Dogfooding v3.11.1 — see #1259.

## Verification

- New test `tests/integration/issue-1259-watch-call-resolution.test.ts`
  drives `rebuildFile` directly (the watch path) on a fixture that exercises
  all three failure modes. It **fails on the pre-fix code** (extra
  `commonName` fan-out edge + duplicate `leafVal` edge) and passes after.
  The existing parity tests use `buildGraph`'s native-orchestrator incremental
  path and never exercised the buggy JS cascade — which is why they were green.
- Full suite: **2788 passed, 11 skipped, 0 failed** (160 files, regression
  guard included).
- End-to-end on the codegraph repo: `watch` + comment-only edit of
  `src/shared/kinds.ts` now reports net-zero `calls` change; DB distinct/total
  calls stay at 10178.

## Follow-up
The cascade still under-rebuilds `receiver`/`extends`/`dynamic-imports` edges
(and slightly over-counts `imports`) vs the full build — filed separately as
#1260. This PR is scoped to the `calls`-edge inflation (#1259).

## Test plan
- [ ] `npx vitest run tests/integration/issue-1259-watch-call-resolution.test.ts`
- [ ] `npx vitest run tests/integration/watcher-rebuild.test.ts tests/integration/incremental-edge-parity.test.ts`
- [ ] Manual: `build` a repo, `watch`, append a comment to a high-fan-in file, confirm net-zero `calls` delta