### PR TITLE
fix(resolver): apply confidence filter to static receiver fallback

### DIFF
--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -106,7 +106,9 @@ export function resolveByMethodOrGlobal(
     }
 
     if (typeName) {
-      const typed = lookup.byName(`${typeName}.${call.name}`).filter((n) => n.kind === 'method');
+      const typed = lookup
+        .byName(`${typeName}.${call.name}`)
+        .filter((n) => n.kind === 'method' && computeConfidence(relPath, n.file, null) >= 0.5);
       if (typed.length > 0) return typed;
 
       // Prototype alias: `Foo.prototype.bar = identifier` seeds typeMap['Foo.bar'] = { type: identifier }.

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -133,7 +133,11 @@ export function resolveByMethodOrGlobal(
       const qualifiedName = `${effectiveReceiver}.${call.name}`;
       const direct = lookup
         .byName(qualifiedName)
-        .filter((n) => n.kind === 'method' || n.kind === 'function');
+        .filter(
+          (n) =>
+            (n.kind === 'method' || n.kind === 'function') &&
+            computeConfidence(relPath, n.file, null) >= 0.5,
+        );
       if (direct.length > 0) return direct;
     }
 

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -118,3 +118,31 @@ describe('resolveByMethodOrGlobal — static receiver confidence filter (#1398)'
     expect(result).toEqual([]);
   });
 });
+
+describe('resolveByMethodOrGlobal — typeName branch confidence filter (#1398)', () => {
+  it('returns same-directory typed method target (confidence 0.7 >= 0.5)', () => {
+    const target = { id: 3, file: 'app/Foo.cs', kind: 'method' };
+    const lookup = makeLookup({ 'Foo.bar': [target] });
+    // typeMap entry: 'f' -> 'Foo' (e.g. from `let f = new Foo()`)
+    const result = resolveByMethodOrGlobal(
+      lookup,
+      { name: 'bar', receiver: 'f' },
+      'app/Main.cs',
+      new Map([['f', 'Foo']]),
+    );
+    expect(result).toEqual([target]);
+  });
+
+  it('filters out distant typed method target (confidence 0.3 < 0.5)', () => {
+    const target = { id: 4, file: 'lib/util/Foo.cs', kind: 'method' };
+    const lookup = makeLookup({ 'Foo.bar': [target] });
+    // typeMap entry: 'f' -> 'Foo' — but the definition lives in a distant subtree
+    const result = resolveByMethodOrGlobal(
+      lookup,
+      { name: 'bar', receiver: 'f' },
+      'app/main/Main.cs',
+      new Map([['f', 'Foo']]),
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -5,6 +5,10 @@
  * one dot segment (e.g. 'Namespace.ClassName.method'), the same-class dispatch
  * must use only the segment immediately before the method name ('ClassName'),
  * not the full qualified prefix ('Namespace.ClassName').
+ *
+ * Also covers the static receiver confidence filter (#1398): the direct qualified
+ * method fallback must apply computeConfidence >= 0.5 to avoid false edges from
+ * distant files in a polyglot project.
  */
 import { describe, expect, it } from 'vitest';
 import type { CallNodeLookup } from '../../src/domain/graph/builder/call-resolver.js';
@@ -85,6 +89,32 @@ describe('resolveByMethodOrGlobal — same-class this-dispatch with qualified ca
       'Namespace.Shape.describe',
     );
     // callerClass should be 'Shape', so 'Shape.area' is tried — which is absent.
+    expect(result).toEqual([]);
+  });
+});
+
+describe('resolveByMethodOrGlobal — static receiver confidence filter (#1398)', () => {
+  it('returns same-directory static target (confidence 0.7 >= 0.5)', () => {
+    const target = { id: 1, file: 'app/Validators.cs', kind: 'method' };
+    const lookup = makeLookup({ 'Validators.IsValidEmail': [target] });
+    const result = resolveByMethodOrGlobal(
+      lookup,
+      { name: 'IsValidEmail', receiver: 'Validators' },
+      'app/Program.cs',
+      new Map(),
+    );
+    expect(result).toEqual([target]);
+  });
+
+  it('filters out distant static target (confidence 0.3 < 0.5)', () => {
+    const target = { id: 2, file: 'lib/util/Validators.cs', kind: 'method' };
+    const lookup = makeLookup({ 'Validators.IsValidEmail': [target] });
+    const result = resolveByMethodOrGlobal(
+      lookup,
+      { name: 'IsValidEmail', receiver: 'Validators' },
+      'app/main/Program.cs',
+      new Map(),
+    );
     expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- The typed-method lookup in `resolveByMethodOrGlobal` (`if (typeName)` branch, `call-resolver.ts`) was the only `byName` call in the function that did not apply `computeConfidence(relPath, n.file, null) >= 0.5`, leaving it open to false-positive edges from distant files in polyglot projects where two unrelated classes share a method name
- Added the same `computeConfidence(relPath, n.file, null) >= 0.5` guard that every other `byName` call in the function already applies; all resolution paths in `resolveByMethodOrGlobal` are now consistently guarded
- Added unit tests covering the two confidence cases: same-directory target (0.7, passes) and distant target (0.3, filtered)

Closes #1398

## Test plan

- [ ] `npx vitest run tests/unit/call-resolver.test.ts` — 12 tests pass
- [ ] `npx vitest run tests/integration/issue-1372-csharp-static-receiver.test.ts` — 2 tests pass (same-dir cross-file static calls unaffected, confidence 0.7)
- [ ] `npx vitest run tests/benchmarks/resolution/resolution-benchmark.test.ts` — benchmark suite passes (C# benchmark all 3 static edges preserved)