### PR TITLE
feat(resolver): resolve this-dispatch inside Object.defineProperty accessor functions (JS)

### DIFF
--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1134,7 +1134,7 @@ function buildFileCallEdges(
           const qualifiedName = `${typeName}.${call.name}`;
           const qualified = lookup.byNameAndFile(qualifiedName, relPath);
           if (qualified.length > 0) {
-            targets = qualified;
+            targets = [...qualified];
           }
         }
         // If still no targets, search for any definition named `call.name` in
@@ -1146,7 +1146,7 @@ function buildFileCallEdges(
         if (targets.length === 0) {
           const sameFile = lookup.byNameAndFile(call.name, relPath);
           if (sameFile.length > 0) {
-            targets = sameFile;
+            targets = [...sameFile];
           }
         }
       }

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -710,6 +710,94 @@ function buildFnRefBindingsPtsPostPass(
 }
 
 /**
+ * Object.defineProperty accessor post-pass for the native call-edge path.
+ *
+ * When a function is registered as a getter/setter via
+ * `Object.defineProperty(obj, "bar", { get: getter })`, calls to `this.X()`
+ * inside `getter` need to resolve against `obj` (because `this === obj` when
+ * the accessor is invoked). The native Rust engine has no knowledge of
+ * `definePropertyReceivers`, so this JS post-pass adds the missing edges.
+ */
+function buildDefinePropertyPostPass(
+  ctx: PipelineContext,
+  getNodeIdStmt: NodeIdStmt,
+  allEdgeRows: EdgeRowTuple[],
+  sharedLookup?: CallNodeLookup,
+): void {
+  const filesWithReceivers = [...ctx.fileSymbols].filter(
+    ([, symbols]) => symbols.definePropertyReceivers && symbols.definePropertyReceivers.size > 0,
+  );
+  if (filesWithReceivers.length === 0) return;
+
+  const seenByPair = new Set<string>();
+  for (const [srcId, tgtId] of allEdgeRows) {
+    seenByPair.add(`${srcId}|${tgtId}`);
+  }
+
+  const { barrelOnlyFiles, rootDir } = ctx;
+  const lookup = sharedLookup ?? makeContextLookup(ctx, getNodeIdStmt);
+
+  for (const [relPath, symbols] of filesWithReceivers) {
+    if (barrelOnlyFiles.has(relPath)) continue;
+    const fileNodeRow = getNodeIdStmt.get(relPath, 'file', relPath, 0);
+    if (!fileNodeRow) continue;
+
+    const importedNames = buildImportedNamesMap(ctx, relPath, symbols, rootDir);
+    const typeMap: Map<string, TypeMapEntry | string> = symbols.typeMap || new Map();
+    const definePropertyReceivers = symbols.definePropertyReceivers!;
+
+    for (const call of symbols.calls) {
+      if (call.receiver !== 'this') continue;
+
+      const caller = findCaller(lookup, call, symbols.definitions, relPath, fileNodeRow);
+      if (!caller.callerName) continue;
+
+      const receiverVarName = definePropertyReceivers.get(caller.callerName);
+      if (!receiverVarName) continue;
+
+      // Only add edges the native engine missed (no direct target already).
+      const { targets: directTargets } = resolveCallTargets(
+        lookup,
+        call,
+        relPath,
+        importedNames,
+        typeMap as Map<string, unknown>,
+        caller.callerName,
+      );
+      if (directTargets.length > 0) continue;
+
+      // Resolve via receiver type
+      let targets: ReadonlyArray<{ id: number; file: string }> = [];
+      const typeEntry = typeMap.get(receiverVarName);
+      const typeName = typeEntry
+        ? typeof typeEntry === 'string'
+          ? typeEntry
+          : (typeEntry as { type?: string }).type
+        : null;
+      if (typeName) {
+        const qualifiedName = `${typeName}.${call.name}`;
+        targets = lookup.byNameAndFile(qualifiedName, relPath);
+      }
+      // Same-file fallback for plain object-literal methods
+      if (targets.length === 0) {
+        targets = lookup.byNameAndFile(call.name, relPath);
+      }
+
+      for (const t of targets) {
+        const edgeKey = `${caller.id}|${t.id}`;
+        if (t.id !== caller.id && !seenByPair.has(edgeKey)) {
+          const conf = computeConfidence(relPath, t.file, null);
+          if (conf > 0) {
+            seenByPair.add(edgeKey);
+            allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'ts-native']);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
  * Phase 8.5: CHA + RTA post-pass for the native call-edge path.
  *
  * The native Rust engine has no knowledge of the CHA context, so `this.method()`
@@ -1016,6 +1104,47 @@ function buildFileCallEdges(
           .filter((n) => n.kind === 'method');
         if (qualified.length > 0) {
           targets = qualified;
+        }
+      }
+    }
+
+    // Object.defineProperty accessor fallback: when a function is registered as
+    // a getter/setter via `Object.defineProperty(obj, "bar", { get: getter })`,
+    // calls to `this.X()` inside `getter` resolve against `obj` (this === obj
+    // when the accessor is invoked). If the same-class fallback above found
+    // nothing, try treating `obj` as the receiver and look up `obj.X` in the
+    // typeMap, or fall back to a same-file lookup of any definition named X
+    // that belongs to the object literal or its type.
+    if (
+      targets.length === 0 &&
+      call.receiver === 'this' &&
+      caller.callerName != null &&
+      symbols.definePropertyReceivers
+    ) {
+      const receiverVarName = symbols.definePropertyReceivers.get(caller.callerName);
+      if (receiverVarName) {
+        // Try typeMap lookup for receiver.methodName
+        const typeEntry = typeMap.get(receiverVarName);
+        const typeName = typeEntry
+          ? typeof typeEntry === 'string'
+            ? typeEntry
+            : (typeEntry as { type?: string }).type
+          : null;
+        if (typeName) {
+          const qualifiedName = `${typeName}.${call.name}`;
+          const qualified = lookup.byNameAndFile(qualifiedName, relPath).filter(() => true);
+          if (qualified.length > 0) {
+            targets = qualified;
+          }
+        }
+        // If still no targets, search for any definition named `call.name` in
+        // the same file — handles plain object literals where the method isn't
+        // qualified (e.g. `const obj = { baz() {} }` defines `baz` directly).
+        if (targets.length === 0) {
+          const sameFile = lookup.byNameAndFile(call.name, relPath).filter(() => true);
+          if (sameFile.length > 0) {
+            targets = sameFile;
+          }
         }
       }
     }
@@ -1482,6 +1611,9 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
       // (e.g. `const f = fn.bind(ctx)`), so calls to bind-created aliases are
       // not resolved to their original function on the native path.
       buildFnRefBindingsPtsPostPass(ctx, getNodeIdStmt, allEdgeRows, sharedLookup);
+      // Object.defineProperty accessor post-pass: resolve this-dispatch inside
+      // getter/setter functions registered via Object.defineProperty.
+      buildDefinePropertyPostPass(ctx, getNodeIdStmt, allEdgeRows, sharedLookup);
       // Phase 8.5 post-pass: augment native call edges with CHA-resolved dispatch.
       // The native Rust engine has no knowledge of the CHA context, so this/self
       // calls and interface dispatch are not expanded to concrete implementations.

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1132,7 +1132,7 @@ function buildFileCallEdges(
           : null;
         if (typeName) {
           const qualifiedName = `${typeName}.${call.name}`;
-          const qualified = lookup.byNameAndFile(qualifiedName, relPath).filter(() => true);
+          const qualified = lookup.byNameAndFile(qualifiedName, relPath);
           if (qualified.length > 0) {
             targets = qualified;
           }
@@ -1140,8 +1140,11 @@ function buildFileCallEdges(
         // If still no targets, search for any definition named `call.name` in
         // the same file — handles plain object literals where the method isn't
         // qualified (e.g. `const obj = { baz() {} }` defines `baz` directly).
+        // Note: this is intentionally broad — it matches any same-file definition
+        // with the called name, not just members of the receiver object. This is
+        // the same behaviour used by the native post-pass path (buildDefinePropertyPostPass).
         if (targets.length === 0) {
-          const sameFile = lookup.byNameAndFile(call.name, relPath).filter(() => true);
+          const sameFile = lookup.byNameAndFile(call.name, relPath);
           if (sameFile.length > 0) {
             targets = sameFile;
           }

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -804,6 +804,9 @@ function serializeExtractorOutput(
     astNodes,
     ...(symbols.fnRefBindings?.length ? { fnRefBindings: symbols.fnRefBindings } : {}),
     ...(symbols.newExpressions?.length ? { newExpressions: symbols.newExpressions } : {}),
+    ...(symbols.definePropertyReceivers?.size
+      ? { definePropertyReceivers: Array.from(symbols.definePropertyReceivers.entries()) }
+      : {}),
   };
 }
 

--- a/src/domain/wasm-worker-pool.ts
+++ b/src/domain/wasm-worker-pool.ts
@@ -108,6 +108,11 @@ function deserializeResult(ser: SerializedExtractorOutput | null): ExtractorOutp
   if (ser.astNodes !== undefined) out.astNodes = ser.astNodes as unknown as ASTNodeRow[];
   if (ser.fnRefBindings?.length) out.fnRefBindings = ser.fnRefBindings;
   if (ser.newExpressions?.length) out.newExpressions = ser.newExpressions;
+  if (ser.definePropertyReceivers?.length) {
+    const m = new Map<string, string>();
+    for (const [k, v] of ser.definePropertyReceivers) m.set(k, v);
+    out.definePropertyReceivers = m;
+  }
   return out;
 }
 

--- a/src/domain/wasm-worker-protocol.ts
+++ b/src/domain/wasm-worker-protocol.ts
@@ -64,6 +64,8 @@ export interface SerializedExtractorOutput {
   }>;
   fnRefBindings?: import('../types.js').FnRefBinding[];
   newExpressions?: readonly string[];
+  /** Serialized definePropertyReceivers map (funcName → receiverVarName) as tuple array. */
+  definePropertyReceivers?: Array<[string, string]>;
 }
 
 export interface WorkerParseResponseOk {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1461,6 +1461,12 @@ function extractDefinePropertyReceiversWalk(
                     val?.type === 'identifier' &&
                     !BUILTIN_GLOBALS.has(val.text)
                   ) {
+                    // Known limitation: if the same function is registered as an
+                    // accessor on multiple objects, last-write-wins — only the
+                    // last target object is retained. This is an unusual pattern
+                    // (sharing one function across multiple defineProperty calls)
+                    // and covering it would require Map<string, string[]> which
+                    // changes the consumer API. Tracked as a known edge case.
                     out.set(val.text, targetName);
                   }
                 }
@@ -1471,7 +1477,8 @@ function extractDefinePropertyReceiversWalk(
       }
     }
     for (let i = 0; i < node.childCount; i++) {
-      walk(node.child(i)!, depth + 1);
+      const child = node.child(i);
+      if (child) walk(child, depth + 1);
     }
   }
   walk(rootNode, 0);

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -358,6 +358,10 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
   const newExpressions: string[] = [];
   extractNewExpressionsWalk(tree.rootNode, newExpressions);
 
+  // Object.defineProperty accessor receiver bindings
+  const definePropertyReceivers: Map<string, string> = new Map();
+  extractDefinePropertyReceiversWalk(tree.rootNode, definePropertyReceivers);
+
   return {
     definitions,
     calls,
@@ -370,6 +374,7 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
     fnRefBindings,
     paramBindings,
     newExpressions,
+    ...(definePropertyReceivers.size > 0 ? { definePropertyReceivers } : {}),
   };
 }
 
@@ -623,6 +628,10 @@ function extractSymbolsWalk(tree: TreeSitterTree): ExtractorOutput {
   const newExpressions: string[] = [];
   extractNewExpressionsWalk(tree.rootNode, newExpressions);
   ctx.newExpressions = newExpressions;
+  // Object.defineProperty accessor receiver bindings
+  const definePropertyReceivers: Map<string, string> = new Map();
+  extractDefinePropertyReceiversWalk(tree.rootNode, definePropertyReceivers);
+  if (definePropertyReceivers.size > 0) ctx.definePropertyReceivers = definePropertyReceivers;
   return ctx;
 }
 
@@ -1394,6 +1403,72 @@ function extractNewExpressionsWalk(rootNode: TreeSitterNode, newExpressions: str
     if (node.type === 'new_expression') {
       const name = extractNewExprTypeName(node);
       if (name) newExpressions.push(name);
+    }
+    for (let i = 0; i < node.childCount; i++) {
+      walk(node.child(i)!, depth + 1);
+    }
+  }
+  walk(rootNode, 0);
+}
+
+/**
+ * Walk the AST to find `Object.defineProperty(obj, "bar", { get: getter })` patterns
+ * and record which functions are used as getter/setter accessors for which objects.
+ *
+ * Result is stored in the provided map as `funcName → receiverVarName`.
+ */
+function extractDefinePropertyReceiversWalk(
+  rootNode: TreeSitterNode,
+  out: Map<string, string>,
+): void {
+  function walk(node: TreeSitterNode, depth: number): void {
+    if (depth >= MAX_WALK_DEPTH) return;
+    if (node.type === 'call_expression') {
+      const fn = node.childForFieldName('function');
+      // Match `Object.defineProperty`
+      if (fn?.type === 'member_expression') {
+        const obj = fn.childForFieldName('object');
+        const prop = fn.childForFieldName('property');
+        if (
+          obj?.type === 'identifier' &&
+          obj.text === 'Object' &&
+          prop?.text === 'defineProperty'
+        ) {
+          const argsNode = node.childForFieldName('arguments') ?? findChild(node, 'arguments');
+          if (argsNode) {
+            // Collect non-punctuation children: arg0 (target obj), arg1 (prop name string), arg2 (descriptor)
+            const argChildren: TreeSitterNode[] = [];
+            for (let i = 0; i < argsNode.childCount; i++) {
+              const c = argsNode.child(i);
+              if (!c) continue;
+              if (c.type === ',' || c.type === '(' || c.type === ')') continue;
+              argChildren.push(c);
+            }
+            if (argChildren.length >= 3) {
+              const targetObj = argChildren[0];
+              const descriptor = argChildren[2];
+              if (targetObj?.type === 'identifier' && descriptor?.type === 'object') {
+                const targetName = targetObj.text;
+                // Walk the descriptor object's pair children looking for get/set
+                for (let i = 0; i < descriptor.childCount; i++) {
+                  const pair = descriptor.child(i);
+                  if (pair?.type !== 'pair') continue;
+                  const key = pair.childForFieldName('key');
+                  const val = pair.childForFieldName('value');
+                  if (
+                    key &&
+                    (key.text === 'get' || key.text === 'set') &&
+                    val?.type === 'identifier' &&
+                    !BUILTIN_GLOBALS.has(val.text)
+                  ) {
+                    out.set(val.text, targetName);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
     for (let i = 0; i < node.childCount; i++) {
       walk(node.child(i)!, depth + 1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -601,6 +601,16 @@ export interface ExtractorOutput {
    * project-wide instantiated-types set for Rapid Type Analysis filtering.
    */
   newExpressions?: readonly string[];
+  /**
+   * Object.defineProperty receiver bindings: maps function name → target object name.
+   * Records `Object.defineProperty(obj, "bar", { get: getter })` so the edge builder
+   * can resolve `this.X()` calls inside `getter` as `obj.X()` (this === obj when the
+   * accessor is invoked through the property).
+   *
+   * Example: `Object.defineProperty(obj, "bar", { get: getter })` emits
+   * `definePropertyReceivers.set("getter", "obj")`.
+   */
+  definePropertyReceivers?: Map<string, string>;
   /** WASM tree retained for downstream analysis (complexity, CFG, dataflow). */
   _tree?: TreeSitterTree;
   /** Language identifier. */

--- a/tests/benchmarks/resolution/fixtures/javascript/define-property.js
+++ b/tests/benchmarks/resolution/fixtures/javascript/define-property.js
@@ -30,3 +30,18 @@ function create() {
   obj.f1();
   obj.f2();
 }
+
+// Object.defineProperty accessor this-dispatch:
+// When getter is registered as a get accessor for accessorTarget, `this` inside getter
+// refers to accessorTarget. So this.baz() → accessorTarget.baz → baz.
+function baz() {
+  return 42;
+}
+
+const accessorTarget = { baz };
+
+function getter() {
+  this.baz();
+}
+
+Object.defineProperty(accessorTarget, 'bar', { get: getter });

--- a/tests/benchmarks/resolution/fixtures/javascript/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/javascript/expected-edges.json
@@ -165,6 +165,13 @@
       "notes": "obj.f2() — resolved via Object.create({ f1, f2 })"
     },
     {
+      "source": { "name": "getter", "file": "define-property.js" },
+      "target": { "name": "baz", "file": "define-property.js" },
+      "kind": "calls",
+      "mode": "define-property",
+      "notes": "this.baz() inside getter — this === accessorTarget (registered via Object.defineProperty)"
+    },
+    {
       "source": { "name": "runBind", "file": "bind-call-apply.js" },
       "target": { "name": "greet", "file": "bind-call-apply.js" },
       "kind": "calls",

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -93,6 +93,7 @@ const TECHNIQUE_MAP: Record<string, string> = {
   'points-to': 'points-to',
   'pts-define-property': 'points-to',
   'pts-create-prototype': 'points-to',
+  'define-property': 'ts-native',
 };
 
 // ── Configuration ────────────────────────────────────────────────────────

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -119,6 +119,8 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   //   (5 new edges in define-property.js) + Phase 8.5 adds class-inheritance and prototype edges
   //   (inheritance.js, prototypes.js, prototypes2.js), lifting total expected to 30. Phase 8.3f
   //   adds bind/call/apply resolution (3 new edges in bind-call-apply.js), total expected now 33.
+  //   Phase 8.3g adds Object.defineProperty accessor this-dispatch (1 new edge in define-property.js),
+  //   total expected now 34.
   javascript: { precision: 1.0, recall: 0.9 },
   // TS 0.72: Phase 8.3e adds this.method() same-class resolution (Shape.describe → Shape.area),
   //   lifting recall from 69.4% to 72.2%.  Remaining gap (interface-dispatch, CHA) is tracked


### PR DESCRIPTION
## Summary

- Extracts `Object.defineProperty(obj, "bar", { get: getter })` patterns during AST walking, recording that `getter` has `obj` as its `this` receiver
- In `buildFileCallEdges` (WASM path): when `this.method()` has no targets and the caller function is a defineProperty-registered accessor, resolves through the receiver object
- In `buildDefinePropertyPostPass` (native path): post-pass that adds the same edges for the Rust engine
- Wires `definePropertyReceivers` through the WASM worker protocol (`SerializedExtractorOutput`) so it survives the worker-thread boundary
- Adds `getter → baz` test edge to the JS benchmark fixture via the `define-property` mode

Closes #1335

## Test evidence

Resolution benchmark: `define-property: 1/1 (100% recall)` — `getter → baz` now resolves via `this.baz()` with `this === accessorTarget`

All 171 benchmark tests pass.