### PR TITLE
feat(resolver): phase 8.4 — barrel file re-export chain resolution for call edges

### DIFF
--- a/src/domain/graph/builder/context.ts
+++ b/src/domain/graph/builder/context.ts
@@ -68,6 +68,8 @@ export class PipelineContext {
   batchResolved!: Map<string, string> | null;
   reexportMap!: Map<string, unknown[]>;
   barrelOnlyFiles!: Set<string>;
+  /** Phase 8.4: cache for resolveBarrelExport results keyed as "barrelPath|symbolName". */
+  barrelExportCache: Map<string, string | null> = new Map();
 
   // ── Node lookup (set by insertNodes / buildEdges stages) ───────────
   nodesByName!: Map<string, NodeRow[]>;

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -34,7 +34,7 @@ import {
 } from '../call-resolver.js';
 import type { PipelineContext } from '../context.js';
 import { BUILTIN_RECEIVERS, batchInsertEdges } from '../helpers.js';
-import { getResolved, isBarrelFile, resolveBarrelExport } from './resolve-imports.js';
+import { getResolved, isBarrelFile, resolveBarrelExportCached } from './resolve-imports.js';
 
 // ── Local types ──────────────────────────────────────────────────────────
 
@@ -126,7 +126,7 @@ function emitTypeOnlySymbolEdges(
     const cleanName = name.replace(/^\*\s+as\s+/, '');
     let targetFile = resolvedPath;
     if (isBarrelFile(ctx, resolvedPath)) {
-      const actual = resolveBarrelExport(ctx, resolvedPath, cleanName);
+      const actual = resolveBarrelExportCached(ctx, resolvedPath, cleanName);
       if (actual) targetFile = actual;
     }
     const candidates = ctx.nodesByNameAndFile.get(`${cleanName}|${targetFile}`);
@@ -197,7 +197,7 @@ function buildBarrelEdges(
   const resolvedSources = new Set<string>();
   for (const name of imp.names) {
     const cleanName = name.replace(/^\*\s+as\s+/, '');
-    const actualSource = resolveBarrelExport(ctx, resolvedPath, cleanName);
+    const actualSource = resolveBarrelExportCached(ctx, resolvedPath, cleanName);
     if (actualSource && actualSource !== resolvedPath && !resolvedSources.has(actualSource)) {
       resolvedSources.add(actualSource);
       const actualRow = getNodeIdStmt.get(actualSource, 'file', actualSource, 0);
@@ -620,7 +620,7 @@ function buildImportedNamesForNative(
       const cleanName = name.replace(/^\*\s+as\s+/, '');
       let targetFile = resolvedPath;
       if (isBarrelFile(ctx, resolvedPath)) {
-        const actual = resolveBarrelExport(ctx, resolvedPath, cleanName);
+        const actual = resolveBarrelExportCached(ctx, resolvedPath, cleanName);
         if (actual) targetFile = actual;
       }
       importedNames.push({ name: cleanName, file: targetFile });
@@ -681,11 +681,21 @@ function buildImportedNamesMap(
   // (higher priority). Static imports represent direct bindings while dynamic
   // imports often use aliased destructuring (`{ foo: bar } = await import(…)`).
   // When both contribute the same name, the static binding is authoritative.
+  //
+  // Phase 8.4: trace through barrel files so that symbol names map to their
+  // actual definition file, not the re-exporting barrel. Mirrors the tracing
+  // already done in buildImportedNamesForNative (the native path).
+  const traceBarrel = (resolvedPath: string, cleanName: string): string => {
+    if (!isBarrelFile(ctx, resolvedPath)) return resolvedPath;
+    const actual = resolveBarrelExportCached(ctx, resolvedPath, cleanName);
+    return actual ?? resolvedPath;
+  };
   for (const imp of symbols.imports) {
     if (!imp.dynamicImport) continue;
     const resolvedPath = getResolved(ctx, path.join(rootDir, relPath), imp.source);
     for (const name of imp.names) {
-      importedNames.set(name.replace(/^\*\s+as\s+/, ''), resolvedPath);
+      const cleanName = name.replace(/^\*\s+as\s+/, '');
+      importedNames.set(cleanName, traceBarrel(resolvedPath, cleanName));
     }
   }
   for (const imp of symbols.imports) {
@@ -693,7 +703,7 @@ function buildImportedNamesMap(
     const resolvedPath = getResolved(ctx, path.join(rootDir, relPath), imp.source);
     for (const name of imp.names) {
       const cleanName = name.replace(/^\*\s+as\s+/, '');
-      importedNames.set(cleanName, resolvedPath);
+      importedNames.set(cleanName, traceBarrel(resolvedPath, cleanName));
     }
   }
   return importedNames;
@@ -704,7 +714,8 @@ function makeContextLookup(ctx: PipelineContext, getNodeIdStmt: NodeIdStmt): Cal
     byNameAndFile: (name, file) => ctx.nodesByNameAndFile.get(`${name}|${file}`) ?? [],
     byName: (name) => ctx.nodesByName.get(name) ?? [],
     isBarrel: (file) => isBarrelFile(ctx, file),
-    resolveBarrel: (barrelFile, symbolName) => resolveBarrelExport(ctx, barrelFile, symbolName),
+    resolveBarrel: (barrelFile, symbolName) =>
+      resolveBarrelExportCached(ctx, barrelFile, symbolName),
     nodeId: (name, kind, file, line) => getNodeIdStmt.get(name, kind, file, line),
   };
 }

--- a/src/domain/graph/builder/stages/resolve-imports.ts
+++ b/src/domain/graph/builder/stages/resolve-imports.ts
@@ -175,7 +175,8 @@ export function resolveBarrelExportCached(
   symbolName: string,
 ): string | null {
   const cacheKey = `${barrelPath}|${symbolName}`;
-  if (ctx.barrelExportCache.has(cacheKey)) return ctx.barrelExportCache.get(cacheKey) ?? null;
+  if (ctx.barrelExportCache.has(cacheKey))
+    return ctx.barrelExportCache.get(cacheKey) as string | null;
   const result = resolveBarrelExport(ctx, barrelPath, symbolName);
   ctx.barrelExportCache.set(cacheKey, result);
   return result;

--- a/src/domain/graph/builder/stages/resolve-imports.ts
+++ b/src/domain/graph/builder/stages/resolve-imports.ts
@@ -169,9 +169,22 @@ async function reparseBarrelFiles(
   return added;
 }
 
+export function resolveBarrelExportCached(
+  ctx: PipelineContext,
+  barrelPath: string,
+  symbolName: string,
+): string | null {
+  const cacheKey = `${barrelPath}|${symbolName}`;
+  if (ctx.barrelExportCache.has(cacheKey)) return ctx.barrelExportCache.get(cacheKey) ?? null;
+  const result = resolveBarrelExport(ctx, barrelPath, symbolName);
+  ctx.barrelExportCache.set(cacheKey, result);
+  return result;
+}
+
 export async function resolveImports(ctx: PipelineContext): Promise<void> {
   const { fileSymbols, rootDir, aliases, allFiles, isFullBuild } = ctx;
   const t0 = performance.now();
+  ctx.barrelExportCache = new Map();
 
   const batchInputs: Array<{ fromFile: string; importSource: string }> = [];
   for (const [relPath, symbols] of fileSymbols) {

--- a/tests/fixtures/barrel-call-resolution/App.ts
+++ b/tests/fixtures/barrel-call-resolution/App.ts
@@ -1,0 +1,5 @@
+import { Button } from './components/index.js';
+
+export function render(): string {
+  return Button('Click me');
+}

--- a/tests/fixtures/barrel-call-resolution/components/Button.ts
+++ b/tests/fixtures/barrel-call-resolution/components/Button.ts
@@ -1,0 +1,3 @@
+export function Button(label: string): string {
+  return `<button>${label}</button>`;
+}

--- a/tests/fixtures/barrel-call-resolution/components/index.ts
+++ b/tests/fixtures/barrel-call-resolution/components/index.ts
@@ -1,0 +1,2 @@
+// Pure barrel — re-exports only.
+export { Button } from './Button.js';

--- a/tests/integration/phase-8.4-barrel-call-resolution.test.ts
+++ b/tests/integration/phase-8.4-barrel-call-resolution.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Phase 8.4: barrel file re-export chain resolution for call edges.
+ *
+ * Before this fix, symbols imported through barrel files resolved to the barrel
+ * (e.g. `components/index.ts`) instead of the actual definition file
+ * (`components/Button.ts`). buildImportedNamesMap (JS/WASM path) mapped
+ * `Button → components/index.ts`, so the call edge from `render → Button`
+ * was unresolvable.
+ *
+ * Fixture:
+ *   components/Button.ts   — defines `Button`
+ *   components/index.ts    — pure barrel: `export { Button } from './Button.js'`
+ *   App.ts                 — imports `Button` from barrel, calls it inside `render()`
+ *
+ * Expected: a `calls` edge from `render` (App.ts) → `Button` (components/Button.ts)
+ * — not to the barrel index.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FIXTURE_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'barrel-call-resolution');
+
+interface CallEdgeRow {
+  caller_name: string;
+  caller_file: string;
+  callee_name: string;
+  callee_file: string;
+}
+
+function readCallEdges(dbPath: string): CallEdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS caller_name, n1.file AS caller_file,
+                n2.name AS callee_name, n2.file AS callee_file
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.file, n1.name, n2.file, n2.name`,
+      )
+      .all() as CallEdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)('Phase 8.4 barrel call resolution (%s)', (engine) => {
+  let tmpDir: string;
+  let callEdges: CallEdgeRow[];
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `codegraph-8.4-${engine}-`));
+    // Copy fixture to a temp dir so the build doesn't pollute the source tree
+    fs.cpSync(FIXTURE_DIR, tmpDir, { recursive: true });
+
+    await buildGraph(tmpDir, { incremental: false, skipRegistry: true, engine });
+    callEdges = readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+  }, 60_000);
+
+  afterAll(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits a calls edge from render to Button in the leaf definition file', () => {
+    const barrelCallEdge = callEdges.find(
+      (e) =>
+        e.caller_name === 'render' &&
+        e.callee_name === 'Button' &&
+        e.callee_file === 'components/Button.ts',
+    );
+    expect(
+      barrelCallEdge,
+      `Expected render → Button (components/Button.ts) edge.\nActual call edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeDefined();
+  });
+
+  it('does NOT emit a calls edge from render to the barrel index', () => {
+    const barrelEdge = callEdges.find(
+      (e) =>
+        e.caller_name === 'render' &&
+        e.callee_name === 'Button' &&
+        e.callee_file === 'components/index.ts',
+    );
+    expect(barrelEdge).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixes call edge resolution through barrel files** on the JS/WASM path. `buildImportedNamesMap` was mapping imported symbol names (e.g. `Button`) to the barrel file (`components/index.ts`) rather than the actual definition file (`components/Button.ts`). The native path already handled this correctly; this PR brings the WASM/JS fallback into parity.
- **Adds `barrelExportCache`** to `PipelineContext` — a build-scoped `Map<"barrelPath|symbolName", actualFilePath>` that caches `resolveBarrelExport` results, avoiding repeated DFS walks when many files import from the same barrel.
- **Migrates all `resolveBarrelExport` call sites** in `build-edges.ts` to the new cached wrapper `resolveBarrelExportCached` for consistency and performance.

## Test plan

- [ ] New integration test `phase-8.4-barrel-call-resolution.test.ts` passes on both `wasm` and `native` engines:
  - `render` → `Button` edge resolves to `components/Button.ts` (not the barrel `components/index.ts`)
- [ ] Existing barrel tests continue to pass: `issue-1174-chained-barrel-incremental`
- [ ] All 5 pre-existing failures in `pts-parity`, `build-parity`, and `issue-1292` are confirmed pre-existing (not introduced by this PR)
- [ ] Opens #1297 for the separate WASM-only issue where barrel-through import edges are missing on full builds

## Affected files

- `src/domain/graph/builder/context.ts` — new `barrelExportCache` field
- `src/domain/graph/builder/stages/resolve-imports.ts` — `resolveBarrelExportCached` export + cache reset
- `src/domain/graph/builder/stages/build-edges.ts` — barrel tracing in `buildImportedNamesMap` + cache migration
- `tests/fixtures/barrel-call-resolution/` — new fixture
- `tests/integration/phase-8.4-barrel-call-resolution.test.ts` — new integration test