### PR TITLE
feat(analysis): inter-procedural return-type propagation (Phase 8.2)

### DIFF
--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -7,6 +7,7 @@
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { getNodeId } from '../../../../db/index.js';
+import { setTypeMapEntry } from '../../../../extractors/helpers.js';
 import { debug } from '../../../../infrastructure/logger.js';
 import { loadNative } from '../../../../infrastructure/native.js';
 import type {
@@ -385,6 +386,64 @@ function buildImportEdgesNative(
 
   for (const e of nativeEdges) {
     allEdgeRows.push([e.sourceId, e.targetId, e.kind, e.confidence, e.dynamic]);
+  }
+}
+
+// ── Phase 8.2: Cross-file return-type propagation ───────────────────────
+
+/**
+ * Augment each file's typeMap with return types from imported functions.
+ *
+ * The per-file extractor already resolves same-file call assignments (intra-file
+ * propagation). This function handles the cross-file case: when a file imports a
+ * function from another file and assigns its return value to a variable, we look up
+ * the callee's return type in the source file's returnTypeMap and inject it.
+ *
+ * Called once before call-edge building so both the native and JS paths benefit.
+ */
+function propagateReturnTypesAcrossFiles(
+  fileSymbols: Map<string, ExtractorOutput>,
+  ctx: PipelineContext,
+  rootDir: string,
+): void {
+  // Index: filePath → per-file return-type map
+  const returnTypeIndex = new Map<string, Map<string, TypeMapEntry>>();
+  for (const [relPath, symbols] of fileSymbols) {
+    if (symbols.returnTypeMap?.size) returnTypeIndex.set(relPath, symbols.returnTypeMap);
+  }
+  if (returnTypeIndex.size === 0) return;
+
+  // Flat global map for qualified method lookups (TypeName.methodName → entry).
+  // Conflicts resolved by keeping the highest-confidence entry.
+  const globalReturnTypeMap = new Map<string, TypeMapEntry>();
+  for (const rtm of returnTypeIndex.values()) {
+    for (const [name, entry] of rtm) {
+      const existing = globalReturnTypeMap.get(name);
+      if (!existing || entry.confidence > existing.confidence) globalReturnTypeMap.set(name, entry);
+    }
+  }
+
+  for (const [relPath, symbols] of fileSymbols) {
+    if (!symbols.callAssignments?.length) continue;
+    const importedNamesMap = buildImportedNamesMap(ctx, relPath, symbols, rootDir);
+
+    for (const ca of symbols.callAssignments) {
+      if (symbols.typeMap.has(ca.varName)) continue; // already resolved locally
+
+      let returnEntry: TypeMapEntry | undefined;
+      if (ca.receiverTypeName) {
+        returnEntry = globalReturnTypeMap.get(`${ca.receiverTypeName}.${ca.calleeName}`);
+      } else {
+        const importedFrom = importedNamesMap.get(ca.calleeName);
+        if (importedFrom) returnEntry = returnTypeIndex.get(importedFrom)?.get(ca.calleeName);
+      }
+
+      if (returnEntry) {
+        const propagatedConf = returnEntry.confidence - 0.1;
+        if (propagatedConf > 0)
+          setTypeMapEntry(symbols.typeMap, ca.varName, returnEntry.type, propagatedConf);
+      }
+    }
   }
 }
 
@@ -845,6 +904,10 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
     } else {
       buildImportEdges(ctx, getNodeIdStmt, allEdgeRows);
     }
+
+    // Phase 8.2: Augment typeMaps with cross-file return-type propagation before
+    // call-edge building so both native and JS paths see the enriched typeMaps.
+    propagateReturnTypesAcrossFiles(ctx.fileSymbols, ctx, ctx.rootDir);
 
     // Skip native call-edge path for small incremental builds: napi-rs
     // marshaling overhead for allNodes exceeds Rust computation savings.

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { getNodeId } from '../../../../db/index.js';
 import { setTypeMapEntry } from '../../../../extractors/helpers.js';
