### PR TITLE
ci: pin windows runner to windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     name: Native host build (${{ matrix.os }})
     steps:
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         node-version: [22]
 
     runs-on: ${{ matrix.os }}
@@ -215,7 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
 
     runs-on: ${{ matrix.os }}
     name: Engine parity (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-2022]  # pinned: node-gyp cannot detect VS2026 on windows-latest; revert once node-gyp supports VS ≥ 18
     runs-on: ${{ matrix.os }}
     name: Native host build (${{ matrix.os }})
     steps:
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-2022]  # pinned: node-gyp cannot detect VS2026 on windows-latest; revert once node-gyp supports VS ≥ 18
         node-version: [22]
 
     runs-on: ${{ matrix.os }}
@@ -215,7 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-2022]  # pinned: node-gyp cannot detect VS2026 on windows-latest; revert once node-gyp supports VS ≥ 18
 
     runs-on: ${{ matrix.os }}
     name: Engine parity (${{ matrix.os }})


### PR DESCRIPTION
The `windows-latest` runner image began shipping Visual Studio 2026 (version 18) on 2026-06-10. node-gyp only knows VS versions up to 2022 (version 17) and fails to detect VS on the new image, causing `npm install` to fail when building the `tree-sitter-erlang` git dependency.

Pin all three Windows matrix jobs (`native-host-build`, `test`, `parity`) to `windows-2022` which ships VS2022 and is fully supported by node-gyp.

Fixes the `Test Node 22 (windows-latest)`, `Engine parity (windows-latest)`, and `CI Testing Pipeline` check failures currently affecting all open PRs.