### PR TITLE
feat(resolver): parameter-flow tracking in points-to analysis (Phase 8.3c)

### DIFF
--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -36,8 +36,9 @@ export function findCaller(
   }>,
   relPath: string,
   fileNodeRow: { id: number },
-): { id: number } {
+): { id: number; callerName: string | null } {
   let caller: { id: number } | null = null;
+  let callerName: string | null = null;
   let callerSpan = Infinity;
   for (const def of definitions) {
     if (def.line <= call.line) {
@@ -48,13 +49,14 @@ export function findCaller(
           const row = lookup.nodeId(def.name, def.kind, relPath, def.line);
           if (row) {
             caller = row;
+            callerName = def.name;
             callerSpan = span;
           }
         }
       }
     }
   }
-  return caller ?? fileNodeRow;
+  return { ...(caller ?? fileNodeRow), callerName };
 }
 
 export function resolveByMethodOrGlobal(

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -15,6 +15,7 @@ import type {
   BetterSqlite3Database,
   Call,
   ClassRelation,
+  Definition,
   ExtractorOutput,
   Import,
   NativeAddon,
@@ -634,13 +635,33 @@ function buildPointsToMapForFile(
   symbols: ExtractorOutput,
   importedNames: Map<string, string>,
 ): PointsToMap | null {
-  if (!symbols.fnRefBindings?.length) return null;
+  if (!symbols.fnRefBindings?.length && !symbols.paramBindings?.length) return null;
   const defNames = new Set(
     symbols.definitions
       .filter((d) => d.kind === 'function' || d.kind === 'method')
       .map((d) => d.name),
   );
-  return buildPointsToMap(symbols.fnRefBindings, defNames, importedNames);
+  const definitionParams = buildDefinitionParamsMap(symbols.definitions);
+  return buildPointsToMap(
+    symbols.fnRefBindings ?? [],
+    defNames,
+    importedNames,
+    symbols.paramBindings,
+    definitionParams,
+  );
+}
+
+function buildDefinitionParamsMap(
+  definitions: readonly Definition[],
+): Map<string, readonly string[]> {
+  const map = new Map<string, readonly string[]>();
+  for (const def of definitions) {
+    if ((def.kind === 'function' || def.kind === 'method') && def.children) {
+      const params = def.children.filter((c) => c.kind === 'parameter').map((c) => c.name);
+      if (params.length > 0) map.set(def.name, params);
+    }
+  }
+  return map;
 }
 
 function buildFileCallEdges(
@@ -698,17 +719,22 @@ function buildFileCallEdges(
       }
     }
 
-    // Phase 8.3: points-to fallback for unresolved dynamic identifier calls.
-    // When primary resolution finds nothing and the call is flagged dynamic (i.e.
-    // it was emitted by extractCallbackReferenceCalls as a named function reference),
-    // check whether the call name is an alias in the pts map and retry resolution
-    // with each concrete target. Confidence is penalised by one hop to reflect the
-    // extra indirection.
+    // Phase 8.3 / 8.3c: points-to fallback for unresolved calls.
+    // Fires for two cases:
+    //   (a) dynamic=true: alias calls emitted by extractCallbackReferenceCalls
+    //   (b) non-dynamic: parameter variable calls (fn() where fn is a param)
+    //       — only when the name has a pts entry to avoid spurious lookups.
+    // Confidence is penalised by one hop to reflect the extra indirection.
     //
     // Note: pts edges are added to ptsEdgeRows (not seenCallEdges) so that a later
     // direct call to the same target in the same function body can upgrade confidence
     // rather than being silently dropped by the dedup guard.
-    if (targets.length === 0 && call.dynamic && !call.receiver && ptsMap) {
+    if (
+      targets.length === 0 &&
+      !call.receiver &&
+      ptsMap &&
+      (call.dynamic || ptsMap.has(call.name))
+    ) {
       for (const alias of resolveViaPointsTo(call.name, ptsMap)) {
         // Resolve the concrete alias target. Only `name` is needed here — receiver
         // and line are not relevant for alias resolution (we are looking up the

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -516,6 +516,91 @@ function buildCallEdgesNative(
   }
 }
 
+/**
+ * Phase 8.3c pts post-pass for the native call-edge path.
+ *
+ * The native Rust engine builds call edges without knowledge of paramBindings,
+ * so `fn()` calls inside higher-order functions are not resolved to their
+ * concrete targets. This JS post-pass runs after the native edge pass and adds
+ * only the parameter-flow pts edges that the native engine missed.
+ *
+ * To avoid duplicating edges already emitted by the native engine, the current
+ * allEdgeRows snapshot is used to seed a seenByPair set before processing each
+ * file.
+ */
+function buildParamFlowPtsPostPass(
+  ctx: PipelineContext,
+  getNodeIdStmt: NodeIdStmt,
+  allEdgeRows: EdgeRowTuple[],
+): void {
+  // Only process files that actually have paramBindings (avoid useless work).
+  const filesWithParams = [...ctx.fileSymbols].filter(
+    ([, symbols]) => symbols.paramBindings && symbols.paramBindings.length > 0,
+  );
+  if (filesWithParams.length === 0) return;
+
+  // Seed seenByPair from the existing rows so we don't duplicate native edges.
+  // This is O(|allEdgeRows|) once per post-pass, which is acceptable.
+  const seenByPair = new Set<string>();
+  for (const [srcId, tgtId] of allEdgeRows) {
+    seenByPair.add(`${srcId}|${tgtId}`);
+  }
+
+  const { barrelOnlyFiles, rootDir } = ctx;
+  const lookup = makeContextLookup(ctx, getNodeIdStmt);
+
+  for (const [relPath, symbols] of filesWithParams) {
+    if (barrelOnlyFiles.has(relPath)) continue;
+    const fileNodeRow = getNodeIdStmt.get(relPath, 'file', relPath, 0);
+    if (!fileNodeRow) continue;
+
+    const importedNames = buildImportedNamesMap(ctx, relPath, symbols, rootDir);
+    const typeMap: Map<string, TypeMapEntry | string> = symbols.typeMap || new Map();
+    const ptsMap = buildPointsToMapForFile(symbols, importedNames);
+    if (!ptsMap) continue;
+
+    for (const call of symbols.calls) {
+      if (call.receiver || call.dynamic) continue; // pts post-pass handles only param-flow (non-dynamic)
+      if (BUILTIN_RECEIVERS.has(call.receiver ?? '')) continue;
+
+      const caller = findCaller(lookup, call, symbols.definitions, relPath, fileNodeRow);
+      const scopedKey = caller.callerName != null ? `${caller.callerName}::${call.name}` : null;
+      if (!scopedKey || !ptsMap.has(scopedKey)) continue;
+
+      // Only resolve calls that had no direct targets (same guard as buildFileCallEdges).
+      const { targets } = resolveCallTargets(
+        lookup,
+        call,
+        relPath,
+        importedNames,
+        typeMap as Map<string, unknown>,
+      );
+      if (targets.length > 0) continue;
+
+      for (const alias of resolveViaPointsTo(scopedKey, ptsMap)) {
+        const { targets: aliasTargets, importedFrom: aliasFrom } = resolveCallTargets(
+          lookup,
+          { name: alias },
+          relPath,
+          importedNames,
+          typeMap as Map<string, unknown>,
+        );
+        for (const t of aliasTargets) {
+          const edgeKey = `${caller.id}|${t.id}`;
+          if (t.id !== caller.id && !seenByPair.has(edgeKey)) {
+            const conf =
+              computeConfidence(relPath, t.file, aliasFrom ?? null) - PROPAGATION_HOP_PENALTY;
+            if (conf > 0) {
+              seenByPair.add(edgeKey);
+              allEdgeRows.push([caller.id, t.id, 'calls', conf, 0]);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 function buildImportedNamesForNative(
   ctx: PipelineContext,
   relPath: string,
@@ -658,7 +743,18 @@ function buildDefinitionParamsMap(
   for (const def of definitions) {
     if ((def.kind === 'function' || def.kind === 'method') && def.children) {
       const params = def.children.filter((c) => c.kind === 'parameter').map((c) => c.name);
-      if (params.length > 0) map.set(def.name, params);
+      if (params.length > 0) {
+        if (map.has(def.name)) {
+          // Two definitions share the same name (e.g. overloads, same-named method and
+          // function, or conditional redeclaration). Keep the first entry — using the
+          // wrong parameter list would map argIndex to the wrong parameter name.
+          debug(
+            `buildDefinitionParamsMap: duplicate def name "${def.name}" (kind=${def.kind}, line=${def.line}) — skipping; first entry kept`,
+          );
+        } else {
+          map.set(def.name, params);
+        }
+      }
     }
   }
   return map;
@@ -721,21 +817,25 @@ function buildFileCallEdges(
 
     // Phase 8.3 / 8.3c: points-to fallback for unresolved calls.
     // Fires for two cases:
-    //   (a) dynamic=true: alias calls emitted by extractCallbackReferenceCalls
-    //   (b) non-dynamic: parameter variable calls (fn() where fn is a param)
-    //       — only when the name has a pts entry to avoid spurious lookups.
+    //   (a) dynamic=true: alias calls emitted by extractCallbackReferenceCalls.
+    //       Looks up `call.name` directly (alias entries are flat-keyed).
+    //   (b) non-dynamic: parameter variable calls (fn() where fn is a param).
+    //       Looks up the scoped key `callerName::call.name` to avoid spurious
+    //       edges from same-named parameters across different functions.
     // Confidence is penalised by one hop to reflect the extra indirection.
     //
     // Note: pts edges are added to ptsEdgeRows (not seenCallEdges) so that a later
     // direct call to the same target in the same function body can upgrade confidence
     // rather than being silently dropped by the dedup guard.
+    const scopedPtsKey = caller.callerName != null ? `${caller.callerName}::${call.name}` : null;
     if (
       targets.length === 0 &&
       !call.receiver &&
       ptsMap &&
-      (call.dynamic || ptsMap.has(call.name))
+      (call.dynamic || (scopedPtsKey != null && ptsMap.has(scopedPtsKey)))
     ) {
-      for (const alias of resolveViaPointsTo(call.name, ptsMap)) {
+      const ptsLookupName = call.dynamic ? call.name : (scopedPtsKey ?? call.name);
+      for (const alias of resolveViaPointsTo(ptsLookupName, ptsMap)) {
         // Resolve the concrete alias target. Only `name` is needed here — receiver
         // and line are not relevant for alias resolution (we are looking up the
         // aliased function by name, not dispatching a method call).
@@ -1033,6 +1133,12 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
       (ctx.isFullBuild || ctx.fileSymbols.size > ctx.config.build.smallFilesThreshold);
     if (useNativeCallEdges) {
       buildCallEdgesNative(ctx, getNodeIdStmt, allEdgeRows, allNodesBefore, native!);
+      // Phase 8.3c post-pass: augment native call edges with parameter-flow pts
+      // edges. The native Rust engine has no knowledge of paramBindings, so any
+      // `fn()` call inside a higher-order function would be missed. This JS pass
+      // runs on top of the native edges and adds only the pts-resolved edges that
+      // the native engine could not produce.
+      buildParamFlowPtsPostPass(ctx, getNodeIdStmt, allEdgeRows);
     } else {
       buildCallEdgesJS(ctx, getNodeIdStmt, allEdgeRows);
     }

--- a/src/domain/graph/resolver/points-to.ts
+++ b/src/domain/graph/resolver/points-to.ts
@@ -79,16 +79,24 @@ export function buildPointsToMap(
 
   // Phase 8.3c: parameter-flow constraints.
   // For each call f(x) at argIndex i where f is locally defined, add
-  // constraint: pts(paramName_i) ⊇ pts(x). This makes the pts solver
+  // constraint: pts(f::paramName_i) ⊇ pts(x). This makes the pts solver
   // inter-procedural within the module so that `fn()` inside `f` resolves
   // to the concrete function passed at each call site.
+  //
+  // Keys are scoped as "callee::paramName" to prevent name collisions: bare
+  // parameter names like `fn`, `cb`, and `callback` appear in many functions
+  // within the same file. Without scoping, pts(fn) from runA and runB would
+  // merge into a single set, producing spurious call edges. The scoped key is
+  // resolved in buildFileCallEdges by combining the enclosing caller's name
+  // with the call's name (see callerName::call.name lookup there).
+  //
   // Scope: intra-module only (definitionParams contains local defs only).
   if (paramBindings && definitionParams) {
     for (const { callee, argIndex, argName } of paramBindings) {
       const params = definitionParams.get(callee);
       if (!params || argIndex >= params.length) continue;
       const paramName = params[argIndex];
-      if (paramName) constraints.push({ lhs: paramName, rhsKey: argName });
+      if (paramName) constraints.push({ lhs: `${callee}::${paramName}`, rhsKey: argName });
     }
   }
 

--- a/src/domain/graph/resolver/points-to.ts
+++ b/src/domain/graph/resolver/points-to.ts
@@ -19,7 +19,7 @@
  * that build-edges.ts already builds per file is the cross-module link — if
  * a variable aliases an imported name, resolveCallTargets follows it).
  */
-import type { FnRefBinding } from '../../../types.js';
+import type { FnRefBinding, ParamBinding } from '../../../types.js';
 
 export type PointsToMap = Map<string, Set<string>>;
 
@@ -41,14 +41,18 @@ const MAX_SOLVER_ITERATIONS = 50;
  * look up — either a locally-defined function name (found via byNameAndFile) or
  * an imported name (found via importedNames → byNameAndFile in the source file).
  *
- * @param fnRefBindings  - identifier/member-expr bindings from the extractor
- * @param definitionNames - locally-defined callable names in this file
- * @param importedNames   - names imported into this file (name → resolved file)
+ * @param fnRefBindings    - identifier/member-expr bindings from the extractor
+ * @param definitionNames  - locally-defined callable names in this file
+ * @param importedNames    - names imported into this file (name → resolved file)
+ * @param paramBindings    - call-site arg→param bindings (Phase 8.3c)
+ * @param definitionParams - per-function ordered parameter names (Phase 8.3c)
  */
 export function buildPointsToMap(
   fnRefBindings: readonly FnRefBinding[],
   definitionNames: ReadonlySet<string>,
   importedNames: ReadonlyMap<string, string>,
+  paramBindings?: readonly ParamBinding[],
+  definitionParams?: ReadonlyMap<string, readonly string[]>,
 ): PointsToMap {
   const pts: PointsToMap = new Map();
 
@@ -63,8 +67,6 @@ export function buildPointsToMap(
     if (!pts.has(name)) pts.set(name, new Set([name]));
   }
 
-  if (fnRefBindings.length === 0) return pts;
-
   // Build constraint list: pts(lhs) ⊇ pts(rhsKey).
   // For member expressions (const fn = obj.method), key is "obj.method".
   // These composite keys won't be in pts unless a prior statement seeded them
@@ -74,6 +76,23 @@ export function buildPointsToMap(
     lhs: b.lhs,
     rhsKey: b.rhsReceiver ? `${b.rhsReceiver}.${b.rhs}` : b.rhs,
   }));
+
+  // Phase 8.3c: parameter-flow constraints.
+  // For each call f(x) at argIndex i where f is locally defined, add
+  // constraint: pts(paramName_i) ⊇ pts(x). This makes the pts solver
+  // inter-procedural within the module so that `fn()` inside `f` resolves
+  // to the concrete function passed at each call site.
+  // Scope: intra-module only (definitionParams contains local defs only).
+  if (paramBindings && definitionParams) {
+    for (const { callee, argIndex, argName } of paramBindings) {
+      const params = definitionParams.get(callee);
+      if (!params || argIndex >= params.length) continue;
+      const paramName = params[argIndex];
+      if (paramName) constraints.push({ lhs: paramName, rhsKey: argName });
+    }
+  }
+
+  if (constraints.length === 0) return pts;
 
   // Fixed-point iteration: propagate pts sets until no new information flows.
   for (let iter = 0; iter < MAX_SOLVER_ITERATIONS; iter++) {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -8,6 +8,7 @@ import type {
   ExtractorOutput,
   FnRefBinding,
   Import,
+  ParamBinding,
   SubDeclaration,
   TreeSitterNode,
   TreeSitterQuery,
@@ -316,6 +317,7 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
   const returnTypeMap: Map<string, TypeMapEntry> = new Map();
   const callAssignments: CallAssignment[] = [];
   const fnRefBindings: FnRefBinding[] = [];
+  const paramBindings: ParamBinding[] = [];
 
   const matches = query.matches(tree.rootNode);
 
@@ -338,6 +340,9 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
   // Extract typeMap with intra-file return-type propagation
   extractTypeMapWalk(tree.rootNode, typeMap, returnTypeMap, callAssignments, fnRefBindings);
 
+  // Phase 8.3c: Extract call-site argument bindings for parameter-flow pts analysis
+  extractParamBindingsWalk(tree.rootNode, paramBindings);
+
   // Extract definitions from destructured bindings (query patterns don't match object_pattern)
   extractDestructuredBindingsWalk(tree.rootNode, definitions);
 
@@ -351,6 +356,7 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
     returnTypeMap,
     callAssignments,
     fnRefBindings,
+    paramBindings,
   };
 }
 
@@ -582,6 +588,7 @@ function extractSymbolsWalk(tree: TreeSitterTree): ExtractorOutput {
     returnTypeMap: new Map(),
     callAssignments: [],
     fnRefBindings: [],
+    paramBindings: [],
   };
 
   walkJavaScriptNode(tree.rootNode, ctx);
@@ -595,6 +602,8 @@ function extractSymbolsWalk(tree: TreeSitterTree): ExtractorOutput {
     ctx.callAssignments,
     ctx.fnRefBindings,
   );
+  // Phase 8.3c: Extract call-site argument bindings for parameter-flow pts analysis
+  extractParamBindingsWalk(tree.rootNode, ctx.paramBindings!);
   return ctx;
 }
 
@@ -1490,6 +1499,44 @@ function handleParamTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEn
     const typeName = extractSimpleTypeName(typeAnno);
     if (typeName) setTypeMapEntry(typeMap, nameNode.text, typeName, 0.9);
   }
+}
+
+/**
+ * Phase 8.3c: record argument-to-parameter bindings at call sites.
+ *
+ * For each `f(x, y)` where the callee is a simple identifier and an argument
+ * is a simple identifier, emits a ParamBinding so the pts solver can add
+ * constraint: pts(param_i_of_f) ⊇ pts(arg_i). The solver uses the
+ * definitionParams map to resolve the actual parameter names.
+ *
+ * Scope: intra-module only (the solver only materialises constraints for
+ * locally-defined callees, so cross-module calls produce no spurious flow).
+ */
+function extractParamBindingsWalk(rootNode: TreeSitterNode, paramBindings: ParamBinding[]): void {
+  function walk(node: TreeSitterNode, depth: number): void {
+    if (depth >= MAX_WALK_DEPTH) return;
+    if (node.type === 'call_expression') {
+      const fn = node.childForFieldName('function');
+      const args = node.childForFieldName('arguments') ?? findChild(node, 'arguments');
+      if (fn?.type === 'identifier' && !BUILTIN_GLOBALS.has(fn.text) && args) {
+        let argIdx = 0;
+        for (let i = 0; i < args.childCount; i++) {
+          const child = args.child(i);
+          if (!child) continue;
+          const ct = child.type;
+          if (ct === ',' || ct === '(' || ct === ')') continue;
+          if (ct === 'identifier' && !BUILTIN_GLOBALS.has(child.text)) {
+            paramBindings.push({ callee: fn.text, argIndex: argIdx, argName: child.text });
+          }
+          argIdx++;
+        }
+      }
+    }
+    for (let i = 0; i < node.childCount; i++) {
+      walk(node.child(i)!, depth + 1);
+    }
+  }
+  walk(rootNode, 0);
 }
 
 function extractReceiverName(objNode: TreeSitterNode | null): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -550,6 +550,20 @@ export interface FnRefBinding {
   rhsReceiver?: string;
 }
 
+/**
+ * An argument-to-parameter binding at a call site, recorded for parameter-flow
+ * points-to analysis (Phase 8.3c). Captures `f(x)` where `x` is an identifier
+ * that may carry a function reference into `f`'s parameter.
+ */
+export interface ParamBinding {
+  /** The function being called at the call site. */
+  callee: string;
+  /** Zero-based index of the argument. */
+  argIndex: number;
+  /** Identifier name of the argument being passed. */
+  argName: string;
+}
+
 /** The normalized output shape returned by every language extractor. */
 export interface ExtractorOutput {
   definitions: Definition[];
@@ -575,6 +589,12 @@ export interface ExtractorOutput {
    * edge builder can follow aliases when a call target has no direct definition.
    */
   fnRefBindings?: FnRefBinding[];
+  /**
+   * Argument-to-parameter bindings for parameter-flow points-to analysis (Phase 8.3c).
+   * Records `f(x)` call sites where `x` is an identifier, enabling the pts solver
+   * to propagate function references through function parameters.
+   */
+  paramBindings?: ParamBinding[];
   /** WASM tree retained for downstream analysis (complexity, CFG, dataflow). */
   _tree?: TreeSitterTree;
   /** Language identifier. */

--- a/tests/unit/points-to.test.ts
+++ b/tests/unit/points-to.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the points-to solver — Phase 8.3 alias constraints and
+ * Phase 8.3c parameter-flow constraints.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildPointsToMap, resolveViaPointsTo } from '../../src/domain/graph/resolver/points-to.js';
+
+const NO_IMPORTS: ReadonlyMap<string, string> = new Map();
+const NO_DEF_PARAMS: ReadonlyMap<string, readonly string[]> = new Map();
+
+describe('buildPointsToMap — alias constraints (Phase 8.3)', () => {
+  it('seeds locally-defined functions to themselves', () => {
+    const pts = buildPointsToMap([], new Set(['foo', 'bar']), NO_IMPORTS);
+    expect(resolveViaPointsTo('foo', pts)).toEqual([]);
+    expect(resolveViaPointsTo('bar', pts)).toEqual([]);
+  });
+
+  it('propagates simple alias: const fn = handler', () => {
+    const pts = buildPointsToMap([{ lhs: 'fn', rhs: 'handler' }], new Set(['handler']), NO_IMPORTS);
+    expect(resolveViaPointsTo('fn', pts)).toEqual(['handler']);
+  });
+
+  it('propagates member-expression alias: const fn = obj.method', () => {
+    const pts = buildPointsToMap(
+      [
+        { lhs: 'h', rhs: 'method', rhsReceiver: 'obj' },
+        { lhs: 'obj.method', rhs: 'realMethod' },
+      ],
+      new Set(['realMethod']),
+      NO_IMPORTS,
+    );
+    // h → obj.method → realMethod (two hops, should converge)
+    const targets = resolveViaPointsTo('h', pts);
+    expect(targets).toContain('realMethod');
+  });
+});
+
+describe('buildPointsToMap — parameter-flow constraints (Phase 8.3c)', () => {
+  it('adds pts constraint for parameter when callee is locally defined', () => {
+    // function runWith(fn) { fn(); }
+    // function myHandler() {}
+    // runWith(myHandler);
+    const defNames = new Set(['runWith', 'myHandler']);
+    const defParams = new Map([['runWith', ['fn']]]);
+    const paramBindings = [{ callee: 'runWith', argIndex: 0, argName: 'myHandler' }];
+    const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
+    expect(resolveViaPointsTo('fn', pts)).toEqual(['myHandler']);
+  });
+
+  it('does not add constraint for out-of-range argIndex', () => {
+    const defNames = new Set(['f', 'handler']);
+    const defParams = new Map([['f', ['a']]]); // only 1 param
+    const paramBindings = [{ callee: 'f', argIndex: 1, argName: 'handler' }]; // index 1 out of range
+    const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
+    expect(resolveViaPointsTo('a', pts)).toEqual([]);
+  });
+
+  it('ignores call when callee is not in definitionParams (cross-module or untracked)', () => {
+    const defNames = new Set(['handler']);
+    const defParams = NO_DEF_PARAMS; // empty — callee 'externalFn' not local
+    const paramBindings = [{ callee: 'externalFn', argIndex: 0, argName: 'handler' }];
+    const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
+    // No 'p0' or any new pts entry from the constraint
+    expect([...pts.keys()]).toEqual(['handler']);
+  });
+
+  it('handles multiple parameters — routes to correct parameter name', () => {
+    // function withBoth(errFn, successFn) { ... }
+    // withBoth(onError, onSuccess);
+    const defNames = new Set(['withBoth', 'onError', 'onSuccess']);
+    const defParams = new Map([['withBoth', ['errFn', 'successFn']]]);
+    const paramBindings = [
+      { callee: 'withBoth', argIndex: 0, argName: 'onError' },
+      { callee: 'withBoth', argIndex: 1, argName: 'onSuccess' },
+    ];
+    const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
+    expect(resolveViaPointsTo('errFn', pts)).toEqual(['onError']);
+    expect(resolveViaPointsTo('successFn', pts)).toEqual(['onSuccess']);
+  });
+
+  it('propagates through alias + parameter chain (two-hop)', () => {
+    // const h = realHandler;       → fn alias binding
+    // function run(fn) { fn(); }   → paramBinding
+    // run(h);                       → paramBinding
+    const defNames = new Set(['run', 'realHandler']);
+    const fnRefs = [{ lhs: 'h', rhs: 'realHandler' }];
+    const defParams = new Map([['run', ['fn']]]);
+    const paramBindings = [{ callee: 'run', argIndex: 0, argName: 'h' }];
+    const pts = buildPointsToMap(fnRefs, defNames, NO_IMPORTS, paramBindings, defParams);
+    // fn → h → realHandler
+    expect(resolveViaPointsTo('fn', pts)).toContain('realHandler');
+  });
+
+  it('produces no constraint when paramBindings is absent', () => {
+    const defNames = new Set(['f', 'g']);
+    const pts = buildPointsToMap([], defNames, NO_IMPORTS);
+    expect(resolveViaPointsTo('f', pts)).toEqual([]);
+    expect(resolveViaPointsTo('g', pts)).toEqual([]);
+  });
+
+  it('does not introduce self-referential pts entries for parameter names', () => {
+    // Ensures that a parameter name that also matches a local function is not confused
+    const defNames = new Set(['fn', 'run']); // 'fn' is both a local def AND a param name of 'run'
+    const defParams = new Map([['run', ['fn']]]);
+    const paramBindings = [{ callee: 'run', argIndex: 0, argName: 'fn' }];
+    const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
+    // pts('fn') seeds to {'fn'} from definitionNames; param constraint adds pts('fn') ⊇ pts('fn')
+    // which is a no-op. resolveViaPointsTo filters self-reference, so returns [].
+    expect(resolveViaPointsTo('fn', pts)).toEqual([]);
+  });
+});

--- a/tests/unit/points-to.test.ts
+++ b/tests/unit/points-to.test.ts
@@ -40,11 +40,14 @@ describe('buildPointsToMap — parameter-flow constraints (Phase 8.3c)', () => {
     // function runWith(fn) { fn(); }
     // function myHandler() {}
     // runWith(myHandler);
+    // pts key is scoped: "runWith::fn" → {myHandler}
     const defNames = new Set(['runWith', 'myHandler']);
     const defParams = new Map([['runWith', ['fn']]]);
     const paramBindings = [{ callee: 'runWith', argIndex: 0, argName: 'myHandler' }];
     const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
-    expect(resolveViaPointsTo('fn', pts)).toEqual(['myHandler']);
+    expect(resolveViaPointsTo('runWith::fn', pts)).toEqual(['myHandler']);
+    // bare name has no entry (scoping prevents cross-function collision)
+    expect(resolveViaPointsTo('fn', pts)).toEqual([]);
   });
 
   it('does not add constraint for out-of-range argIndex', () => {
@@ -52,7 +55,7 @@ describe('buildPointsToMap — parameter-flow constraints (Phase 8.3c)', () => {
     const defParams = new Map([['f', ['a']]]); // only 1 param
     const paramBindings = [{ callee: 'f', argIndex: 1, argName: 'handler' }]; // index 1 out of range
     const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
-    expect(resolveViaPointsTo('a', pts)).toEqual([]);
+    expect(resolveViaPointsTo('f::a', pts)).toEqual([]);
   });
 
   it('ignores call when callee is not in definitionParams (cross-module or untracked)', () => {
@@ -60,7 +63,7 @@ describe('buildPointsToMap — parameter-flow constraints (Phase 8.3c)', () => {
     const defParams = NO_DEF_PARAMS; // empty — callee 'externalFn' not local
     const paramBindings = [{ callee: 'externalFn', argIndex: 0, argName: 'handler' }];
     const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
-    // No 'p0' or any new pts entry from the constraint
+    // No scoped entry is added for externalFn::p0 or similar
     expect([...pts.keys()]).toEqual(['handler']);
   });
 
@@ -74,8 +77,8 @@ describe('buildPointsToMap — parameter-flow constraints (Phase 8.3c)', () => {
       { callee: 'withBoth', argIndex: 1, argName: 'onSuccess' },
     ];
     const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
-    expect(resolveViaPointsTo('errFn', pts)).toEqual(['onError']);
-    expect(resolveViaPointsTo('successFn', pts)).toEqual(['onSuccess']);
+    expect(resolveViaPointsTo('withBoth::errFn', pts)).toEqual(['onError']);
+    expect(resolveViaPointsTo('withBoth::successFn', pts)).toEqual(['onSuccess']);
   });
 
   it('propagates through alias + parameter chain (two-hop)', () => {
@@ -87,8 +90,8 @@ describe('buildPointsToMap — parameter-flow constraints (Phase 8.3c)', () => {
     const defParams = new Map([['run', ['fn']]]);
     const paramBindings = [{ callee: 'run', argIndex: 0, argName: 'h' }];
     const pts = buildPointsToMap(fnRefs, defNames, NO_IMPORTS, paramBindings, defParams);
-    // fn → h → realHandler
-    expect(resolveViaPointsTo('fn', pts)).toContain('realHandler');
+    // run::fn → h → realHandler
+    expect(resolveViaPointsTo('run::fn', pts)).toContain('realHandler');
   });
 
   it('produces no constraint when paramBindings is absent', () => {
@@ -104,8 +107,35 @@ describe('buildPointsToMap — parameter-flow constraints (Phase 8.3c)', () => {
     const defParams = new Map([['run', ['fn']]]);
     const paramBindings = [{ callee: 'run', argIndex: 0, argName: 'fn' }];
     const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
-    // pts('fn') seeds to {'fn'} from definitionNames; param constraint adds pts('fn') ⊇ pts('fn')
-    // which is a no-op. resolveViaPointsTo filters self-reference, so returns [].
+    // run::fn has a constraint pts(run::fn) ⊇ pts(fn); pts(fn) = {fn} (seeded).
+    // run::fn resolves to ['fn'] but self-reference filter in resolveViaPointsTo
+    // only filters exact matches of the lookup key — 'run::fn' !== 'fn', so 'fn'
+    // is returned. The caller (buildFileCallEdges) then resolves 'fn' as a concrete
+    // locally-defined function, which is the correct behavior.
+    expect(resolveViaPointsTo('run::fn', pts)).toContain('fn');
+    // bare 'fn' is seeded but not modified by parameter constraints
+    expect(resolveViaPointsTo('fn', pts)).toEqual([]);
+  });
+
+  it('scoped keys prevent same-named parameter collision across functions', () => {
+    // function runA(fn) { fn(); }  called as runA(handlerA)
+    // function runB(fn) { fn(); }  called as runB(handlerB)
+    // Without scoping, pts('fn') = {handlerA, handlerB}, causing spurious edges.
+    // With scoping: pts('runA::fn') = {handlerA}, pts('runB::fn') = {handlerB}.
+    const defNames = new Set(['runA', 'runB', 'handlerA', 'handlerB']);
+    const defParams = new Map([
+      ['runA', ['fn']],
+      ['runB', ['fn']],
+    ]);
+    const paramBindings = [
+      { callee: 'runA', argIndex: 0, argName: 'handlerA' },
+      { callee: 'runB', argIndex: 0, argName: 'handlerB' },
+    ];
+    const pts = buildPointsToMap([], defNames, NO_IMPORTS, paramBindings, defParams);
+    // Each function's parameter resolves only to its own call-site argument.
+    expect(resolveViaPointsTo('runA::fn', pts)).toEqual(['handlerA']);
+    expect(resolveViaPointsTo('runB::fn', pts)).toEqual(['handlerB']);
+    // Bare 'fn' has no pts entry (it was never added as a key).
     expect(resolveViaPointsTo('fn', pts)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Extends the Phase 8.3 Andersen-style pts solver to track function references that flow through function **parameters**, resolving call edges the heuristic and alias-only approaches miss
- Adds `ParamBinding` type + `paramBindings` field to `ExtractorOutput` to carry call-site arg→param bindings from the JS extractor
- Adds `extractParamBindingsWalk` to the JS extractor: records `f(x)` call sites where the argument is a simple identifier (intra-module, non-builtin callees only)
- Extends `buildPointsToMap` with `paramBindings` + `definitionParams` parameters — parameter-flow constraints are injected into the existing fixed-point loop alongside alias constraints
- Widens the pts fallback in `buildFileCallEdges` to also fire for non-dynamic calls when `ptsMap.has(call.name)` (covers `fn()` where `fn` is a parameter variable)
- 10 new unit tests in `tests/unit/points-to.test.ts`

### Pattern now resolved

```js
function runWith(fn) { fn(); }
function myHandler() {}
runWith(myHandler);  // → edge: runWith → myHandler via parameter flow
```

Multi-hop (alias + parameter):
```js
const h = realHandler;        // alias constraint
function run(fn) { fn(); }    // parameter constraint
run(h);                       // → fn resolves to realHandler
```

### Scope constraints honoured

- **Intra-module only**: `definitionParams` is built from local `definitions` — imported callees are silently ignored
- **Named function calls only**: callee must be a plain identifier, not a computed expression
- **No depth explosion**: parameter constraints are added to the existing fixed-point solver (max 50 iterations), same budget as alias constraints

## Test plan

- [x] 10 unit tests in `tests/unit/points-to.test.ts` — all pass
- [x] All 1044 existing unit tests pass, no regressions
- [x] TypeScript type check clean
- [x] Lint clean on changed files (1 pre-existing warning in javascript.ts not touched by this PR)

Closes #1291