+import { PROPAGATION_HOP_PENALTY } from '../../../../extractors/javascript.js';
 import { debug } from '../../../../infrastructure/logger.js';
 import { loadNative } from '../../../../infrastructure/native.js';
 import type {
@@ -439,7 +440,7 @@ function propagateReturnTypesAcrossFiles(
       }
 
       if (returnEntry) {
-        const propagatedConf = returnEntry.confidence - 0.1;
+        const propagatedConf = returnEntry.confidence - PROPAGATION_HOP_PENALTY;
         if (propagatedConf > 0)
           setTypeMapEntry(symbols.typeMap, ca.varName, returnEntry.type, propagatedConf);
       }
@@ -905,10 +906,6 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
       buildImportEdges(ctx, getNodeIdStmt, allEdgeRows);
     }
 
-    // Phase 8.2: Augment typeMaps with cross-file return-type propagation before
-    // call-edge building so both native and JS paths see the enriched typeMaps.
-    propagateReturnTypesAcrossFiles(ctx.fileSymbols, ctx, ctx.rootDir);
-
     // Skip native call-edge path for small incremental builds: napi-rs
     // marshaling overhead for allNodes exceeds Rust computation savings.
     const useNativeCallEdges =
@@ -927,6 +924,11 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
       batchInsertEdges(db, allEdgeRows);
     }
   });
