### PR TITLE
docs(CLAUDE.md): update language count from 23 to 34

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Skip the above commands for non-code files, trivial edits, or when you already h
 
 Codegraph (`@optave/codegraph`) is a local code dependency graph CLI. It parses codebases with tree-sitter (WASM), builds function-level dependency graphs stored in SQLite, and supports semantic search with local embeddings. No cloud services required.
 
-**Languages supported (23):** JavaScript, TypeScript, TSX, Python, Go, Rust, Java, C#, Ruby, PHP, C, C++, Kotlin, Swift, Scala, Bash, Elixir, Lua, Dart, Zig, Haskell, OCaml, Terraform/HCL. `LANGUAGE_REGISTRY` in `domain/parser.ts` is the single source of truth — check there for the current list.
+**Languages supported (34):** JavaScript, TypeScript, TSX, Python, Go, Rust, Java, C#, Ruby, PHP, C, C++, Kotlin, Swift, Scala, Bash, Elixir, Lua, Dart, Zig, Haskell, OCaml, F#, Terraform/HCL, Gleam, Clojure, Julia, R, Erlang, Solidity, Objective-C, CUDA, Groovy, Verilog. `LANGUAGE_REGISTRY` in `domain/parser.ts` is the single source of truth — check there for the current list.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Updates the "Languages supported" count from 23 → 34
- Adds the 11 languages added since the original doc was written: F#, Gleam, Clojure, Julia, R, Erlang, Solidity, Objective-C, CUDA, Groovy, Verilog
- Count derived from `LANGUAGE_REGISTRY` in `src/domain/parser.ts` (36 entries, minus `ocaml-interface` and `fsharp-signature` which are file-format variants of OCaml and F#)

Closes #1342