### PR TITLE
chore(hooks): block AI attribution in commits and PR bodies

### DIFF
--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -170,6 +170,27 @@ if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)gh[[:space:]]+pr[[
   validate_branch_name
 fi
 
+# --- Block AI attribution in commit messages ---
+
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+commit'; then
+  if echo "$COMMAND" | grep -qiE 'co-authored-by:.*claude|co-authored-by:.*anthropic|generated with claude|generated with \[claude|built with claude|claude\.ai'; then
+    deny "BLOCKED: Remove AI attribution lines (Co-Authored-By with Claude/Anthropic, 'Generated with Claude', 'Built with Claude', claude.ai URLs) from the commit message."
+  fi
+  # Extract -F <file> or --file=<file> or --file <file> (all equivalent git commit forms)
+  MSG_FILE=$(echo "$COMMAND" | grep -oE '\-F[[:space:]]+[^[:space:]]+' | awk '{print $2}' || true)
+  if [ -z "$MSG_FILE" ]; then
+    MSG_FILE=$(echo "$COMMAND" | grep -oE '\-\-file=[^[:space:]]+' | sed 's/--file=//' || true)
+  fi
+  if [ -z "$MSG_FILE" ]; then
+    MSG_FILE=$(echo "$COMMAND" | grep -oE '\-\-file[[:space:]]+[^[:space:]]+' | awk '{print $2}' || true)
+  fi
+  if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+    if grep -qiE 'co-authored-by:.*claude|co-authored-by:.*anthropic|generated with claude|generated with \[claude|built with claude|claude\.ai' "$MSG_FILE"; then
+      deny "BLOCKED: Remove AI attribution lines from the commit message file '$MSG_FILE'."
+    fi
+  fi
+fi
+
 # --- Commit validation against edit log ---
 
 if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+commit'; then

--- a/.claude/hooks/guard-pr-body.sh
+++ b/.claude/hooks/guard-pr-body.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Block PR creation if the body contains "generated with" (case-insensitive)
+# Block PR creation if the body contains AI attribution (case-insensitive)
 
 set -euo pipefail
 
@@ -17,35 +17,34 @@ cmd=$(echo "$INPUT" | node -e "
 
 echo "$cmd" | grep -qi 'gh pr create' || exit 0
 
-# Block if body contains "generated with"
-if echo "$cmd" | grep -qi 'generated with'; then
+deny_pr() {
+  local reason="$1"
   node -e "
     console.log(JSON.stringify({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'deny',
-        permissionDecisionReason: 'BLOCKED: Remove any \'Generated with ...\' line from the PR body.'
+        permissionDecisionReason: process.argv[1]
       }
     }));
-  "
+  " "$reason"
   exit 0
-fi
+}
+
+check_attribution() {
+  local text="$1"
+  local source="$2"
+  if echo "$text" | grep -qiE 'generated with claude|generated with \[claude|co-authored-by:.*claude|co-authored-by:.*anthropic|built with claude|claude\.ai'; then
+    deny_pr "BLOCKED: Remove AI attribution lines (Co-Authored-By with Claude/Anthropic, 'Generated with Claude', 'Built with Claude', claude.ai URLs) from the PR ${source}."
+  fi
+}
+
+check_attribution "$cmd" "body"
 
 # Also check --body-file path
-BODY_FILE=$(echo "$cmd" | grep -oP '(?<=--body-file\s)\S+' || true)
+BODY_FILE=$(echo "$cmd" | grep -oE '\-\-body-file[[:space:]]+[^[:space:]]+' | awk '{print $2}' || true)
 if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
-  if grep -qi 'generated with' "$BODY_FILE"; then
-    node -e "
-      console.log(JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'deny',
-          permissionDecisionReason: 'BLOCKED: Remove any \'Generated with ...\' line from the PR body file.'
-        }
-      }));
-    "
-    exit 0
-  fi
+  check_attribution "$(cat "$BODY_FILE")" "body file"
 fi
 
 exit 0

--- a/.claude/hooks/guard-pr-body.sh
+++ b/.claude/hooks/guard-pr-body.sh
@@ -41,8 +41,11 @@ check_attribution() {
 
 check_attribution "$cmd" "body"
 
-# Also check --body-file path
+# Also check --body-file path (handles both --body-file <path> and --body-file=<path>)
 BODY_FILE=$(echo "$cmd" | grep -oE '\-\-body-file[[:space:]]+[^[:space:]]+' | awk '{print $2}' || true)
+if [ -z "$BODY_FILE" ]; then
+  BODY_FILE=$(echo "$cmd" | grep -oE '\-\-body-file=[^[:space:]]+' | sed 's/--body-file=//' || true)
+fi
 if [ -n "$BODY_FILE" ] && [ -f "$BODY_FILE" ]; then
   check_attribution "$(cat "$BODY_FILE")" "body file"
 fi


### PR DESCRIPTION
## Summary

- `guard-git.sh`: adds a new check on `git commit` commands that denies any message containing AI authorship footers or AI tool URLs (inline `-m` and via `-F <file>`)
- `guard-pr-body.sh`: expands the previous narrow single-phrase check to the same full pattern set — covers authorship footers and AI tool URLs in both inline `--body` and `--body-file`

## Why

The existing `guard-pr-body.sh` only caught one specific phrase, leaving other attribution forms (authorship footers, tool URLs) unblocked. `guard-git.sh` had no commit-message content check at all — it only validated staged files against the session edit log.

## Test plan

- [ ] Attempt `git commit -m` with an AI authorship footer → blocked
- [ ] Attempt `git commit -m` with an AI tool URL → blocked
- [ ] Attempt `gh pr create --body` with blocked attribution phrases → blocked
- [ ] Normal commit message and PR body → allowed