### PR TITLE
test(parity): add native-engine guards for returnTypeMap and callAssignments

### DIFF
--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -740,7 +740,7 @@ end
   // Native assertions are skipped if the installed binary predates #1283
   // (field is absent rather than empty, so a simple existence check suffices).
 
-  it('JS — returnTypeMap is populated by both WASM and native engines', () => {
+  it('JS — returnTypeMap is populated by WASM; native when binary >= #1283', () => {
     // extractReturnTypeMapWalk / match_js_return_type_map infer the return type
     // when a class method body contains `return new Constructor()` (confidence 0.85).
     const code = `
@@ -751,11 +751,15 @@ class UserService {
 `;
     const wasm = wasmExtract(code, 'service.js');
     expect(wasm?.returnTypeMap).toBeInstanceOf(Map);
-    expect(wasm?.returnTypeMap?.get('UserService.getUser')).toMatchObject({
+    const getUserEntry = wasm?.returnTypeMap?.get('UserService.getUser');
+    expect(getUserEntry, 'WASM returnTypeMap missing UserService.getUser').toBeDefined();
+    expect(getUserEntry).toMatchObject({
       type: 'User',
       confidence: 0.85,
     });
-    expect(wasm?.returnTypeMap?.get('UserService.buildQuery')).toMatchObject({
+    const buildQueryEntry = wasm?.returnTypeMap?.get('UserService.buildQuery');
+    expect(buildQueryEntry, 'WASM returnTypeMap missing UserService.buildQuery').toBeDefined();
+    expect(buildQueryEntry).toMatchObject({
       type: 'QueryBuilder',
       confidence: 0.85,
     });
@@ -772,19 +776,23 @@ class UserService {
       confidence: number;
     }>;
     expect(entries).toBeInstanceOf(Array);
-    expect(entries.find((e) => e.name === 'UserService.getUser')).toMatchObject({
+    const nativeGetUser = entries.find((e) => e.name === 'UserService.getUser');
+    expect(nativeGetUser, 'native returnTypeMap missing UserService.getUser').toBeDefined();
+    expect(nativeGetUser).toMatchObject({
       name: 'UserService.getUser',
       typeName: 'User',
       confidence: 0.85,
     });
-    expect(entries.find((e) => e.name === 'UserService.buildQuery')).toMatchObject({
+    const nativeBuildQuery = entries.find((e) => e.name === 'UserService.buildQuery');
+    expect(nativeBuildQuery, 'native returnTypeMap missing UserService.buildQuery').toBeDefined();
+    expect(nativeBuildQuery).toMatchObject({
       name: 'UserService.buildQuery',
       typeName: 'QueryBuilder',
       confidence: 0.85,
     });
   });
 
-  it('JS — callAssignments is populated by both WASM and native engines', () => {
+  it('JS — callAssignments is populated by WASM; native when binary >= #1283', () => {
     // recordCallAssignment / match_js_call_assignments fire when a variable is
     // assigned from a call expression whose return type is NOT resolvable within
     // the current file. Here, UserRepository.findById is not defined in the
@@ -796,7 +804,9 @@ const user = repo.findById('alice');
 `;
     const wasm = wasmExtract(code, 'service.js');
     expect(wasm?.callAssignments).toBeInstanceOf(Array);
-    expect(wasm?.callAssignments?.find((ca) => ca.varName === 'user')).toMatchObject({
+    const wasmUserAssignment = wasm?.callAssignments?.find((ca) => ca.varName === 'user');
+    expect(wasmUserAssignment, "WASM callAssignments missing entry for 'user'").toBeDefined();
+    expect(wasmUserAssignment).toMatchObject({
       varName: 'user',
       calleeName: 'findById',
       receiverTypeName: 'UserRepository',
@@ -808,15 +818,15 @@ const user = repo.findById('alice');
     if (raw?.callAssignments === undefined) return;
     // Native returns Vec<NativeCallAssignment> with the same shape as CallAssignment.
     expect(raw.callAssignments).toBeInstanceOf(Array);
-    expect(
-      (
-        raw.callAssignments as Array<{
-          varName: string;
-          calleeName: string;
-          receiverTypeName?: string;
-        }>
-      ).find((ca) => ca.varName === 'user'),
-    ).toMatchObject({
+    const nativeUserAssignment = (
+      raw.callAssignments as Array<{
+        varName: string;
+        calleeName: string;
+        receiverTypeName?: string;
+      }>
+    ).find((ca) => ca.varName === 'user');
+    expect(nativeUserAssignment, "native callAssignments missing entry for 'user'").toBeDefined();
+    expect(nativeUserAssignment).toMatchObject({
       varName: 'user',
       calleeName: 'findById',
       receiverTypeName: 'UserRepository',

--- a/tests/engines/parity.test.ts
+++ b/tests/engines/parity.test.ts
@@ -726,6 +726,103 @@ end
     }
   });
 
+  // Explicit guards for #1286: normalize() above strips returnTypeMap and
+  // callAssignments from the structural comparison loop, so a regression where
+  // either field is missing or wrong on native would slip through undetected.
+  // These two tests lock in native-engine parity for those fields, preventing
+  // a recurrence of the bug introduced in #1279 and fixed in #1283.
+  //
+  // Note on native format: the native engine returns returnTypeMap as a raw
+  // array of { name, typeName, confidence } objects. patchReturnTypeMap()
+  // (called by parseFileAuto/parseFilesAuto in production) converts that array
+  // to a Map<string, TypeMapEntry>. These tests check the extraction layer
+  // directly — WASM asserts on the Map, native asserts on the raw array.
+  // Native assertions are skipped if the installed binary predates #1283
+  // (field is absent rather than empty, so a simple existence check suffices).
+
+  it('JS — returnTypeMap is populated by both WASM and native engines', () => {
+    // extractReturnTypeMapWalk / match_js_return_type_map infer the return type
+    // when a class method body contains `return new Constructor()` (confidence 0.85).
+    const code = `
+class UserService {
+  getUser() { return new User(); }
+  buildQuery() { return new QueryBuilder(); }
+}
+`;
+    const wasm = wasmExtract(code, 'service.js');
+    expect(wasm?.returnTypeMap).toBeInstanceOf(Map);
+    expect(wasm?.returnTypeMap?.get('UserService.getUser')).toMatchObject({
+      type: 'User',
+      confidence: 0.85,
+    });
+    expect(wasm?.returnTypeMap?.get('UserService.buildQuery')).toMatchObject({
+      type: 'QueryBuilder',
+      confidence: 0.85,
+    });
+
+    if (!hasNative) return;
+    const raw = nativeExtract(code, 'service.js');
+    // Binaries older than #1283 don't emit returnTypeMap — skip those.
+    if (raw?.returnTypeMap === undefined) return;
+    // Native returns Vec<TypeMapEntry> as an array; patchReturnTypeMap converts
+    // it to a Map in production. Assert the raw extraction is correct here.
+    const entries = raw.returnTypeMap as Array<{
+      name: string;
+      typeName: string;
+      confidence: number;
+    }>;
+    expect(entries).toBeInstanceOf(Array);
+    expect(entries.find((e) => e.name === 'UserService.getUser')).toMatchObject({
+      name: 'UserService.getUser',
+      typeName: 'User',
+      confidence: 0.85,
+    });
+    expect(entries.find((e) => e.name === 'UserService.buildQuery')).toMatchObject({
+      name: 'UserService.buildQuery',
+      typeName: 'QueryBuilder',
+      confidence: 0.85,
+    });
+  });
+
+  it('JS — callAssignments is populated by both WASM and native engines', () => {
+    // recordCallAssignment / match_js_call_assignments fire when a variable is
+    // assigned from a call expression whose return type is NOT resolvable within
+    // the current file. Here, UserRepository.findById is not defined in the
+    // snippet, so resolveCallExprReturnType returns null and the assignment falls
+    // through to callAssignments with the receiver type from typeMap.
+    const code = `
+const repo = new UserRepository();
+const user = repo.findById('alice');
+`;
+    const wasm = wasmExtract(code, 'service.js');
+    expect(wasm?.callAssignments).toBeInstanceOf(Array);
+    expect(wasm?.callAssignments?.find((ca) => ca.varName === 'user')).toMatchObject({
+      varName: 'user',
+      calleeName: 'findById',
+      receiverTypeName: 'UserRepository',
+    });
+
+    if (!hasNative) return;
+    const raw = nativeExtract(code, 'service.js');
+    // Binaries older than #1283 don't emit callAssignments — skip those.
+    if (raw?.callAssignments === undefined) return;
+    // Native returns Vec<NativeCallAssignment> with the same shape as CallAssignment.
+    expect(raw.callAssignments).toBeInstanceOf(Array);
+    expect(
+      (
+        raw.callAssignments as Array<{
+          varName: string;
+          calleeName: string;
+          receiverTypeName?: string;
+        }>
+      ).find((ca) => ca.varName === 'user'),
+    ).toMatchObject({
+      varName: 'user',
+      calleeName: 'findById',
+      receiverTypeName: 'UserRepository',
+    });
+  });
+
   // Explicit guard for the WASM Python fix in #1189. The structural parity
   // loop above strips `self` from both sides via normalize(), so a regression
   // where WASM re-emits self/cls would slip through. Assert it directly.


### PR DESCRIPTION
## Summary

- Adds two explicit parity tests in `tests/engines/parity.test.ts` for `returnTypeMap` and `callAssignments`, the fields introduced by #1283
- `normalize()` in the structural loop strips these fields, so any future divergence between engines would go undetected — these tests close that gap

**`returnTypeMap` test** — verifies WASM produces a `Map` with `return new Constructor()` inference (confidence 0.85); verifies native produces an equivalent raw array (the form before `patchReturnTypeMap` converts it to a Map in production)

**`callAssignments` test** — verifies WASM records method calls in `callAssignments` when the callee's return type is not locally resolvable (cross-file propagation case); verifies native produces the same

Both native assertion blocks soft-skip on binaries older than #1283 (field absent = `undefined`).

## Test plan

- [x] `npx vitest run tests/engines/parity.test.ts -t "returnTypeMap|callAssignments"` — 2 passed
- [x] `npx vitest run tests/parsers/javascript.test.ts` — 63 passed
- [x] Biome lint clean on modified file

Closes #1286