### PR TITLE
fix(hooks): fall back to git root when CLAUDE_PROJECT_DIR points to wrong directory

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,32 +9,32 @@
         "hooks": [
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/check-readme.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/check-readme.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/guard-git.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/guard-git.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/guard-pr-body.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/guard-pr-body.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/commitlint-local.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/commitlint-local.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/pre-commit.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/pre-commit.sh\"",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/lint-staged.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/lint-staged.sh\"",
             "timeout": 15
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/enrich-context.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/enrich-context.sh\"",
             "timeout": 10
           }
         ]
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/enrich-context.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/enrich-context.sh\"",
             "timeout": 10
           }
         ]
@@ -66,12 +66,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/update-graph.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/update-graph.sh\"",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/track-edits.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/track-edits.sh\"",
             "timeout": 5
           }
         ]
@@ -81,12 +81,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/track-moves.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/track-moves.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/post-git-ops.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; [ -n \"$p\" ] || exit 0; bash \"$p/.claude/hooks/post-git-ops.sh\"",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,32 +9,32 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-readme.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/check-readme.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-git.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/guard-git.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-pr-body.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/guard-pr-body.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/commitlint-local.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/commitlint-local.sh\"",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/pre-commit.sh\"",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/lint-staged.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/lint-staged.sh\"",
             "timeout": 15
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/enrich-context.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/enrich-context.sh\"",
             "timeout": 10
           }
         ]
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/enrich-context.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/enrich-context.sh\"",
             "timeout": 10
           }
         ]
@@ -66,12 +66,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/update-graph.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/update-graph.sh\"",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/track-edits.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/track-edits.sh\"",
             "timeout": 5
           }
         ]
@@ -81,12 +81,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/track-moves.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/track-moves.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-git-ops.sh\"",
+            "command": "p=\"${CLAUDE_PROJECT_DIR}\"; [ -d \"$p/.claude/hooks\" ] || p=\"$(git rev-parse --show-toplevel 2>/dev/null)\"; bash \"$p/.claude/hooks/post-git-ops.sh\"",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
## Summary

- Hook commands were failing with `No such file or directory` errors whenever `$CLAUDE_PROJECT_DIR` was set to a parent directory (e.g. `~/Documents/GitHub` instead of `~/Documents/GitHub/codegraph`)
- This happens when Claude Code is opened with a workspace rooted above the repo, causing every tool use to produce non-blocking hook errors
- Each hook command now validates `$CLAUDE_PROJECT_DIR/.claude/hooks` exists before using it, falling back to `git rev-parse --show-toplevel` if not

## Test plan

- [ ] Open Claude Code from a parent directory (e.g. `~/Documents/GitHub`) with codegraph as a subdirectory — hook errors should no longer appear
- [ ] Open Claude Code normally from the `codegraph` project root — hooks continue to work as before
- [ ] Use a git worktree — hooks resolve correctly via the fallback