### PR TITLE
fix(parity): resolve C# static receiver calls in WASM engine (#1372)

### DIFF
--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -124,6 +124,17 @@ export function resolveByMethodOrGlobal(
         .filter((t) => computeConfidence(relPath, t.file, null) >= 0.5);
       if (resolved.length > 0) return resolved;
     }
+
+    // Static receiver fallback: treat receiver as a direct class/struct name.
+    // Handles `Validators.IsValidEmail(...)` in C# where `Validators` is a static class —
+    // it never appears in a variable declaration, so typeMap has no entry for it, but the
+    // method `Validators.IsValidEmail` exists in the symbol DB under its full qualified name.
+    if (!typeName) {
+      const staticCandidates = lookup
+        .byName(`${call.receiver}.${call.name}`)
+        .filter((n) => n.kind === 'method');
+      if (staticCandidates.length > 0) return staticCandidates;
+    }
   }
   if (
     !call.receiver ||

--- a/tests/integration/issue-1372-csharp-static-receiver.test.ts
+++ b/tests/integration/issue-1372-csharp-static-receiver.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression test for #1372 — WASM engine missing C# static receiver call edges.
+ *
+ * The gap: the WASM resolver had no fallback for calls where the receiver is a
+ * class name used directly (e.g. `Validators.IsValidEmail(...)`).  The class name
+ * is never assigned to a local variable, so it has no typeMap entry, and the old
+ * code returned empty.  The fix adds a fallback that treats the receiver as a
+ * potential class name and looks up `Receiver.Method` directly in the symbol DB.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+// ── Fixture ──────────────────────────────────────────────────────────────────
+
+const FILES: Record<string, string> = {
+  // Static class with two public methods.
+  'Validators.cs': `
+namespace Demo;
+public static class Validators {
+  public static bool IsValidEmail(string email) {
+    return email.Contains("@");
+  }
+  public static bool IsValidName(string name) {
+    return name.Length >= 2;
+  }
+}
+`,
+  // Caller class that references Validators via explicit static receiver.
+  'Program.cs': `
+namespace Demo;
+public class Program {
+  public static void Main() {
+    bool ok = Validators.IsValidEmail("a@b.com");
+  }
+  public static void Run() {
+    bool ok2 = Validators.IsValidName("Alice");
+  }
+}
+`,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    fs.writeFileSync(path.join(dir, rel), content.trimStart());
+  }
+}
+
+function readEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n2.name AS tgt, e.kind
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as Array<{ src: string; tgt: string; kind: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('C# static receiver call resolution (#1372)', () => {
+  let tmpDir: string;
+  let edges: Array<{ src: string; tgt: string; kind: string }>;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-1372-'));
+    writeFixture(tmpDir);
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+    edges = readEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+  }, 60_000);
+
+  afterAll(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves static receiver call: Program.Main → Validators.IsValidEmail', () => {
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        src: 'Program.Main',
+        tgt: 'Validators.IsValidEmail',
+        kind: 'calls',
+      }),
+    );
+  });
+
+  it('resolves static receiver call: Program.Run → Validators.IsValidName', () => {
+    expect(edges).toContainEqual(
+      expect.objectContaining({ src: 'Program.Run', tgt: 'Validators.IsValidName', kind: 'calls' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause:** `resolveByMethodOrGlobal` had no fallback for calls where the receiver is a class name used directly (e.g. `Validators.IsValidEmail(...)`). Static class names never appear in variable declarations, so `typeMap` has no entry for them. The code fell through and returned an empty target set.
- **Fix:** After all typeMap and pts-key lookups fail, if `typeName` is still null, try `${receiver}.${callName}` directly in the symbol DB with a `kind='method'` filter. This is the static dispatch path — the receiver IS the class name, so the qualified method name is exactly what the DB holds.
- **Regression test:** `tests/integration/issue-1372-csharp-static-receiver.test.ts` — builds a two-file C# fixture with WASM and asserts the two static receiver edges are produced.
- **Parity test:** `tests/integration/build-parity.test.ts` for the `csharp Repository` fixture now passes all 8 assertions.

## Edges fixed

| Caller | Callee | Type |
|--------|--------|------|
| `Program.Main` | `Validators.IsValidEmail` | static receiver |
| `Program.RunWithValidation` | `Validators.ValidateUser` | static receiver |
| `UserService.AddUser` | `Validators.ValidateUser` | static receiver |

## Test plan

- [x] `npx vitest run tests/integration/issue-1372-csharp-static-receiver.test.ts` — 2 new tests pass
- [x] `npx vitest run tests/integration/build-parity.test.ts` — all 8 assertions pass (was 2 failures before)
- [x] `npx vitest run` — 3 pre-existing prototype failures (tracked in #1361), no new failures
- [x] `npm run lint` — no errors

Closes #1372