### PR TITLE
fix(wasm-worker): wire paramBindings, returnTypeMap, callAssignments through worker boundary

### DIFF
--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -806,6 +806,11 @@ function serializeExtractorOutput(
     astNodes,
     ...(symbols.fnRefBindings?.length ? { fnRefBindings: symbols.fnRefBindings } : {}),
     ...(symbols.newExpressions?.length ? { newExpressions: symbols.newExpressions } : {}),
+    ...(symbols.returnTypeMap?.size
+      ? { returnTypeMap: Array.from(symbols.returnTypeMap.entries()) }
+      : {}),
+    ...(symbols.callAssignments?.length ? { callAssignments: symbols.callAssignments } : {}),
+    ...(symbols.paramBindings?.length ? { paramBindings: symbols.paramBindings } : {}),
   };
 }
 

--- a/src/domain/wasm-worker-pool.ts
+++ b/src/domain/wasm-worker-pool.ts
@@ -108,6 +108,13 @@ function deserializeResult(ser: SerializedExtractorOutput | null): ExtractorOutp
   if (ser.astNodes !== undefined) out.astNodes = ser.astNodes as unknown as ASTNodeRow[];
   if (ser.fnRefBindings?.length) out.fnRefBindings = ser.fnRefBindings;
   if (ser.newExpressions?.length) out.newExpressions = ser.newExpressions;
+  if (ser.returnTypeMap?.length) {
+    const returnTypeMap = new Map<string, TypeMapEntry>();
+    for (const [k, v] of ser.returnTypeMap) returnTypeMap.set(k, v);
+    out.returnTypeMap = returnTypeMap;
+  }
+  if (ser.callAssignments?.length) out.callAssignments = ser.callAssignments;
+  if (ser.paramBindings?.length) out.paramBindings = ser.paramBindings;
   return out;
 }
 

--- a/src/domain/wasm-worker-protocol.ts
+++ b/src/domain/wasm-worker-protocol.ts
@@ -12,12 +12,14 @@
 
 import type {
   Call,
+  CallAssignment,
   ClassRelation,
   DataflowResult,
   Definition,
   Export,
   Import,
   LanguageId,
+  ParamBinding,
   TypeMapEntry,
 } from '../types.js';
 
@@ -64,6 +66,9 @@ export interface SerializedExtractorOutput {
   }>;
   fnRefBindings?: import('../types.js').FnRefBinding[];
   newExpressions?: readonly string[];
+  returnTypeMap?: Array<[string, TypeMapEntry]>;
+  callAssignments?: CallAssignment[];
+  paramBindings?: ParamBinding[];
 }
 
 export interface WorkerParseResponseOk {


### PR DESCRIPTION
## Summary

- `SerializedExtractorOutput` in `wasm-worker-protocol.ts` was missing `paramBindings`, `returnTypeMap`, and `callAssignments` — three fields the JS/TS extractor populates but that were silently dropped at the Worker thread boundary
- Added all three to `SerializedExtractorOutput` (with `returnTypeMap` encoded as `Array<[string, TypeMapEntry]>` tuples, matching the existing `typeMap` pattern)
- Wired them through `serializeExtractorOutput` in `wasm-worker-entry.ts` and `deserializeResult` in `wasm-worker-pool.ts`

Closes #1348