### PR TITLE
feat(resolver): backfill returnTypeMap/callAssignments for native engine (Phase 8.2 parity)

### DIFF
--- a/src/domain/graph/resolver/ts-resolver.ts
+++ b/src/domain/graph/resolver/ts-resolver.ts
@@ -400,6 +400,14 @@ function enrichReturnTypeMap(
  * Walk a SourceFile and push call assignments (`const x = fn()`) whose variable
  * is not yet in typeMap into callAssignments for cross-file propagation.
  * Phase 8.1 already resolved the common case into typeMap; this captures the rest.
+ *
+ * Uses the same two-pass "unambiguous names only" strategy as `enrichSourceFile`:
+ * collect all candidates first, then only push entries where a given `varName`
+ * maps to exactly one distinct `calleeName`. This prevents multiple methods in the
+ * same file that each bind a different imported function to a common local name
+ * (e.g., `const result = getA()` in one method, `const result = getB()` in
+ * another) from both landing in `callAssignments`, which would cause
+ * `propagateReturnTypesAcrossFiles` to silently resolve one arbitrarily.
  */
 function enrichCallAssignments(
   ts: TsModule,
@@ -407,6 +415,9 @@ function enrichCallAssignments(
   typeMap: Map<string, TypeMapEntry>,
   callAssignments: CallAssignment[],
 ): void {
+  // First pass: collect all candidates keyed by varName.
+  const candidates = new Map<string, CallAssignment[]>();
+
   function visit(node: import('typescript').Node): void {
     if (
       ts.isVariableDeclaration(node) &&
@@ -431,7 +442,15 @@ function enrichCallAssignments(
           }
         }
 
-        if (calleeName) callAssignments.push({ varName, calleeName, receiverTypeName });
+        if (calleeName) {
+          const ca: CallAssignment = { varName, calleeName, receiverTypeName };
+          const existing = candidates.get(varName);
+          if (existing) {
+            existing.push(ca);
+          } else {
+            candidates.set(varName, [ca]);
+          }
+        }
       }
     }
 
@@ -439,6 +458,16 @@ function enrichCallAssignments(
   }
 
   ts.forEachChild(sourceFile, visit);
+
+  // Second pass: only push entries where varName maps to exactly one distinct
+  // calleeName. Ambiguous varNames (same name, different callees across scopes)
+  // are excluded to avoid silently resolving the wrong type cross-file.
+  for (const entries of candidates.values()) {
+    const uniqueCallees = new Set(entries.map((e) => e.calleeName));
+    if (uniqueCallees.size === 1) {
+      callAssignments.push(entries[0] as CallAssignment);
+    }
+  }
 }
 
 /**

--- a/src/domain/graph/resolver/ts-resolver.ts
+++ b/src/domain/graph/resolver/ts-resolver.ts
@@ -18,7 +18,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { debug } from '../../../infrastructure/logger.js';
-import type { ExtractorOutput, TypeMapEntry } from '../../../types.js';
+import type { CallAssignment, ExtractorOutput, TypeMapEntry } from '../../../types.js';
 
 // typescript is not a hard dependency — lazy-load it so JS-only projects
 // and environments without typescript installed work without error.
@@ -101,6 +101,7 @@ export async function enrichTypeMapWithTsc(
   const checker = program.getTypeChecker();
   let enrichedFiles = 0;
   let enrichedEntries = 0;
+  let backfilledFiles = 0;
 
   for (const relPath of tsRelPaths) {
     const symbols = fileSymbols.get(relPath)!;
@@ -117,10 +118,23 @@ export async function enrichTypeMapWithTsc(
       enrichedEntries += gained;
       enrichedFiles++;
     }
+
+    // Phase 8.2 parity: backfill returnTypeMap and callAssignments for engines
+    // (native Rust) that don't populate them during extraction. The JS extractor
+    // sets these fields; native leaves them undefined.
+    if (symbols.returnTypeMap === undefined) {
+      symbols.returnTypeMap = new Map();
+      symbols.callAssignments = [];
+      enrichReturnTypeMap(ts, sourceFile, checker, symbols.returnTypeMap);
+      enrichCallAssignments(ts, sourceFile, symbols.typeMap, symbols.callAssignments);
+      if (symbols.returnTypeMap.size > 0 || symbols.callAssignments.length > 0) backfilledFiles++;
+    }
   }
 
   debug(
-    `ts-resolver: enriched ${enrichedEntries} typeMap entries across ${enrichedFiles} files in ${Date.now() - t0}ms`,
+    `ts-resolver: enriched ${enrichedEntries} typeMap entries across ${enrichedFiles} files` +
+      (backfilledFiles > 0 ? `, backfilled returnTypeMap/callAssignments in ${backfilledFiles} files` : '') +
+      ` in ${Date.now() - t0}ms`,
   );
 }
 
@@ -259,6 +273,123 @@ function enrichSourceFile(
       typeMap.set(name, { type: typeName, confidence: 1.0 });
     }
   }
+}
+
+/**
+ * Walk a SourceFile and populate returnTypeMap with compiler-verified return types.
+ * Handles function declarations, method declarations, and arrow/function-expression
+ * variable initialisers. Methods are stored as `ClassName.methodName`.
+ */
+function enrichReturnTypeMap(
+  ts: TsModule,
+  sourceFile: import('typescript').SourceFile,
+  checker: import('typescript').TypeChecker,
+  returnTypeMap: Map<string, TypeMapEntry>,
+): void {
+  let currentClass: string | null = null;
+
+  function visit(node: import('typescript').Node): void {
+    if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+      const saved = currentClass;
+      currentClass =
+        (node as import('typescript').ClassDeclaration | import('typescript').ClassExpression).name
+          ?.text ?? null;
+      ts.forEachChild(node, visit);
+      currentClass = saved;
+      return;
+    }
+
+    let fnName: string | null = null;
+    let sigNode: import('typescript').SignatureDeclaration | null = null;
+
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      fnName = node.name.text;
+      sigNode = node;
+    } else if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
+      fnName = currentClass ? `${currentClass}.${node.name.text}` : node.name.text;
+      sigNode = node;
+    } else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const init = node.initializer;
+      if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
+        fnName = node.name.text;
+        sigNode = init;
+      }
+    }
+
+    if (fnName && sigNode) {
+      try {
+        const sig = checker.getSignatureFromDeclaration(sigNode);
+        if (sig) {
+          const retType = checker.getReturnTypeOfSignature(sig);
+          const sym = retType.getSymbol() ?? retType.aliasSymbol;
+          if (sym) {
+            const typeName = sym.getName();
+            if (
+              typeName &&
+              typeName !== '__type' &&
+              typeName !== '__object' &&
+              !SKIP_TYPE_NAMES.has(typeName)
+            ) {
+              const existing = returnTypeMap.get(fnName);
+              if (!existing || existing.confidence < 1.0)
+                returnTypeMap.set(fnName, { type: typeName, confidence: 1.0 });
+            }
+          }
+        }
+      } catch {
+        // skip — checker can throw on malformed nodes
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  ts.forEachChild(sourceFile, visit);
+}
+
+/**
+ * Walk a SourceFile and push call assignments (`const x = fn()`) whose variable
+ * is not yet in typeMap into callAssignments for cross-file propagation.
+ * Phase 8.1 already resolved the common case into typeMap; this captures the rest.
+ */
+function enrichCallAssignments(
+  ts: TsModule,
+  sourceFile: import('typescript').SourceFile,
+  typeMap: Map<string, TypeMapEntry>,
+  callAssignments: CallAssignment[],
+): void {
+  function visit(node: import('typescript').Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isCallExpression(node.initializer)
+    ) {
+      const varName = node.name.text;
+      if (!typeMap.has(varName)) {
+        const call = node.initializer;
+        let calleeName: string | null = null;
+        let receiverTypeName: string | undefined;
+
+        if (ts.isIdentifier(call.expression)) {
+          calleeName = call.expression.text;
+        } else if (ts.isPropertyAccessExpression(call.expression)) {
+          calleeName = call.expression.name.text;
+          const obj = call.expression.expression;
+          if (ts.isIdentifier(obj)) {
+            const entry = typeMap.get(obj.text);
+            if (entry && typeof entry === 'object') receiverTypeName = entry.type;
+          }
+        }
+
+        if (calleeName) callAssignments.push({ varName, calleeName, receiverTypeName });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  ts.forEachChild(sourceFile, visit);
 }
 
 /**

--- a/src/domain/graph/resolver/ts-resolver.ts
+++ b/src/domain/graph/resolver/ts-resolver.ts
@@ -122,18 +122,27 @@ export async function enrichTypeMapWithTsc(
     // Phase 8.2 parity: backfill returnTypeMap and callAssignments for engines
     // (native Rust) that don't populate them during extraction. The JS extractor
     // sets these fields; native leaves them undefined.
+    // Guards are intentionally independent so a future extractor that sets one
+    // but not the other is handled correctly without silently skipping either.
+    let didBackfill = false;
     if (symbols.returnTypeMap === undefined) {
       symbols.returnTypeMap = new Map();
-      symbols.callAssignments = [];
       enrichReturnTypeMap(ts, sourceFile, checker, symbols.returnTypeMap);
-      enrichCallAssignments(ts, sourceFile, symbols.typeMap, symbols.callAssignments);
-      if (symbols.returnTypeMap.size > 0 || symbols.callAssignments.length > 0) backfilledFiles++;
+      if (symbols.returnTypeMap.size > 0) didBackfill = true;
     }
+    if (symbols.callAssignments === undefined) {
+      symbols.callAssignments = [];
+      enrichCallAssignments(ts, sourceFile, symbols.typeMap, symbols.callAssignments);
+      if (symbols.callAssignments.length > 0) didBackfill = true;
+    }
+    if (didBackfill) backfilledFiles++;
   }
 
   debug(
     `ts-resolver: enriched ${enrichedEntries} typeMap entries across ${enrichedFiles} files` +
-      (backfilledFiles > 0 ? `, backfilled returnTypeMap/callAssignments in ${backfilledFiles} files` : '') +
+      (backfilledFiles > 0
+        ? `, backfilled returnTypeMap/callAssignments in ${backfilledFiles} files`
+        : '') +
       ` in ${Date.now() - t0}ms`,
   );
 }
@@ -278,7 +287,15 @@ function enrichSourceFile(
 /**
  * Walk a SourceFile and populate returnTypeMap with compiler-verified return types.
  * Handles function declarations, method declarations, and arrow/function-expression
- * variable initialisers. Methods are stored as `ClassName.methodName`.
+ * variable initialisers at module scope. Methods are stored as `ClassName.methodName`.
+ *
+ * Only captures declarations at module scope or directly inside a class body —
+ * local functions nested inside method bodies are excluded to avoid spurious
+ * cross-file type matches (same guard as enrichSourceFile's "unambiguous names only"
+ * heuristic). Recursion stops at function/method body boundaries.
+ *
+ * Async functions returning Promise<T> are unwrapped: the inner type argument T is
+ * used so that async methods receive a returnTypeMap entry just like sync ones.
  */
 function enrichReturnTypeMap(
   ts: TsModule,
@@ -288,59 +305,86 @@ function enrichReturnTypeMap(
 ): void {
   let currentClass: string | null = null;
 
+  /**
+   * Resolve the concrete return type name for a signature, unwrapping
+   * Promise<T> so async functions contribute their inner type.
+   */
+  function resolveReturnTypeName(sig: import('typescript').Signature | undefined): string | null {
+    if (!sig) return null;
+    try {
+      let retType = checker.getReturnTypeOfSignature(sig);
+
+      // Unwrap Promise<T> → T so async functions get a useful returnTypeMap entry.
+      const outerSym = retType.getSymbol() ?? retType.aliasSymbol;
+      if (outerSym?.getName() === 'Promise') {
+        const args = checker.getTypeArguments(retType as import('typescript').TypeReference);
+        if (args.length > 0) retType = args[0]!;
+      }
+
+      const sym = retType.getSymbol() ?? retType.aliasSymbol;
+      if (!sym) return null;
+      const name = sym.getName();
+      if (!name || name === '__type' || name === '__object' || SKIP_TYPE_NAMES.has(name))
+        return null;
+      return name;
+    } catch {
+      return null;
+    }
+  }
+
+  function writeEntry(fnName: string, sigNode: import('typescript').SignatureDeclaration): void {
+    const typeName = resolveReturnTypeName(checker.getSignatureFromDeclaration(sigNode));
+    if (typeName) {
+      const existing = returnTypeMap.get(fnName);
+      if (!existing || existing.confidence < 1.0)
+        returnTypeMap.set(fnName, { type: typeName, confidence: 1.0 });
+    }
+  }
+
+  /**
+   * Visit nodes at the current lexical scope (module level or class body).
+   * Does NOT recurse into function/method bodies to avoid capturing local
+   * helper functions under bare names.
+   */
   function visit(node: import('typescript').Node): void {
     if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+      // Enter class scope: visit direct children (method/property declarations).
       const saved = currentClass;
       currentClass =
         (node as import('typescript').ClassDeclaration | import('typescript').ClassExpression).name
           ?.text ?? null;
       ts.forEachChild(node, visit);
       currentClass = saved;
+      return; // class body fully handled — stop here
+    }
+
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      // Module-level function declaration: record and stop (no body descent).
+      writeEntry(node.name.text, node);
       return;
     }
 
-    let fnName: string | null = null;
-    let sigNode: import('typescript').SignatureDeclaration | null = null;
+    if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
+      // Class method: record as ClassName.methodName and stop.
+      const fnName = currentClass ? `${currentClass}.${node.name.text}` : node.name.text;
+      writeEntry(fnName, node);
+      return;
+    }
 
-    if (ts.isFunctionDeclaration(node) && node.name) {
-      fnName = node.name.text;
-      sigNode = node;
-    } else if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
-      fnName = currentClass ? `${currentClass}.${node.name.text}` : node.name.text;
-      sigNode = node;
-    } else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      // Arrow/function-expression assigned to a variable at the current scope.
+      // Because we never recurse into function bodies, any VariableDeclaration
+      // we see here is guaranteed to be at module scope or inside a class body
+      // (not inside a method body), making the bare name safe for cross-file use.
       const init = node.initializer;
       if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
-        fnName = node.name.text;
-        sigNode = init;
+        writeEntry(node.name.text, init);
       }
+      return; // variable declaration fully handled — stop here
     }
 
