### PR TITLE
fix(native): promote this-dispatch scope tests from todo to active

### DIFF
--- a/tests/integration/this-dispatch-scope.test.ts
+++ b/tests/integration/this-dispatch-scope.test.ts
@@ -72,47 +72,36 @@ describe.each(ENGINES)('this-dispatch scope (%s)', (engine) => {
     ).toBeDefined();
   });
 
-  // Native binary v3.11.2 does not include the edge_builder.rs fix for issue #1324 yet.
-  // These assertions are active for WASM and will be re-enabled for native once a new
-  // binary is published that includes the Rust fix.
-  if (engine === 'native') {
-    it.todo('does NOT emit Shape.describe → Calculator.area (native binary gap #1324)');
-    it.todo('does NOT emit Shape.describe → Formatter.area (native binary gap #1324)');
-    it.todo(
-      'does NOT emit Caller.run → Sibling.area (single-match false-positive, native binary gap #1324)',
+  it('does NOT emit Shape.describe → Calculator.area (unrelated class, same method name)', () => {
+    const edge = callEdges.find(
+      (e) => e.caller_name === 'Shape.describe' && e.callee_name === 'Calculator.area',
     );
-  } else {
-    it('does NOT emit Shape.describe → Calculator.area (unrelated class, same method name)', () => {
-      const edge = callEdges.find(
-        (e) => e.caller_name === 'Shape.describe' && e.callee_name === 'Calculator.area',
-      );
-      expect(
-        edge,
-        `Expected NO Shape.describe → Calculator.area edge (false-positive from same-file scan).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
-      ).toBeUndefined();
-    });
+    expect(
+      edge,
+      `Expected NO Shape.describe → Calculator.area edge (false-positive from same-file scan).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeUndefined();
+  });
 
-    it('does NOT emit Shape.describe → Formatter.area (unrelated class, same method name)', () => {
-      const edge = callEdges.find(
-        (e) => e.caller_name === 'Shape.describe' && e.callee_name === 'Formatter.area',
-      );
-      expect(
-        edge,
-        `Expected NO Shape.describe → Formatter.area edge (false-positive from same-file scan).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
-      ).toBeUndefined();
-    });
+  it('does NOT emit Shape.describe → Formatter.area (unrelated class, same method name)', () => {
+    const edge = callEdges.find(
+      (e) => e.caller_name === 'Shape.describe' && e.callee_name === 'Formatter.area',
+    );
+    expect(
+      edge,
+      `Expected NO Shape.describe → Formatter.area edge (false-positive from same-file scan).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeUndefined();
+  });
 
-    // single-sibling.ts: only one class (Sibling) has area(); Caller does not.
-    // The single-match arm must still check the caller's own class — Caller.run
-    // must not gain a false edge to Sibling.area.
-    it('does NOT emit Caller.run → Sibling.area (single-match false-positive, same-file scan)', () => {
-      const edge = callEdges.find(
-        (e) => e.caller_name === 'Caller.run' && e.callee_name === 'Sibling.area',
-      );
-      expect(
-        edge,
-        `Expected NO Caller.run → Sibling.area edge (false-positive from single-match suffix scan).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
-      ).toBeUndefined();
-    });
-  }
+  // single-sibling.ts: only one class (Sibling) has area(); Caller does not.
+  // The single-match arm must still check the caller's own class — Caller.run
+  // must not gain a false edge to Sibling.area.
+  it('does NOT emit Caller.run → Sibling.area (single-match false-positive, same-file scan)', () => {
+    const edge = callEdges.find(
+      (e) => e.caller_name === 'Caller.run' && e.callee_name === 'Sibling.area',
+    );
+    expect(
+      edge,
+      `Expected NO Caller.run → Sibling.area edge (false-positive from single-match suffix scan).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeUndefined();
+  });
 });

--- a/tests/search/embedding-regression.test.ts
+++ b/tests/search/embedding-regression.test.ts
@@ -68,9 +68,12 @@ describe.skipIf(!hasTransformers)('embedding regression (real model)', () => {
     dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
 
     // Build embeddings with the smallest/fastest model.
-    // Skip gracefully when HuggingFace rate-limits the model download (HTTP 429)
-    // or when the network is unavailable (ECONNRESET, ETIMEDOUT, ENOTFOUND,
-    // ECONNREFUSED, ERR_HTTP2_STREAM_CANCEL, ERR_HTTP2_SESSION_ERROR).
+    // Skip gracefully when HuggingFace rate-limits the model download (HTTP 429),
+    // when the network is unavailable (ECONNRESET, ETIMEDOUT, ENOTFOUND,
+    // ECONNREFUSED, ERR_HTTP2_STREAM_CANCEL, ERR_HTTP2_SESSION_ERROR), or when
+    // HF's fetch layer times out. buildEmbeddings wraps HF failures as EngineError
+    // (code: ENGINE_UNAVAILABLE), losing the original errno, so we also match the
+    // "timeout" substring from HF's "Request timeout error occurred" message.
     try {
       await buildEmbeddings(tmpDir, 'minilm', dbPath);
     } catch (err: unknown) {
@@ -78,6 +81,7 @@ describe.skipIf(!hasTransformers)('embedding regression (real model)', () => {
       const code = (err as NodeJS.ErrnoException).code ?? '';
       const isNetworkError =
         msg.includes('429') ||
+        msg.toLowerCase().includes('timeout') ||
         code === 'ECONNRESET' ||
         code === 'ETIMEDOUT' ||
         code === 'ENOTFOUND' ||


### PR DESCRIPTION
## Summary

- Removes the `if (engine === 'native')` guard that was skipping three negative assertions with `.todo` in `this-dispatch-scope.test.ts`
- The class-scoped this-dispatch fix landed in `edge_builder.rs` in #1343 (commit `16af0e0`), and the prototype extraction was added to the Rust extractor before v3.11.2; CI compiles the native addon from source on every PR so the binary used in tests already includes both fixes
- All four assertions now run for both `wasm` and `native` engines

Closes #1413