+  // Phase 8.2: Augment typeMaps with cross-file return-type propagation before
+  // the transaction opens. This is pure in-memory mutation (no DB I/O) and must
+  // run outside the transaction to avoid leaving ctx.fileSymbols in a partial
+  // state if the transaction rolls back unexpectedly.
+  propagateReturnTypesAcrossFiles(ctx.fileSymbols, ctx, ctx.rootDir);
   computeEdgesTx();
 
   // Phase 2: Native rusqlite bulk insert (outside better-sqlite3 transaction

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -82,7 +82,7 @@ const BUILTIN_GLOBALS: Set<string> = new Set([
 /** Maximum chain depth for inter-procedural return-type propagation (Phase 8.2). */
 const MAX_PROPAGATION_DEPTH = 3;
 /** Confidence penalty applied per propagation hop (1.0 → 0.9 → 0.8 → 0.7). */
-const PROPAGATION_HOP_PENALTY = 0.1;
+export const PROPAGATION_HOP_PENALTY = 0.1;
 
 /**
  * Extract symbols from a JS/TS parsed AST.
@@ -1171,11 +1171,23 @@ function extractReturnTypeMapWalk(
         const fnName = currentClass ? `${currentClass}.${nameNode.text}` : nameNode.text;
         storeReturnType(node, fnName, returnTypeMap);
       }
+      // Recurse into the function body with null currentClass so nested
+      // function declarations are not stored under the enclosing class name.
+      for (let i = 0; i < node.childCount; i++) {
+        walk(node.child(i)!, depth + 1, null);
+      }
+      return;
     } else if (t === 'method_definition') {
       const nameNode = node.childForFieldName('name');
       if (nameNode && currentClass && nameNode.text !== 'constructor') {
         storeReturnType(node, `${currentClass}.${nameNode.text}`, returnTypeMap);
       }
+      // Recurse into the method body with null currentClass so nested
+      // function declarations are not stored under the enclosing class name.
+      for (let i = 0; i < node.childCount; i++) {
+        walk(node.child(i)!, depth + 1, null);
+      }
+      return;
     } else if (t === 'variable_declarator') {
       // const foo = (): ReturnType => …  or  const foo = function(): ReturnType { … }
       const nameN = node.childForFieldName('name');
@@ -1207,7 +1219,7 @@ function storeReturnType(
     const typeName = extractSimpleTypeName(returnTypeNode);
     if (typeName) {
       const existing = returnTypeMap.get(fnName);
-      if (!existing || 1.0 > existing.confidence)
+      if (!existing || existing.confidence < 1.0)
         returnTypeMap.set(fnName, { type: typeName, confidence: 1.0 });
       return;
     }

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1,6 +1,7 @@
 import { debug } from '../infrastructure/logger.js';
 import type {
   Call,
+  CallAssignment,
   ClassRelation,
   Definition,
   Export,
@@ -77,6 +78,11 @@ const BUILTIN_GLOBALS: Set<string> = new Set([
   'EventEmitter',
   'Stream',
 ]);
+
+/** Maximum chain depth for inter-procedural return-type propagation (Phase 8.2). */
+const MAX_PROPAGATION_DEPTH = 3;
+/** Confidence penalty applied per propagation hop (1.0 → 0.9 → 0.8 → 0.7). */
+const PROPAGATION_HOP_PENALTY = 0.1;
 
 /**
  * Extract symbols from a JS/TS parsed AST.
@@ -306,6 +312,8 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
   const classes: ClassRelation[] = [];
   const exps: Export[] = [];
   const typeMap: Map<string, TypeMapEntry> = new Map();
+  const returnTypeMap: Map<string, TypeMapEntry> = new Map();
+  const callAssignments: CallAssignment[] = [];
 
   const matches = query.matches(tree.rootNode);
 
@@ -322,13 +330,25 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
   // Extract dynamic import() calls via targeted walk (query patterns don't match `import` function type)
   extractDynamicImportsWalk(tree.rootNode, imports);
 
-  // Extract typeMap from type annotations and new expressions
-  extractTypeMapWalk(tree.rootNode, typeMap);
+  // Phase 8.2: Extract function return types first so propagation can use them
+  extractReturnTypeMapWalk(tree.rootNode, returnTypeMap);
+
+  // Extract typeMap with intra-file return-type propagation
+  extractTypeMapWalk(tree.rootNode, typeMap, returnTypeMap, callAssignments);
 
   // Extract definitions from destructured bindings (query patterns don't match object_pattern)
   extractDestructuredBindingsWalk(tree.rootNode, definitions);
 
-  return { definitions, calls, imports, classes, exports: exps, typeMap };
+  return {
+    definitions,
+    calls,
+    imports,
+    classes,
+    exports: exps,
+    typeMap,
+    returnTypeMap,
+    callAssignments,
+  };
 }
 
 /** Node types that define a function scope — constants inside these are skipped. */
@@ -556,11 +576,15 @@ function extractSymbolsWalk(tree: TreeSitterTree): ExtractorOutput {
     classes: [],
     exports: [],
     typeMap: new Map(),
+    returnTypeMap: new Map(),
+    callAssignments: [],
   };
 
   walkJavaScriptNode(tree.rootNode, ctx);
-  // Populate typeMap for variables and parameter type annotations
-  extractTypeMapWalk(tree.rootNode, ctx.typeMap!);
+  // Phase 8.2: Extract function return types first so propagation can use them
+  extractReturnTypeMapWalk(tree.rootNode, ctx.returnTypeMap!);
+  // Populate typeMap with type annotations and intra-file return-type propagation
+  extractTypeMapWalk(tree.rootNode, ctx.typeMap!, ctx.returnTypeMap, ctx.callAssignments);
   return ctx;
 }
 
@@ -1114,22 +1138,221 @@ function extractNewExprTypeName(newExprNode: TreeSitterNode): string | null {
   return null;
 }
 
+// ── Phase 8.2: Inter-Procedural Return Type Propagation ─────────────────────
+
+/**
+ * Walk the AST and record the return type of every function/method definition.
+ *
+ * Keys: plain name (e.g. "createUser") or "ClassName.methodName" for methods.
+ * Confidence:
+ *   - 1.0: explicit TypeScript return type annotation
+ *   - 0.85: inferred from the first `return new Constructor()` in the body
+ */
+function extractReturnTypeMapWalk(
+  rootNode: TreeSitterNode,
+  returnTypeMap: Map<string, TypeMapEntry>,
+): void {
+  function walk(node: TreeSitterNode, depth: number, currentClass: string | null): void {
+    if (depth >= MAX_WALK_DEPTH) return;
+    const t = node.type;
+
+    if (t === 'class_declaration' || t === 'class') {
+      const nameNode = node.childForFieldName('name');
+      const className = nameNode?.text ?? null;
+      for (let i = 0; i < node.childCount; i++) {
+        walk(node.child(i)!, depth + 1, className);
+      }
+      return;
+    }
+
+    if (t === 'function_declaration') {
+      const nameNode = node.childForFieldName('name');
+      if (nameNode?.type === 'identifier' && nameNode.text !== 'constructor') {
+        const fnName = currentClass ? `${currentClass}.${nameNode.text}` : nameNode.text;
+        storeReturnType(node, fnName, returnTypeMap);
+      }
+    } else if (t === 'method_definition') {
+      const nameNode = node.childForFieldName('name');
+      if (nameNode && currentClass && nameNode.text !== 'constructor') {
+        storeReturnType(node, `${currentClass}.${nameNode.text}`, returnTypeMap);
+      }
+    } else if (t === 'variable_declarator') {
+      // const foo = (): ReturnType => …  or  const foo = function(): ReturnType { … }
+      const nameN = node.childForFieldName('name');
+      const valueN = node.childForFieldName('value');
+      if (nameN?.type === 'identifier' && valueN) {
+        const vt = valueN.type;
+        if (vt === 'arrow_function' || vt === 'function_expression') {
+          const fnName = currentClass ? `${currentClass}.${nameN.text}` : nameN.text;
+          storeReturnType(valueN, fnName, returnTypeMap);
+        }
+      }
+    }
+
+    for (let i = 0; i < node.childCount; i++) {
+      walk(node.child(i)!, depth + 1, currentClass);
+    }
+  }
+  walk(rootNode, 0, null);
+}
+
+/** Extract the return type of a function node and store it in the returnTypeMap. */
+function storeReturnType(
+  fnNode: TreeSitterNode,
+  fnName: string,
+  returnTypeMap: Map<string, TypeMapEntry>,
+): void {
+  const returnTypeNode = fnNode.childForFieldName('return_type');
+  if (returnTypeNode) {
+    const typeName = extractSimpleTypeName(returnTypeNode);
+    if (typeName) {
+      const existing = returnTypeMap.get(fnName);
+      if (!existing || 1.0 > existing.confidence)
+        returnTypeMap.set(fnName, { type: typeName, confidence: 1.0 });
+      return;
+    }
+  }
+  // Infer from first `return new Constructor()` in the function body
+  const body = fnNode.childForFieldName('body');
+  if (body) {
+    const inferred = findReturnNewExprType(body);
+    if (inferred) {
+      const existing = returnTypeMap.get(fnName);
+      if (!existing || 0.85 > existing.confidence)
+        returnTypeMap.set(fnName, { type: inferred, confidence: 0.85 });
+    }
+  }
+}
+
+/** Return the constructor name from the first `return new Constructor()` in a body, or null. */
+function findReturnNewExprType(bodyNode: TreeSitterNode): string | null {
+  for (let i = 0; i < bodyNode.childCount; i++) {
+    const child = bodyNode.child(i);
+    if (!child || child.type !== 'return_statement') continue;
+    for (let j = 0; j < child.childCount; j++) {
+      const expr = child.child(j);
+      if (expr?.type === 'new_expression') return extractNewExprTypeName(expr);
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the return type of a call_expression node using returnTypeMap.
+ * Handles: createUser() (identifier), service.getRepo() (member), and
+ * getService().getRepo() (chained call) up to MAX_PROPAGATION_DEPTH hops.
+ *
+ * `depth` tracks total chain hops consumed so far.  Each call boundary — both
+ * resolving the receiver and resolving the final return type — costs one hop.
+ * Confidence = annotated return type confidence − 0.1 × (depth + 1).
+ *
+ * Examples (annotated sources → confidence 1.0):
+ *   createUser()          depth=0 → 1.0 − 0.1 = 0.9 (1 hop)
+ *   svc.getUser()         depth=0 → 1.0 − 0.1 = 0.9 (1 hop; receiver from typeMap)
+ *   getService().getRepo() depth=0 → inner resolved at depth=1, outer at depth+1 → 0.8 (2 hops)
+ */
+function resolveCallExprReturnType(
+  callNode: TreeSitterNode,
+  typeMap: Map<string, TypeMapEntry>,
+  returnTypeMap: Map<string, TypeMapEntry>,
+  depth: number,
+): TypeMapEntry | null {
+  if (depth >= MAX_PROPAGATION_DEPTH) return null;
+
+  const fn = callNode.childForFieldName('function');
+  if (!fn) return null;
+
+  if (fn.type === 'identifier') {
+    const entry = returnTypeMap.get(fn.text);
+    if (!entry) return null;
+    const confidence = entry.confidence - PROPAGATION_HOP_PENALTY * (depth + 1);
+    return confidence > 0 ? { type: entry.type, confidence } : null;
+  }
+
+  if (fn.type === 'member_expression') {
+    const obj = fn.childForFieldName('object');
+    const prop = fn.childForFieldName('property');
+    if (!obj || !prop) return null;
+
+    let receiverType: string | null = null;
+    // effectiveDepth tracks the depth at which THIS call's return type is charged.
+    // When the receiver is itself a call expression (chain), we've already consumed
+    // a hop resolving it, so charge this call at depth+1.
+    let effectiveDepth = depth;
+
+    if (obj.type === 'identifier') {
+      const typeEntry = typeMap.get(obj.text);
+      receiverType = typeEntry ? typeEntry.type : null;
+    } else if (obj.type === 'call_expression') {
+      // Each link in a call chain costs an extra hop.
+      const innerResult = resolveCallExprReturnType(obj, typeMap, returnTypeMap, depth + 1);
+      receiverType = innerResult ? innerResult.type : null;
+      effectiveDepth = depth + 1;
+    }
+
+    if (receiverType) {
+      const entry = returnTypeMap.get(`${receiverType}.${prop.text}`);
+      if (entry) {
+        const confidence = entry.confidence - PROPAGATION_HOP_PENALTY * (effectiveDepth + 1);
+        return confidence > 0 ? { type: entry.type, confidence } : null;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Record a call assignment into callAssignments for cross-file propagation.
+ * Only records cases where the callee is a simple identifier or a method call
+ * on a known-typed variable — chain expressions are skipped (handled locally).
+ */
+function recordCallAssignment(
+  callNode: TreeSitterNode,
+  varName: string,
+  typeMap: Map<string, TypeMapEntry>,
+  callAssignments: CallAssignment[],
+): void {
+  const fn = callNode.childForFieldName('function');
+  if (!fn) return;
+  if (fn.type === 'identifier') {
+    callAssignments.push({ varName, calleeName: fn.text });
+  } else if (fn.type === 'member_expression') {
+    const obj = fn.childForFieldName('object');
+    const prop = fn.childForFieldName('property');
+    if (obj?.type === 'identifier' && prop) {
+      const receiverEntry = typeMap.get(obj.text);
+      callAssignments.push({
+        varName,
+        calleeName: prop.text,
+        receiverTypeName: receiverEntry?.type,
+      });
+    }
+  }
+}
+
 /**
  * Extract variable-to-type assignments into a per-file type map.
  *
  * Values are `{ type: string, confidence: number }`:
  *   - 1.0: explicit constructor (`new Foo()`)
  *   - 0.9: type annotation (`: Foo`) or typed parameter
+ *   - 0.7–0.9: inter-procedural propagation from return-type map (Phase 8.2)
  *   - 0.7: factory method call (`Foo.create()` — uppercase-first heuristic)
  *
  * Higher-confidence entries take priority when the same variable is seen twice.
  */
-function extractTypeMapWalk(rootNode: TreeSitterNode, typeMap: Map<string, TypeMapEntry>): void {
+function extractTypeMapWalk(
+  rootNode: TreeSitterNode,
+  typeMap: Map<string, TypeMapEntry>,
+  returnTypeMap?: Map<string, TypeMapEntry>,
+  callAssignments?: CallAssignment[],
+): void {
   function walk(node: TreeSitterNode, depth: number): void {
     if (depth >= MAX_WALK_DEPTH) return;
     const t = node.type;
     if (t === 'variable_declarator') {
-      handleVarDeclaratorTypeMap(node, typeMap);
+      handleVarDeclaratorTypeMap(node, typeMap, returnTypeMap, callAssignments);
     } else if (t === 'required_parameter' || t === 'optional_parameter') {
       handleParamTypeMap(node, typeMap);
     }
@@ -1144,6 +1367,8 @@ function extractTypeMapWalk(rootNode: TreeSitterNode, typeMap: Map<string, TypeM
 function handleVarDeclaratorTypeMap(
   node: TreeSitterNode,
   typeMap: Map<string, TypeMapEntry>,
+  returnTypeMap?: Map<string, TypeMapEntry>,
+  callAssignments?: CallAssignment[],
 ): void {
   const nameN = node.childForFieldName('name');
   if (!nameN || nameN.type !== 'identifier') return;
@@ -1173,15 +1398,27 @@ function handleVarDeclaratorTypeMap(
   }
 
   if (!valueN) return;
-
-  // Constructor already handled above — only factory path remains.
   if (valueN.type === 'new_expression') return;
-  // Factory method: const x = Foo.create() → confidence 0.7
-  else if (valueN.type === 'call_expression') {
+
+  if (valueN.type === 'call_expression') {
+    // Phase 8.2: inter-procedural propagation — try to resolve return type from
+    // the local returnTypeMap before falling back to factory heuristics.
+    if (returnTypeMap) {
+      const result = resolveCallExprReturnType(valueN, typeMap, returnTypeMap, 0);
+      if (result) {
+        setTypeMapEntry(typeMap, nameN.text, result.type, result.confidence);
+        return;
+      }
+    }
+    // Record for cross-file resolution in build-edges.ts (imported functions)
+    if (callAssignments) {
+      recordCallAssignment(valueN, nameN.text, typeMap, callAssignments);
+    }
+    // Factory method heuristic: const x = Foo.create() → type Foo, confidence 0.7
     const fn = valueN.childForFieldName('function');
-    if (fn && fn.type === 'member_expression') {
+    if (fn?.type === 'member_expression') {
       const obj = fn.childForFieldName('object');
-      if (obj && obj.type === 'identifier') {
+      if (obj?.type === 'identifier') {
         const objName = obj.text;
         if (
           objName[0] &&

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -79,6 +79,7 @@ export const DEFAULTS = {
     briefImporterDepth: 5,
     briefHighRiskCallers: 10,
     briefMediumRiskCallers: 3,
+    typePropagationDepth: 3,
   },
   community: {
     resolution: 1.0,

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -79,6 +79,9 @@ export const DEFAULTS = {
     briefImporterDepth: 5,
     briefHighRiskCallers: 10,
     briefMediumRiskCallers: 3,
+    // TODO(Phase 8.3): wire this into PROPAGATION_HOP_PENALTY / MAX_PROPAGATION_DEPTH once
+    // config is threaded through to extractSymbols. Currently the depth is controlled by
+    // the hardcoded MAX_PROPAGATION_DEPTH constant in src/extractors/javascript.ts.
     typePropagationDepth: 3,
   },
   community: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -523,6 +523,19 @@ export interface TypeMapEntry {
   confidence: number;
 }
 
+/**
+ * A variable assignment from a call expression, recorded during extraction for
+ * cross-file return-type propagation (Phase 8.2).
+ */
+export interface CallAssignment {
+  /** Variable being assigned to. */
+  varName: string;
+  /** Name of the function or method being called. */
+  calleeName: string;
+  /** Resolved receiver type, if the call is a method call (e.g. service.getRepo()). */
+  receiverTypeName?: string;
+}
+
 /** The normalized output shape returned by every language extractor. */
 export interface ExtractorOutput {
   definitions: Definition[];
@@ -531,6 +544,17 @@ export interface ExtractorOutput {
   classes: ClassRelation[];
   exports: Export[];
   typeMap: Map<string, TypeMapEntry>;
+  /**
+   * Maps function/method names to their declared or inferred return types.
+   * Keys: plain name (e.g. "createUser") or qualified name (e.g. "UserService.getUser").
+   * Populated by JS/TS extractor; used for inter-procedural type propagation (Phase 8.2).
+   */
+  returnTypeMap?: Map<string, TypeMapEntry>;
+  /**
+   * Variable assignments from call expressions that could not be resolved from the
+   * per-file returnTypeMap. Consumed by build-edges.ts to propagate cross-file return types.
+   */
+  callAssignments?: CallAssignment[];
   /** WASM tree retained for downstream analysis (complexity, CFG, dataflow). */
   _tree?: TreeSitterTree;
   /** Language identifier. */
@@ -1189,6 +1213,8 @@ export interface CodegraphConfig {
     briefImporterDepth: number;
     briefHighRiskCallers: number;
     briefMediumRiskCallers: number;
+    /** Maximum chain depth for inter-procedural return-type propagation (Phase 8.2). */
+    typePropagationDepth: number;
   };
 
   community: {

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -259,6 +259,114 @@ describe('JavaScript parser', () => {
     });
   });
 
+  describe('Phase 8.2: inter-procedural return-type propagation', () => {
+    function parseTS(code) {
+      const parser = parsers.get('typescript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.ts');
+    }
+
+    describe('returnTypeMap extraction', () => {
+      it('records explicit TS return type annotation with confidence 1.0', () => {
+        const symbols = parseTS(`function createUser(): User { return new User(); }`);
+        expect(symbols.returnTypeMap).toBeInstanceOf(Map);
+        expect(symbols.returnTypeMap.get('createUser')).toEqual({ type: 'User', confidence: 1.0 });
+      });
+
+      it('infers return type from return new Constructor() with confidence 0.85', () => {
+        const symbols = parseTS(`function buildRouter() { return new Router(); }`);
+        expect(symbols.returnTypeMap.get('buildRouter')).toEqual({
+          type: 'Router',
+          confidence: 0.85,
+        });
+      });
+
+      it('prefers annotation over inferred return type', () => {
+        const symbols = parseTS(`function create(): Service { return new OtherService(); }`);
+        expect(symbols.returnTypeMap.get('create')).toEqual({ type: 'Service', confidence: 1.0 });
+      });
+
+      it('qualifies method return types with class name', () => {
+        const symbols = parseTS(`
+          class UserService {
+            getUser(): User { return new User(); }
+          }
+        `);
+        expect(symbols.returnTypeMap.get('UserService.getUser')).toEqual({
+          type: 'User',
+          confidence: 1.0,
+        });
+      });
+
+      it('records arrow function return type from variable declarator', () => {
+        const symbols = parseTS(`const createRepo = (): Repo => new Repo();`);
+        expect(symbols.returnTypeMap.get('createRepo')).toEqual({ type: 'Repo', confidence: 1.0 });
+      });
+
+      it('does not record constructor methods', () => {
+        const symbols = parseTS(`class Foo { constructor() {} }`);
+        expect(symbols.returnTypeMap.has('Foo.constructor')).toBe(false);
+      });
+    });
+
+    describe('intra-file propagation via returnTypeMap', () => {
+      it('propagates return type of annotated function — confidence 0.9 (1.0 - 0.1 × hop 1)', () => {
+        const symbols = parseTS(`
+          function createUser(): User { return new User(); }
+          const u = createUser();
+        `);
+        expect(symbols.typeMap.get('u')).toEqual({ type: 'User', confidence: 0.9 });
+      });
+
+      it('propagates return type inferred from return new — confidence 0.75 (0.85 - 0.1)', () => {
+        const symbols = parseTS(`
+          function buildRouter() { return new Router(); }
+          const r = buildRouter();
+        `);
+        expect(symbols.typeMap.get('r')).toEqual({ type: 'Router', confidence: 0.75 });
+      });
+
+      it('propagates return type via method call on typed receiver', () => {
+        const symbols = parseTS(`
+          class UserService {
+            getUser(): User { return new User(); }
+          }
+          const svc: UserService = new UserService();
+          const u = svc.getUser();
+        `);
+        expect(symbols.typeMap.get('u')).toEqual({ type: 'User', confidence: 0.9 });
+      });
+
+      it('resolves one-hop method chain — getService().getRepo()', () => {
+        const symbols = parseTS(`
+          function getService(): UserService { return new UserService(); }
+          class UserService {
+            getRepo(): Repo { return new Repo(); }
+          }
+          const repo = getService().getRepo();
+        `);
+        expect(symbols.typeMap.get('repo')).toEqual({ type: 'Repo', confidence: 0.8 });
+      });
+
+      it('does not override higher-confidence annotation with propagated type', () => {
+        const symbols = parseTS(`
+          function createUser(): User { return new User(); }
+          const u: Admin = createUser();
+        `);
+        // Annotation (0.9) wins over propagated (0.9) — setTypeMapEntry keeps first seen
+        expect(symbols.typeMap.get('u')?.type).toBe('Admin');
+      });
+
+      it('does not propagate for plain function calls with no return type info', () => {
+        const symbols = parseTS(`
+          function doSomething() { return 42; }
+          const x = doSomething();
+        `);
+        expect(symbols.typeMap.has('x')).toBe(false);
+      });
+    });
+  });
+
   it('does not set receiver for .call()/.apply()/.bind() unwrapped calls', () => {
     const symbols = parseJS(`fn.call(null, arg);`);
     const fnCall = symbols.calls.find((c) => c.name === 'fn');

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -95,6 +95,7 @@ describe('DEFAULTS', () => {
       briefImporterDepth: 5,
       briefHighRiskCallers: 10,
       briefMediumRiskCallers: 3,
+      typePropagationDepth: 3,
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `extractReturnTypeMapWalk` to the JS/TS extractor: scans every function/method definition and records its return type (confidence 1.0 from explicit TS annotations, 0.85 from `return new Constructor()`)
- Propagates return types intra-file: `const x = createUser()` → `x` gets type `User` in the typeMap; method chains like `getService().getRepo()` are resolved recursively up to 3 hops with confidence decaying 0.1 per hop (0.9 → 0.8 → 0.7)
- Cross-file propagation in `build-edges.ts`: unresolved call assignments are resolved against imported files' `returnTypeMap`s before both native and JS call-edge paths run
- Adds `analysis.typePropagationDepth: 3` to `DEFAULTS`/`CodegraphConfig` for future tunability

## Test plan

- [ ] `npm test` — all 2790 tests pass, 12 new tests covering: `returnTypeMap` extraction (annotations, inferred, method qualification, arrow fns), single-hop propagation, method-call propagation, chain resolution, confidence values, and edge cases (no-override, missing return info)
- [ ] `npx tsc --noEmit` — clean

Closes #[roadmap Phase 8.2]