### PR TITLE
feat(resolver): phase 8.3d — object property write tracking in points-to analysis

### DIFF
--- a/crates/codegraph-core/src/edge_builder.rs
+++ b/crates/codegraph-core/src/edge_builder.rs
@@ -258,6 +258,17 @@ fn resolve_call_targets<'a>(
                 .unwrap_or_default();
             if !typed.is_empty() { return typed; }
         }
+        // 4.5. Phase 8.3d: composite pts key — `obj.prop = fn` seeds typeMap['obj.prop']
+        let composite_key = format!("{}.{}", receiver, call.name);
+        if let Some(&(pts_target, _)) = type_map.get(composite_key.as_str()) {
+            let resolved: Vec<&NodeInfo> = ctx.nodes_by_name
+                .get(pts_target)
+                .map(|v| v.iter()
+                    .filter(|n| import_resolution::compute_confidence(rel_path, &n.file, None) >= 0.5)
+                    .copied().collect())
+                .unwrap_or_default();
+            if !resolved.is_empty() { return resolved; }
+        }
     }
 
     // 5. Scoped fallback (this/self/super or no receiver)

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -100,8 +100,44 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                 }
             }
         }
+        // Phase 8.3d: property-write pts tracking — `obj.prop = fn` seeds composite key.
+        "assignment_expression" => {
+            let lhs = node.child_by_field_name("left");
+            let rhs = node.child_by_field_name("right");
+            if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
+                if lhs.kind() == "member_expression" && rhs.kind() == "identifier" {
+                    let obj = lhs.child_by_field_name("object");
+                    let prop = lhs.child_by_field_name("property");
+                    if let (Some(obj), Some(prop)) = (obj, prop) {
+                        if obj.kind() == "identifier" {
+                            let obj_name = node_text(&obj, source);
+                            if !is_js_builtin_global(obj_name) {
+                                let key = format!("{}.{}", obj_name, node_text(&prop, source));
+                                let rhs_name = node_text(&rhs, source).to_string();
+                                symbols.type_map.push(TypeMapEntry {
+                                    name: key,
+                                    type_name: rhs_name,
+                                    confidence: 0.85,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
         _ => {}
     }
+}
+
+/// Returns true for JS built-in global objects whose property writes should not be tracked.
+fn is_js_builtin_global(name: &str) -> bool {
+    matches!(
+        name,
+        "Math" | "JSON" | "Promise" | "Array" | "Object" | "Date" | "Error"
+        | "Symbol" | "Map" | "Set" | "RegExp" | "Number" | "String" | "Boolean"
+        | "WeakMap" | "WeakSet" | "WeakRef" | "Proxy" | "Reflect" | "Intl"
+        | "console" | "process" | "window" | "document" | "globalThis"
+    )
 }
 
 // ── Return-type map extraction (Phase 8.2 parity) ───────────────────────────

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -130,13 +130,29 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 }
 
 /// Returns true for JS built-in global objects whose property writes should not be tracked.
+/// Mirrors the TypeScript `BUILTIN_GLOBALS` set in `src/extractors/javascript.ts`.
 fn is_js_builtin_global(name: &str) -> bool {
     matches!(
         name,
         "Math" | "JSON" | "Promise" | "Array" | "Object" | "Date" | "Error"
         | "Symbol" | "Map" | "Set" | "RegExp" | "Number" | "String" | "Boolean"
         | "WeakMap" | "WeakSet" | "WeakRef" | "Proxy" | "Reflect" | "Intl"
+        // Binary/typed data
+        | "ArrayBuffer" | "SharedArrayBuffer" | "DataView" | "Atomics" | "BigInt"
+        | "Float32Array" | "Float64Array"
+        | "Int8Array" | "Int16Array" | "Int32Array"
+        | "Uint8Array" | "Uint16Array" | "Uint32Array" | "Uint8ClampedArray"
+        // Web platform globals
+        | "URL" | "URLSearchParams"
+        | "TextEncoder" | "TextDecoder"
+        | "AbortController" | "AbortSignal"
+        | "Headers" | "Request" | "Response"
+        | "FormData" | "Blob" | "File"
+        | "ReadableStream" | "WritableStream" | "TransformStream"
+        // Browser/runtime globals
         | "console" | "process" | "window" | "document" | "globalThis"
+        // Node.js built-ins
+        | "Buffer" | "EventEmitter" | "Stream"
     )
 }
 

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -74,6 +74,19 @@ export function resolveByMethodOrGlobal(
       const typed = lookup.byName(`${typeName}.${call.name}`).filter((n) => n.kind === 'method');
       if (typed.length > 0) return typed;
     }
+    // Phase 8.3d: composite pts key — `obj.prop = fn` seeds typeMap['obj.prop'] = { type: 'fn' }.
+    // When a call site references `obj.prop` as a callback, resolve directly to the target fn.
+    const compositeEntry = typeMap.get(`${call.receiver}.${call.name}`);
+    const ptsTarget = compositeEntry
+      ? typeof compositeEntry === 'string'
+        ? compositeEntry
+        : (compositeEntry as { type?: string }).type
+      : null;
+    if (ptsTarget) {
+      return lookup
+        .byName(ptsTarget)
+        .filter((t) => computeConfidence(relPath, t.file, null) >= 0.5);
+    }
   }
   if (
     !call.receiver ||

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -85,9 +85,10 @@ export function resolveByMethodOrGlobal(
         : (compositeEntry as { type?: string }).type
       : null;
     if (ptsTarget) {
-      return lookup
+      const resolved = lookup
         .byName(ptsTarget)
         .filter((t) => computeConfidence(relPath, t.file, null) >= 0.5);
+      if (resolved.length > 0) return resolved;
     }
   }
   if (

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -430,7 +430,7 @@ function extractDestructuredBindingsWalk(node: TreeSitterNode, definitions: Defi
     ) {
       for (let j = 0; j < declNode.childCount; j++) {
         const declarator = declNode.child(j);
-        if (!declarator || declarator.type !== 'variable_declarator') continue;
+        if (declarator?.type !== 'variable_declarator') continue;
         const nameN = declarator.childForFieldName('name');
         if (nameN && nameN.type === 'object_pattern') {
           extractDestructuredBindings(
@@ -457,7 +457,7 @@ function extractConstDeclarators(declNode: TreeSitterNode, definitions: Definiti
 
   for (let j = 0; j < declNode.childCount; j++) {
     const declarator = declNode.child(j);
-    if (!declarator || declarator.type !== 'variable_declarator') continue;
+    if (declarator?.type !== 'variable_declarator') continue;
     const nameN = declarator.childForFieldName('name');
     const valueN = declarator.childForFieldName('value');
     if (!nameN || nameN.type !== 'identifier' || !valueN) continue;
@@ -1359,6 +1359,7 @@ function recordCallAssignment(
  * Values are `{ type: string, confidence: number }`:
  *   - 1.0: explicit constructor (`new Foo()`)
  *   - 0.9: type annotation (`: Foo`) or typed parameter
+ *   - 0.85: property write (`obj.prop = fn` — Phase 8.3d pts tracking)
  *   - 0.7–0.9: inter-procedural propagation from return-type map (Phase 8.2)
  *   - 0.7: factory method call (`Foo.create()` — uppercase-first heuristic)
  *
@@ -1378,6 +1379,8 @@ function extractTypeMapWalk(
       handleVarDeclaratorTypeMap(node, typeMap, returnTypeMap, callAssignments, fnRefBindings);
     } else if (t === 'required_parameter' || t === 'optional_parameter') {
       handleParamTypeMap(node, typeMap);
+    } else if (t === 'assignment_expression') {
+      handlePropWriteTypeMap(node, typeMap);
     }
     for (let i = 0; i < node.childCount; i++) {
       walk(node.child(i)!, depth + 1);
@@ -1490,6 +1493,32 @@ function handleParamTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEn
     const typeName = extractSimpleTypeName(typeAnno);
     if (typeName) setTypeMapEntry(typeMap, nameNode.text, typeName, 0.9);
   }
+}
+
+/**
+ * Phase 8.3d: seed the pts map from object property writes.
+ *
+ * `handlers.auth = authMiddleware` → typeMap.set('handlers.auth', { type: 'authMiddleware', confidence: 0.85 })
+ *
+ * Only simple `obj.prop = identifier` writes are tracked (not chained `a.b.c = x`).
+ * BUILTIN_GLOBALS are skipped (e.g. `console.log = fn` is noise).
+ */
+function handlePropWriteTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEntry>): void {
+  const lhsN = node.childForFieldName('left');
+  const rhsN = node.childForFieldName('right');
+  if (!lhsN || !rhsN) return;
+  if (lhsN.type !== 'member_expression') return;
+  if (rhsN.type !== 'identifier') return;
+
+  const obj = lhsN.childForFieldName('object');
+  const prop = lhsN.childForFieldName('property');
+  if (!obj || !prop) return;
+  if (obj.type !== 'identifier') return; // skip chained: a.b.c = x
+
+  const objName = obj.text;
+  if (BUILTIN_GLOBALS.has(objName)) return;
+
+  setTypeMapEntry(typeMap, `${objName}.${prop.text}`, rhsN.text, 0.85);
 }
 
 function extractReceiverName(objNode: TreeSitterNode | null): string | undefined {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -78,6 +78,10 @@ const BUILTIN_GLOBALS: Set<string> = new Set([
   'Buffer',
   'EventEmitter',
   'Stream',
+  'process',
+  'window',
+  'document',
+  'globalThis',
 ]);
 
 /** Maximum chain depth for inter-procedural return-type propagation (Phase 8.2). */
@@ -1514,6 +1518,9 @@ function handlePropWriteTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeM
   const prop = lhsN.childForFieldName('property');
   if (!obj || !prop) return;
   if (obj.type !== 'identifier') return; // skip chained: a.b.c = x
+  // Guard: only static property access (property_identifier or identifier), not
+  // computed subscript expressions — consistent with the adjacent fnRefBindings block.
+  if (prop.type !== 'property_identifier' && prop.type !== 'identifier') return;
 
   const objName = obj.text;
   if (BUILTIN_GLOBALS.has(objName)) return;

--- a/tests/integration/issue-1292-property-write-pts.test.ts
+++ b/tests/integration/issue-1292-property-write-pts.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration test for #1292: object property write tracking in points-to analysis.
+ *
+ * Before Phase 8.3d, `handlers.auth = authMiddleware` was not tracked, so
+ * `router.use(handlers.auth)` produced no edge to `authMiddleware`.
+ *
+ * The fix seeds typeMap['handlers.auth'] = { type: 'authMiddleware' } from the
+ * assignment_expression walk, then resolveByMethodOrGlobal consults the composite
+ * key and resolves the pts target directly.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+const FIXTURE = {
+  'app.js': `
+function authMiddleware(req, res, next) { next(); }
+function logRequest(req, res, next) { next(); }
+
+const handlers = {};
+handlers.auth = authMiddleware;
+handlers.log = logRequest;
+
+function setupRoutes(router) {
+  router.use(handlers.auth);
+  router.use(handlers.log);
+}
+`,
+};
+
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-1292-'));
+  for (const [rel, content] of Object.entries(FIXTURE)) {
+    fs.writeFileSync(path.join(tmpDir, rel), content);
+  }
+  await buildGraph(tmpDir, { incremental: false, skipRegistry: true });
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function readCallEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n2.name AS tgt, e.kind, e.dynamic
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as Array<{ src: string; tgt: string; kind: string; dynamic: number }>;
+  } finally {
+    db.close();
+  }
+}
+
+describe('Issue #1292: property write pts tracking (same-file)', () => {
+  it('emits a calls edge from setupRoutes to authMiddleware via handlers.auth', () => {
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    const edges = readCallEdges(dbPath);
+    const edge = edges.find((e) => e.src === 'setupRoutes' && e.tgt === 'authMiddleware');
+    expect(edge).toBeDefined();
+    expect(edge!.dynamic).toBe(1);
+  });
+
+  it('emits a calls edge from setupRoutes to logRequest via handlers.log', () => {
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    const edges = readCallEdges(dbPath);
+    const edge = edges.find((e) => e.src === 'setupRoutes' && e.tgt === 'logRequest');
+    expect(edge).toBeDefined();
+    expect(edge!.dynamic).toBe(1);
+  });
+});

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -7,6 +7,7 @@
  */
 import { beforeAll, describe, expect, it } from 'vitest';
 import { createParsers, extractSymbols } from '../../src/domain/parser.js';
+import { setTypeMapEntry } from '../../src/extractors/helpers.js';
 
 describe('JavaScript parser', () => {
   let parsers: any;
@@ -292,21 +293,37 @@ describe('JavaScript parser', () => {
       const symbols = parseJS(`
         console.warn = customWarn;
         Object.assign = myAssign;
+        process.on = myHandler;
+        window.onload = myHandler;
+        document.ready = myHandler;
+        globalThis.fetch = myFetch;
       `);
       expect(symbols.typeMap.has('console.warn')).toBe(false);
       expect(symbols.typeMap.has('Object.assign')).toBe(false);
+      expect(symbols.typeMap.has('process.on')).toBe(false);
+      expect(symbols.typeMap.has('window.onload')).toBe(false);
+      expect(symbols.typeMap.has('document.ready')).toBe(false);
+      expect(symbols.typeMap.has('globalThis.fetch')).toBe(false);
     });
 
-    it('higher-confidence entry wins when same key appears twice', () => {
-      // First write seeds at 0.85; a later type annotation on handlers.auth should win
+    it('first-write wins when same key appears twice at equal confidence', () => {
       const parser = parsers.get('typescript');
       const tree = parser.parse(`
         handlers.auth = firstMiddleware;
         handlers.auth = secondMiddleware;
       `);
       const symbols = extractSymbols(tree, 'test.ts');
-      // Second write at same confidence (0.85) does not overwrite the first
+      // Both writes are at 0.85; first-write wins (equal confidence does not promote)
       expect(symbols.typeMap.get('handlers.auth')?.type).toBe('firstMiddleware');
+    });
+
+    it('higher-confidence entry promotes over lower-confidence entry (setTypeMapEntry)', () => {
+      const typeMap = new Map<string, { type: string; confidence: number }>();
+      // Seed with a low-confidence write (property-write confidence: 0.85)
+      setTypeMapEntry(typeMap, 'handlers.auth', 'firstMiddleware', 0.85);
+      // A higher-confidence annotation (0.9) should overwrite
+      setTypeMapEntry(typeMap, 'handlers.auth', 'AnnotatedHandler', 0.9);
+      expect(typeMap.get('handlers.auth')).toEqual({ type: 'AnnotatedHandler', confidence: 0.9 });
     });
   });
 

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -259,6 +259,57 @@ describe('JavaScript parser', () => {
     });
   });
 
+  describe('Phase 8.3d: property write pts tracking', () => {
+    function parseJS(code) {
+      const parser = parsers.get('javascript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.js');
+    }
+
+    it('seeds typeMap with composite key for obj.prop = identifier', () => {
+      const symbols = parseJS(`
+        const handlers = {};
+        handlers.auth = authMiddleware;
+      `);
+      expect(symbols.typeMap.get('handlers.auth')).toEqual({
+        type: 'authMiddleware',
+        confidence: 0.85,
+      });
+    });
+
+    it('ignores chained writes (a.b.c = x)', () => {
+      const symbols = parseJS(`a.b.c = handler;`);
+      expect(symbols.typeMap.has('a.b.c')).toBe(false);
+      expect(symbols.typeMap.has('b.c')).toBe(false);
+    });
+
+    it('ignores non-identifier RHS (a.prop = obj.method)', () => {
+      const symbols = parseJS(`router.use = obj.method;`);
+      expect(symbols.typeMap.has('router.use')).toBe(false);
+    });
+
+    it('ignores BUILTIN_GLOBALS as object names', () => {
+      const symbols = parseJS(`
+        console.warn = customWarn;
+        Object.assign = myAssign;
+      `);
+      expect(symbols.typeMap.has('console.warn')).toBe(false);
+      expect(symbols.typeMap.has('Object.assign')).toBe(false);
+    });
+
+    it('higher-confidence entry wins when same key appears twice', () => {
+      // First write seeds at 0.85; a later type annotation on handlers.auth should win
+      const parser = parsers.get('typescript');
+      const tree = parser.parse(`
+        handlers.auth = firstMiddleware;
+        handlers.auth = secondMiddleware;
+      `);
+      const symbols = extractSymbols(tree, 'test.ts');
+      // Second write at same confidence (0.85) does not overwrite the first
+      expect(symbols.typeMap.get('handlers.auth')?.type).toBe('firstMiddleware');
+    });
+  });
+
   describe('Phase 8.2: inter-procedural return-type propagation', () => {
     function parseTS(code) {
       const parser = parsers.get('typescript');


### PR DESCRIPTION
## Summary

- Seed `typeMap['obj.prop']` from `assignment_expression` nodes (`handlers.auth = authMiddleware`) in both WASM extractor (`extractTypeMapWalk`) and native Rust extractor (`match_js_type_map`), with confidence 0.85
- Extend `resolveByMethodOrGlobal` (TS) and `resolve_call_targets` (Rust) with a step-4.5 composite pts key lookup: when a call has `receiver + name`, check `typeMap['receiver.name']` for a direct function target before falling through
- Skips BUILTIN_GLOBALS / built-in objects (`console`, `Math`, etc.) and chained writes (`a.b.c = x`)

**Before:** `router.use(handlers.auth)` produced no edge to `authMiddleware`  
**After:** edge `setupRoutes → authMiddleware` is emitted (dynamic=1)

## Test plan

- [x] 5 new unit tests in `tests/parsers/javascript.test.ts` under `Phase 8.3d: property write pts tracking`
- [x] Integration test `tests/integration/issue-1292-property-write-pts.test.ts` verifies full pipeline with acceptance criteria from #1292
- [x] Rust compiles clean (`cargo check` — 0 errors, 6 pre-existing warnings)
- [x] 70 parser + integration tests pass on the feature branch
- [x] Parity test suite (101 tests) green — both engines now emit the property-write edges

Closes #1292