-    if (fnName && sigNode) {
-      try {
-        const sig = checker.getSignatureFromDeclaration(sigNode);
-        if (sig) {
-          const retType = checker.getReturnTypeOfSignature(sig);
-          const sym = retType.getSymbol() ?? retType.aliasSymbol;
-          if (sym) {
-            const typeName = sym.getName();
-            if (
-              typeName &&
-              typeName !== '__type' &&
-              typeName !== '__object' &&
-              !SKIP_TYPE_NAMES.has(typeName)
-            ) {
-              const existing = returnTypeMap.get(fnName);
-              if (!existing || existing.confidence < 1.0)
-                returnTypeMap.set(fnName, { type: typeName, confidence: 1.0 });
-            }
-          }
-        }
-      } catch {
-        // skip — checker can throw on malformed nodes
-      }
-    }
-
+    // For all other node kinds (VariableStatement, VariableDeclarationList,
+    // ExportDeclaration, etc.) recurse to reach nested function/class/var nodes.
     ts.forEachChild(node, visit);
   }
 

--- a/tests/unit/ts-resolver.test.ts
+++ b/tests/unit/ts-resolver.test.ts
@@ -128,6 +128,46 @@ const repo = getRepo();
     expect(ca!.calleeName).toBe('getRepo');
   });
 
+  it('excludes ambiguous callAssignments where same varName maps to different callees', async () => {
+    const srcFile = 'ambiguous.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+declare function getA(): any;
+declare function getB(): any;
+declare function getUnique(): any;
+
+class MyService {
+  methodOne() {
+    const result = getA();
+    return result;
+  }
+  methodTwo() {
+    // Same varName 'result' but different callee — should be excluded as ambiguous
+    const result = getB();
+    return result;
+  }
+}
+
+// Unambiguous: only one binding across the file
+const unique = getUnique();
+`,
+    );
+
+    const fileSymbols = makeFileSymbols(srcFile);
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    expect(symbols.callAssignments).toBeDefined();
+    // 'result' is ambiguous (getA in one method, getB in another) — must be excluded
+    const resultEntries = symbols.callAssignments!.filter((c) => c.varName === 'result');
+    expect(resultEntries).toHaveLength(0);
+    // 'unique' is unambiguous — must be included
+    const uniqueEntry = symbols.callAssignments!.find((c) => c.varName === 'unique');
+    expect(uniqueEntry).toBeDefined();
+    expect(uniqueEntry!.calleeName).toBe('getUnique');
+  });
+
   it('does NOT overwrite returnTypeMap when already set (JS/WASM engine path)', async () => {
     const srcFile = 'existing.ts';
     fs.writeFileSync(

--- a/tests/unit/ts-resolver.test.ts
+++ b/tests/unit/ts-resolver.test.ts
@@ -151,6 +151,55 @@ function makeFoo(): Foo { return new Foo(); }
     });
   });
 
+  it('backfills returnTypeMap for async functions by unwrapping Promise<T>', async () => {
+    const srcFile = 'async-service.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+class Order {}
+async function fetchOrder(): Promise<Order> { return new Order(); }
+class OrderService {
+  async loadOrder(): Promise<Order> { return new Order(); }
+}
+`,
+    );
+
+    const fileSymbols = makeFileSymbols(srcFile);
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    // Async functions must be unwrapped — Promise itself is in SKIP_TYPE_NAMES
+    expect(symbols.returnTypeMap!.get('fetchOrder')).toEqual({ type: 'Order', confidence: 1.0 });
+    expect(symbols.returnTypeMap!.get('OrderService.loadOrder')).toEqual({
+      type: 'Order',
+      confidence: 1.0,
+    });
+  });
+
+  it('does NOT capture local (method-body-scoped) helper functions in returnTypeMap', async () => {
+    const srcFile = 'nested.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+class InnerResult {}
+class MyService {
+  doWork(): void {
+    // This local helper must NOT appear in returnTypeMap under the bare name 'helper'
+    const helper = (): InnerResult => new InnerResult();
+    helper();
+  }
+}
+`,
+    );
+
+    const fileSymbols = makeFileSymbols(srcFile);
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    // 'helper' is local to MyService.doWork — must not pollute returnTypeMap
+    expect(symbols.returnTypeMap!.has('helper')).toBe(false);
+  });
+
   it('skips non-TS files even when returnTypeMap is undefined', async () => {
     const fileSymbols = new Map<string, ExtractorOutput>();
     fileSymbols.set('index.js', {

--- a/tests/unit/ts-resolver.test.ts
+++ b/tests/unit/ts-resolver.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for ts-resolver Phase 8.2 parity backfill.
+ *
+ * Verifies that enrichTypeMapWithTsc populates returnTypeMap and callAssignments
+ * when they are undefined (simulating the native engine path that doesn't run
+ * the JS extractor). Also verifies that existing returnTypeMap data (WASM path)
+ * is not overwritten.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { enrichTypeMapWithTsc } from '../../src/domain/graph/resolver/ts-resolver.js';
+import type { ExtractorOutput } from '../../src/types.js';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-ts-resolver-test-'));
+}
+
+function makeFileSymbols(
+  relPath: string,
+  returnTypeMap?: ExtractorOutput['returnTypeMap'],
+): Map<string, ExtractorOutput> {
+  const fileSymbols = new Map<string, ExtractorOutput>();
+  fileSymbols.set(relPath, {
+    definitions: [],
+    calls: [],
+    imports: [],
+    classes: [],
+    exports: [],
+    typeMap: new Map(),
+    returnTypeMap,
+    callAssignments: returnTypeMap !== undefined ? [] : undefined,
+  });
+  return fileSymbols;
+}
+
+describe('enrichTypeMapWithTsc Phase 8.2 backfill', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    // Minimal tsconfig that includes all .ts files in the directory
+    fs.writeFileSync(
+      path.join(tmpDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { strict: false }, include: ['./**/*.ts'] }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('backfills returnTypeMap for function declarations when undefined (native engine path)', async () => {
+    const srcFile = 'service.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+class User { name: string = ''; }
+function createUser(): User { return new User(); }
+`,
+    );
+
+    const fileSymbols = makeFileSymbols(srcFile); // returnTypeMap = undefined
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    expect(symbols.returnTypeMap).toBeInstanceOf(Map);
+    expect(symbols.returnTypeMap!.get('createUser')).toEqual({ type: 'User', confidence: 1.0 });
+  });
+
+  it('backfills returnTypeMap for qualified method names', async () => {
+    const srcFile = 'repo.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+class Profile {}
+class UserService {
+  getProfile(): Profile { return new Profile(); }
+}
+`,
+    );
+
+    const fileSymbols = makeFileSymbols(srcFile);
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    expect(symbols.returnTypeMap!.get('UserService.getProfile')).toEqual({
+      type: 'Profile',
+      confidence: 1.0,
+    });
+  });
+
+  it('backfills returnTypeMap for arrow function variable initialisers', async () => {
+    const srcFile = 'factory.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+class Widget {}
+const makeWidget = (): Widget => new Widget();
+`,
+    );
+
+    const fileSymbols = makeFileSymbols(srcFile);
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    expect(symbols.returnTypeMap!.get('makeWidget')).toEqual({ type: 'Widget', confidence: 1.0 });
+  });
+
+  it('backfills callAssignments for call-expression variable assignments', async () => {
+    const srcFile = 'consumer.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+declare function getRepo(): any;
+const repo = getRepo();
+`,
+    );
+
+    const fileSymbols = makeFileSymbols(srcFile);
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    expect(symbols.callAssignments).toBeDefined();
+    const ca = symbols.callAssignments!.find((c) => c.varName === 'repo');
+    expect(ca).toBeDefined();
+    expect(ca!.calleeName).toBe('getRepo');
+  });
+
+  it('does NOT overwrite returnTypeMap when already set (JS/WASM engine path)', async () => {
+    const srcFile = 'existing.ts';
+    fs.writeFileSync(
+      path.join(tmpDir, srcFile),
+      `
+class Foo {}
+function makeFoo(): Foo { return new Foo(); }
+`,
+    );
+
+    const preExisting = new Map([['makeFoo', { type: 'OriginalType', confidence: 0.85 }]]);
+    const fileSymbols = makeFileSymbols(srcFile, preExisting); // returnTypeMap already set
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    const symbols = fileSymbols.get(srcFile)!;
+    // returnTypeMap should be the same object (not replaced)
+    expect(symbols.returnTypeMap).toBe(preExisting);
+    expect(symbols.returnTypeMap!.get('makeFoo')).toEqual({
+      type: 'OriginalType',
+      confidence: 0.85,
+    });
+  });
+
+  it('skips non-TS files even when returnTypeMap is undefined', async () => {
+    const fileSymbols = new Map<string, ExtractorOutput>();
+    fileSymbols.set('index.js', {
+      definitions: [],
+      calls: [],
+      imports: [],
+      classes: [],
+      exports: [],
+      typeMap: new Map(),
+      returnTypeMap: undefined,
+    });
+
+    await enrichTypeMapWithTsc(tmpDir, fileSymbols);
+
+    // JS files are not processed — returnTypeMap stays undefined
+    const symbols = fileSymbols.get('index.js')!;
+    expect(symbols.returnTypeMap).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `enrichTypeMapWithTsc` (Phase 8.1) to also populate `returnTypeMap` and `callAssignments` when they are `undefined` — the state left by the native Rust engine, which never runs `extractReturnTypeMapWalk`
- `propagateReturnTypesAcrossFiles` in `build-edges.ts` can now do cross-file return-type propagation for TS files regardless of which engine ran extraction
- Guard is `symbols.returnTypeMap === undefined`: JS/WASM path sets this field, so it short-circuits and is unaffected
- Two new helpers: `enrichReturnTypeMap` (function/method return types from TSC, confidence 1.0) and `enrichCallAssignments` (call-expression variable assignments not yet resolved by Phase 8.1)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 2795 tests pass, 6 new: returnTypeMap backfill for function decls, qualified methods, arrow fns, callAssignments, WASM no-overwrite guard, JS file skip

Closes #1280