### PR TITLE
fix(native): extract func-prop methods in Rust and cut native build post-pass costs

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -633,6 +633,37 @@ fn handle_js_prototype_assignment(lhs: &Node, rhs: &Node, source: &[u8], symbols
         && rhs.kind() == "object"
     {
         extract_js_prototype_object_literal(node_text(&lhs_obj, source), rhs, source, symbols);
+        return;
+    }
+
+    // Pattern 3: `fn.method = function(){}` / `fn.method = () => {}` — function-as-
+    // object-property method definitions (#1432). Mirrors `handleFuncPropAssignment`
+    // in src/extractors/javascript.ts: bare-identifier receiver that is not a builtin
+    // global, property other than `prototype`, RHS a function or arrow. Emitting these
+    // natively lets the Rust edge builder resolve `obj.method()` call sites in-build
+    // (via the direct qualified lookup) and removes the WASM re-parse post-pass that
+    // previously backfilled them on every native build.
+    if lhs_obj.kind() == "identifier"
+        && matches!(lhs_prop.kind(), "property_identifier" | "identifier")
+        && node_text(&lhs_prop, source) != "prototype"
+        && !is_js_builtin_global(node_text(&lhs_obj, source))
+        && matches!(rhs.kind(), "function_expression" | "arrow_function")
+    {
+        let children = extract_js_parameters(rhs, source);
+        symbols.definitions.push(Definition {
+            name: format!(
+                "{}.{}",
+                node_text(&lhs_obj, source),
+                node_text(&lhs_prop, source)
+            ),
+            kind: "method".to_string(),
+            line: start_line(rhs),
+            end_line: Some(end_line(rhs)),
+            decorators: None,
+            complexity: compute_all_metrics(rhs, source, "javascript"),
+            cfg: build_function_cfg(rhs, "javascript", source),
+            children: opt_children(children),
+        });
     }
 }
 
@@ -2911,6 +2942,82 @@ mod tests {
             children.iter().any(|c| c.name == "y"),
             "C.foo should have parameter 'y'; got: {:?}", children
         );
+    }
+
+    // ── Function-as-object-property extraction (#1432) ─────────────────────
+    // Mirrors `handleFuncPropAssignment` in src/extractors/javascript.ts.
+
+    #[test]
+    fn func_prop_function_emits_method_definition() {
+        let s = parse_js(
+            "function f() {}\n\
+             f.g = function() { return 1; };",
+        );
+        let def = s.definitions.iter().find(|d| d.name == "f.g");
+        assert!(def.is_some(), "f.g definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
+        let def = def.unwrap();
+        assert_eq!(def.kind, "method");
+        assert!(def.complexity.is_some(), "f.g should have complexity metrics");
+        assert!(def.cfg.is_some(), "f.g should have a CFG");
+    }
+
+    #[test]
+    fn func_prop_arrow_emits_method_definition() {
+        let s = parse_js(
+            "function f() {}\n\
+             f.g = (x) => x + 1;",
+        );
+        let def = s.definitions.iter().find(|d| d.name == "f.g");
+        assert!(def.is_some(), "f.g definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
+        assert_eq!(def.unwrap().kind, "method");
+    }
+
+    #[test]
+    fn func_prop_extracts_parameters_as_children() {
+        let s = parse_js(
+            "function f() {}\n\
+             f.process = function(a, b) { return a + b; };",
+        );
+        let def = s.definitions.iter().find(|d| d.name == "f.process").expect("f.process missing");
+        let children = def.children.as_deref().unwrap_or(&[]);
+        assert!(
+            children.iter().any(|c| c.name == "a"),
+            "f.process should have parameter 'a'; got: {:?}", children
+        );
+        assert!(
+            children.iter().any(|c| c.name == "b"),
+            "f.process should have parameter 'b'; got: {:?}", children
+        );
+    }
+
+    #[test]
+    fn func_prop_builtin_globals_are_excluded() {
+        let s = parse_js("console.log = function() {};");
+        let def = s.definitions.iter().find(|d| d.name == "console.log");
+        assert!(def.is_none(), "built-in global func-prop assignment should be ignored; got: {:?}", def);
+    }
+
+    #[test]
+    fn func_prop_nested_member_receiver_is_skipped() {
+        // Only bare-identifier receivers qualify — `a.b.c = fn` must not emit a
+        // definition (mirrors the `obj.type !== 'identifier'` guard in the WASM
+        // extractor).
+        let s = parse_js("const a = { b: {} };\na.b.c = function() {};");
+        let def = s.definitions.iter().find(|d| d.name.ends_with(".c"));
+        assert!(def.is_none(), "nested member receiver should be skipped; got: {:?}", def);
+    }
+
+    #[test]
+    fn func_prop_prototype_function_assignment_is_not_a_method() {
+        // `C.prototype = function(){}` matches neither the prototype object-literal
+        // pattern (rhs must be an object) nor the func-prop pattern (property must
+        // not be `prototype`). No definition should be emitted.
+        let s = parse_js(
+            "function C() {}\n\
+             C.prototype = function() {};",
+        );
+        let def = s.definitions.iter().find(|d| d.name == "C.prototype");
+        assert!(def.is_none(), "C.prototype function assignment should not emit a method; got: {:?}", def);
     }
 
     #[test]

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -720,6 +720,10 @@ async function runPostNativeThisDispatch(
     NATIVE_SUPPORTED_EXTENSIONS.has(path.extname(f).toLowerCase()),
   );
   const callsByRel = new Map<string, { name: string; receiver?: string; line: number }[]>();
+  // Track native-supported files that returned null (per-file parse error) so
+  // they can be included in the WASM fallback set below, ensuring no file's
+  // this/super call sites are silently discarded.
+  const nativeNullFiles = new Set<string>();
   let nativeParsed = false;
   if (nativeAbs.length > 0) {
     const native = loadNative();
@@ -729,8 +733,13 @@ async function runPostNativeThisDispatch(
           file: string;
           calls?: { name: string; receiver?: string; line: number }[];
         } | null>;
-        for (const r of results) {
-          if (!r) continue;
+        for (let i = 0; i < results.length; i++) {
+          const r = results[i];
+          if (!r) {
+            // Per-file parse failure — fall back to WASM for this file.
+            if (nativeAbs[i]) nativeNullFiles.add(nativeAbs[i]);
+            continue;
+          }
           callsByRel.set(normalizePath(path.relative(rootDir, r.file)), r.calls ?? []);
         }
         nativeParsed = true;
@@ -739,8 +748,14 @@ async function runPostNativeThisDispatch(
       }
     }
   }
+  // WASM handles: (a) non-native extensions (e.g. .mts/.cts), (b) the entire
+  // file list when the native batch threw, and (c) individual files where the
+  // native addon returned null (per-file parse error).
   const wasmAbs = nativeParsed
-    ? absFiles.filter((f) => !NATIVE_SUPPORTED_EXTENSIONS.has(path.extname(f).toLowerCase()))
+    ? [
+        ...absFiles.filter((f) => !NATIVE_SUPPORTED_EXTENSIONS.has(path.extname(f).toLowerCase())),
+        ...nativeNullFiles,
+      ]
     : absFiles;
   const wasmResults =
     wasmAbs.length > 0
@@ -1433,19 +1448,27 @@ export async function tryNativeOrchestrator(
   // major part of the v3.12.0 native full-build benchmark regression).
   if (chaEdgeCount > 0 || thisDispatchTargetIds.size > 0) {
     const affectedFiles = [...new Set([...chaAffectedFiles, ...thisDispatchAffectedFiles])];
-    if (affectedFiles.length > 0) {
-      try {
-        const { classifyNodeRoles } = (await import('../../../../features/structure.js')) as {
-          classifyNodeRoles: (
-            db: BetterSqlite3Database,
-            changedFiles?: string[] | null,
-          ) => Record<string, number>;
-        };
-        classifyNodeRoles(ctx.db as unknown as BetterSqlite3Database, affectedFiles);
-        debug(`Post-pass role re-classification complete (${affectedFiles.length} file(s))`);
-      } catch (err) {
-        debug(`Post-pass role re-classification failed: ${toErrorMessage(err)}`);
-      }
+    // When edges were inserted but all their endpoint nodes have null `file`
+    // columns (rare but possible), affectedFiles stays empty even though
+    // fan-in/out changed. Fall back to full-graph re-classification in that
+    // case — scoped classification with an empty set would be a no-op, leaving
+    // roles stale for those nodes.
+    const scopedFiles = affectedFiles.length > 0 ? affectedFiles : null;
+    try {
+      const { classifyNodeRoles } = (await import('../../../../features/structure.js')) as {
+        classifyNodeRoles: (
+          db: BetterSqlite3Database,
+          changedFiles?: string[] | null,
+        ) => Record<string, number>;
+      };
+      classifyNodeRoles(ctx.db as unknown as BetterSqlite3Database, scopedFiles);
+      debug(
+        scopedFiles
+          ? `Post-pass role re-classification complete (${scopedFiles.length} file(s))`
+          : 'Post-pass role re-classification complete (full graph — null-file endpoints)',
+      );
+    } catch (err) {
+      debug(`Post-pass role re-classification failed: ${toErrorMessage(err)}`);
     }
   }
 

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -43,7 +43,6 @@ import {
 } from '../../../parser.js';
 import { computeConfidence } from '../../resolve.js';
 import type { CallNodeLookup } from '../call-resolver.js';
-import { findCaller, resolveByMethodOrGlobal } from '../call-resolver.js';
 import type { ChaContext } from '../cha.js';
 import { resolveThisDispatch } from '../cha.js';
 import type { PipelineContext } from '../context.js';
@@ -402,16 +401,22 @@ async function runPostNativeAnalysis(
  * Note: `this`/`super` dispatch is handled separately by `runPostNativeThisDispatch`,
  * which WASM-re-parses JS/TS files to obtain raw call site receiver info.
  *
- * Returns the count of newly inserted CHA edges so the caller can determine
- * whether a full role re-classification is needed.  Zero means no edges were
- * added and role re-classification is unnecessary.
+ * Returns the count of newly inserted CHA edges plus the set of files containing
+ * the new edges' endpoints, so the caller can scope role re-classification to the
+ * nodes whose fan-in/out actually changed. A zero count means no edges were added
+ * and role re-classification is unnecessary.
  */
-function runPostNativeCha(db: BetterSqlite3Database): number {
+function runPostNativeCha(db: BetterSqlite3Database): {
+  newEdgeCount: number;
+  affectedFiles: Set<string>;
+} {
+  const affectedFiles = new Set<string>();
+  const empty = { newEdgeCount: 0, affectedFiles };
   // Fast guard: no hierarchy edges → no CHA work
   const hasHierarchy = db
     .prepare(`SELECT 1 FROM edges WHERE kind IN ('extends', 'implements') LIMIT 1`)
     .get();
-  if (!hasHierarchy) return 0;
+  if (!hasHierarchy) return empty;
 
   // Build implementors map: parent/interface name → [child/implementing class names]
   const hierarchyRows = db
@@ -433,7 +438,7 @@ function runPostNativeCha(db: BetterSqlite3Database): number {
     }
     if (!list.includes(row.child_name)) list.push(row.child_name);
   }
-  if (implementors.size === 0) return 0;
+  if (implementors.size === 0) return empty;
 
   // RTA: collect class names that are actually instantiated via `new X()`.
   // Primary query targets `class`-kind nodes (the canonical schema).
@@ -546,6 +551,8 @@ function runPostNativeCha(db: BetterSqlite3Database): number {
             if (conf <= 0) continue;
             newEdges.push([source_id, methodNode.id, 'calls', conf, 0, 'cha']);
             newEdgeCount++;
+            if (caller_file) affectedFiles.add(caller_file);
+            if (methodNode.method_file) affectedFiles.add(methodNode.method_file);
           }
         }
 
@@ -558,297 +565,7 @@ function runPostNativeCha(db: BetterSqlite3Database): number {
   if (newEdges.length > 0) {
     db.transaction(() => batchInsertEdges(db, newEdges))();
   }
-  return newEdgeCount;
-}
-
-/**
- * Post-pass: backfill function-as-object-property method definitions and their call edges.
- *
- * The Rust engine does not recognise `fn.method = function(){}` patterns as
- * method definitions, so those nodes are absent from the DB after the native
- * orchestrator completes. This pass:
- *   1. Re-parses JS/TS files via WASM to obtain the full ExtractorOutput
- *      (including func-prop definitions emitted by handleFuncPropAssignment).
- *   2. Inserts any method nodes that are missing from the DB.
- *   3. Resolves call edges to those newly-inserted nodes using the WASM typeMap
- *      and the existing DB node table as a lookup.
- *
- * Note: `Foo.prototype.bar = function(){}` patterns are handled natively by
- * the Rust extractor and do not need a WASM re-parse here.
- */
-async function runPostNativePrototypeMethods(
-  db: BetterSqlite3Database,
-  rootDir: string,
-  changedFiles: string[] | undefined,
-  isFullBuild: boolean,
-): Promise<void> {
-  // Only extensions where these patterns can appear.
-  const jsExts = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx']);
-
-  // All JS/TS file paths known to the DB. Used for the definition scan on
-  // full builds, and for the caller-relink second pass below (which must
-  // sweep unchanged files even on incremental builds).
-  const allJsFilesFromDb = (): string[] => {
-    const fileRows = db
-      .prepare(
-        `SELECT DISTINCT file FROM nodes WHERE kind = 'file' AND file IS NOT NULL ORDER BY file`,
-      )
-      .all() as Array<{ file: string }>;
-    return fileRows.map((r) => r.file).filter((f) => jsExts.has(path.extname(f).toLowerCase()));
-  };
-
-  // Incremental builds: only changed files can introduce *new* func-prop
-  // method definitions — unchanged definition files keep their nodes from
-  // the previous build. Restricting the definition scan to changedFiles
-  // (mirroring runPostNativeThisDispatch) keeps the per-build cost
-  // proportional to the change set; the unscoped variant re-read and
-  // WASM-re-parsed the whole repo on every 1-file rebuild (86ms → 1657ms
-  // on codegraph itself — the v3.12.0 publish-gate regression). Removing
-  // this pass entirely via native func-prop extraction is tracked in #1432.
-  const jsFiles =
-    isFullBuild || !changedFiles
-      ? allJsFilesFromDb()
-      : changedFiles.filter((f) => jsExts.has(path.extname(f).toLowerCase()));
-
-  if (jsFiles.length === 0) return;
-
-  // Pre-filter: only re-parse files that contain the function-as-object-property
-  // pattern (`fn.method = function(){}` or `fn.method = () => {}`). The Rust engine
-  // now handles `Foo.prototype.bar = fn` natively, so `.prototype.` files no longer
-  // need a WASM re-parse here.
-  const protoFiles = jsFiles.filter((relPath) => {
-    try {
-      const content = readFileSafe(path.join(rootDir, relPath));
-      // Match `fn.method = function(){}` (traditional) or `fn.method = () => {}`/
-      // `fn.method = param => {}` (arrow). The negative lookahead excludes `.prototype.`
-      // patterns already handled natively by the Rust extractor.
-      return /\b(?!prototype\.)\w+\.\w+\s*=\s*(?:function\b|(?:\([^)]*\)|[A-Za-z_$]\w*)\s*=>)/.test(
-        content,
-      );
-    } catch {
-      return false;
-    }
-  });
-
-  if (protoFiles.length === 0) return;
-
-  // WASM-parse only the files that have func-prop patterns to get full
-  // ExtractorOutput including method definitions and typeMap entries.
-  // symbolsOnly: this pass reads definitions/calls/typeMap — skip the
-  // worker-side AST/complexity/CFG/dataflow visitors and their transfer.
-  const absPaths = protoFiles.map((f) => path.join(rootDir, f));
-  let wasmResults: Map<string, ExtractorOutput>;
-  try {
-    wasmResults = await parseFilesWasmForBackfill(absPaths, rootDir, { symbolsOnly: true });
-  } catch (e) {
-    debug(`runPostNativePrototypeMethods: WASM parse failed: ${toErrorMessage(e)}`);
-    return;
-  }
-
-  if (wasmResults.size === 0) return;
-
-  // Check which nodes already exist — INSERT OR IGNORE handles races but
-  // we need the IDs of newly inserted rows, so we check first.
-  const existsStmt = db.prepare(
-    `SELECT id FROM nodes WHERE name = ? AND kind = 'method' AND file = ?`,
-  );
-
-  // Insert rows: [name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility]
-  const newNodeRows: unknown[][] = [];
-  // Track which file+definition combos are new so we can insert edges for them.
-  const newDefs: Array<{ name: string; file: string; line: number }> = [];
-
-  for (const [relPath, symbols] of wasmResults) {
-    for (const def of symbols.definitions ?? []) {
-      if (def.kind !== 'method') continue;
-      const dotIdx = def.name.indexOf('.');
-      if (dotIdx === -1) continue; // skip bare method names (shouldn't happen, but guard)
-
-      // Only insert if the node is not already in the DB.
-      const existing = existsStmt.get(def.name, relPath) as { id: number } | undefined;
-      if (existing) continue;
-
-      const scope = def.name.slice(0, dotIdx);
-      newNodeRows.push([
-        def.name,
-        'method',
-        relPath,
-        def.line,
-        def.endLine ?? null,
-        null,
-        def.name,
-        scope,
-        null,
-      ]);
-      newDefs.push({ name: def.name, file: relPath, line: def.line });
-    }
-  }
-
-  if (newNodeRows.length === 0) return;
-
-  db.transaction(() => batchInsertNodes(db, newNodeRows))();
-
-  // ── Caller-only second pass (#1371) ──────────────────────────────────────
-  // `wasmResults` only covers `protoFiles` (definition files). A file that
-  // only *calls* a newly-inserted method (e.g. `f.method()`) was excluded from
-  // the pre-filter, so its call edges to the new nodes are silently dropped.
-  // After node insertion we know the method name suffixes; text-search the
-  // remaining JS/TS files and WASM-parse any that contain a matching call.
-  const newMethodSuffixes = new Set(
-    newDefs.map((d) => {
-      const dotIdx = d.name.indexOf('.');
-      return dotIdx !== -1 ? d.name.slice(dotIdx + 1) : d.name;
-    }),
-  );
-
-  let mergedWasmResults = wasmResults;
-  if (newMethodSuffixes.size > 0) {
-    // Pre-compile patterns once — avoids re-compiling up to newMethodSuffixes.size
-    // regexes on every file in the scan loop.
-    const suffixPatterns = [...newMethodSuffixes].map((m) => {
-      const escaped = m.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      return new RegExp(`\\.${escaped}\\s*\\(`);
-    });
-    const protoFileSet = new Set(protoFiles);
-    // This pass must sweep ALL JS/TS files, not just changedFiles: when a
-    // changed definition file is re-parsed, its method nodes get new IDs,
-    // and *unchanged* caller files lost their edges to the old IDs when the
-    // pipeline deleted the definition file's previous nodes. Gated on
-    // newMethodSuffixes (a definition actually changed), so incremental
-    // rebuilds that touch no func-prop definitions never pay this sweep.
-    const callerScanFiles = isFullBuild || !changedFiles ? jsFiles : allJsFilesFromDb();
-    const callerCandidateAbs: string[] = [];
-    for (const relPath of callerScanFiles) {
-      if (protoFileSet.has(relPath)) continue; // already parsed in first pass
-      try {
-        const content = readFileSafe(path.join(rootDir, relPath));
-        const matchesAny = suffixPatterns.some((re) => re.test(content));
-        if (matchesAny) callerCandidateAbs.push(path.join(rootDir, relPath));
-      } catch {
-        /* skip unreadable files */
-      }
-    }
-    if (callerCandidateAbs.length > 0) {
-      try {
-        const callerWasmResults = await parseFilesWasmForBackfill(callerCandidateAbs, rootDir, {
-          symbolsOnly: true,
-        });
-        if (callerWasmResults.size > 0) {
-          mergedWasmResults = new Map([...wasmResults, ...callerWasmResults]);
-        }
-      } catch (e) {
-        debug(`runPostNativePrototypeMethods: caller-only WASM parse failed: ${toErrorMessage(e)}`);
-      }
-    }
-  }
-
-  // Build a name → node lookup from all DB nodes (including newly inserted ones).
-  type NodeEntry = { id: number; file: string; kind: string };
-  const byNameMap = new Map<string, NodeEntry[]>();
-  const byNameFileMap = new Map<string, NodeEntry[]>();
-  const byIdKey = new Map<string, { id: number }>();
-
-  const allNodes = db
-    .prepare(`SELECT id, name, kind, file, line FROM nodes WHERE kind != 'file'`)
-    .all() as Array<{ id: number; name: string; kind: string; file: string; line: number }>;
-
-  for (const n of allNodes) {
-    const list = byNameMap.get(n.name);
-    if (list) list.push(n);
-    else byNameMap.set(n.name, [n]);
-
-    const fk = `${n.name}::${n.file}`;
-    const flist = byNameFileMap.get(fk);
-    if (flist) flist.push(n);
-    else byNameFileMap.set(fk, [n]);
-
-    byIdKey.set(`${n.name}|${n.kind}|${n.file}|${n.line}`, { id: n.id });
-  }
-
-  const lookup: CallNodeLookup = {
-    byName: (name) => byNameMap.get(name) ?? [],
-    byNameAndFile: (name, file) => byNameFileMap.get(`${name}::${file}`) ?? [],
-    isBarrel: () => false,
-    resolveBarrel: () => null,
-    nodeId: (name, kind, file, line) => byIdKey.get(`${name}|${kind}|${file}|${line}`),
-  };
-
-  // Build a fast set of newly-inserted node IDs so we only emit edges to
-  // func-prop nodes that the Rust engine missed (avoids duplicating existing edges).
-  const newNodeIds = new Set<number>(
-    newDefs.flatMap((d) => {
-      const nodes = byNameFileMap.get(`${d.name}::${d.file}`);
-      return nodes ? nodes.map((n) => n.id) : [];
-    }),
-  );
-
-  // seenByPair deduplicates edges we emit within this function only.
-  // No pre-existing edge can target a newly-inserted node ID (SQLite
-  // auto-increment guarantees the new IDs are unique), so there is no need
-  // to seed this set from the DB — doing so would load O(|edges|) data for
-  // zero benefit and could OOM on large repositories.
-  const seenByPair = new Set<string>();
-
-  // Resolve call edges across all parsed files (definition files + caller-only
-  // files discovered in the second WASM pass above). The newNodeIds guard inside
-  // the loop prevents emitting duplicate edges for nodes the Rust engine already built.
-  const newEdgeRows: unknown[][] = [];
-  const fileNodeStmt = db.prepare(`SELECT id FROM nodes WHERE kind = 'file' AND file = ?`);
-
-  for (const [relPath, symbols] of mergedWasmResults) {
-    const fileNodeRow = fileNodeStmt.get(relPath) as { id: number } | undefined;
-    if (!fileNodeRow) continue;
-
-    const typeMap = symbols.typeMap instanceof Map ? symbols.typeMap : new Map();
-
-    for (const call of symbols.calls ?? []) {
-      if (!call.receiver) continue; // receiver calls only
-
-      const caller = findCaller(lookup, call, symbols.definitions ?? [], relPath, fileNodeRow);
-
-      let targets = resolveByMethodOrGlobal(
-        lookup,
-        call,
-        relPath,
-        typeMap as Map<string, unknown>,
-        caller.callerName,
-      );
-
-      // Direct receiver.method fallback: caller-only files often lack typeMap entries
-      // for the receiver (e.g. `f.process()` where `f` isn't declared in the file).
-      // Try qualified-name lookup scoped to newly-inserted nodes to avoid false positives.
-      // Note: `call.receiver` is always truthy here — the `if (!call.receiver) continue`
-      // guard above ensures we never reach this point with a falsy receiver.
-      if (
-        targets.length === 0 &&
-        call.receiver !== 'this' &&
-        call.receiver !== 'super' &&
-        call.receiver !== 'self'
-      ) {
-        const qualifiedName = `${call.receiver}.${call.name}`;
-        const direct = lookup
-          .byName(qualifiedName)
-          .filter((n) => n.kind === 'method' && newNodeIds.has(n.id));
-        if (direct.length > 0) targets = direct;
-      }
-
-      for (const t of targets) {
-        // Only emit edges to newly-inserted func-prop nodes to avoid
-        // duplicating edges the Rust engine already built.
-        if (!newNodeIds.has(t.id)) continue;
-        const key = `${caller.id}|${t.id}`;
-        if (seenByPair.has(key)) continue;
-        seenByPair.add(key);
-        const conf = computeConfidence(relPath, t.file, null);
-        if (conf <= 0) continue;
-        newEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'receiver-typed']);
-      }
-    }
-  }
-
-  if (newEdgeRows.length > 0) {
-    db.transaction(() => batchInsertEdges(db, newEdgeRows))();
-  }
+  return { newEdgeCount, affectedFiles };
 }
 
 // Extensions where `this`/`super` dispatch can occur (JS/TS family)
@@ -871,12 +588,15 @@ async function runPostNativeThisDispatch(
   rootDir: string,
   changedFiles: string[] | undefined,
   isFullBuild: boolean,
-): Promise<{ elapsedMs: number; targetIds: Set<number> }> {
+): Promise<{ elapsedMs: number; targetIds: Set<number>; affectedFiles: Set<string> }> {
   const t0 = Date.now();
   const targetIds = new Set<number>();
+  // Files containing endpoints of newly inserted edges — lets the caller scope
+  // role re-classification to the nodes whose fan-in/out actually changed.
+  const affectedFiles = new Set<string>();
   // Fast guard: need at least one extends edge for this/super to have meaning
   const hasExtends = db.prepare(`SELECT 1 FROM edges WHERE kind = 'extends' LIMIT 1`).get();
-  if (!hasExtends) return { elapsedMs: 0, targetIds };
+  if (!hasExtends) return { elapsedMs: 0, targetIds, affectedFiles };
 
   // Build parents map: child class → direct parent class (from `extends` edges)
   const parentRows = db
@@ -893,7 +613,7 @@ async function runPostNativeThisDispatch(
   for (const row of parentRows) {
     if (!parents.has(row.child_name)) parents.set(row.child_name, row.parent_name);
   }
-  if (parents.size === 0) return { elapsedMs: 0, targetIds };
+  if (parents.size === 0) return { elapsedMs: 0, targetIds, affectedFiles };
 
   const chaCtx: ChaContext = {
     implementors: new Map(), // not needed for this/super resolution
@@ -940,7 +660,7 @@ async function runPostNativeThisDispatch(
     // rebuild (isFullBuild=true) is required to recover in that scenario.
     relFiles = changedFiles.filter((f) => THIS_DISPATCH_EXTS.has(path.extname(f).toLowerCase()));
   }
-  if (relFiles.length === 0) return { elapsedMs: 0, targetIds };
+  if (relFiles.length === 0) return { elapsedMs: 0, targetIds, affectedFiles };
 
   // DB-backed CallNodeLookup — resolveThisDispatch only calls byName()
   const findByNameStmt = db.prepare(`SELECT id, file, kind FROM nodes WHERE name = ?`);
@@ -983,15 +703,57 @@ async function runPostNativeThisDispatch(
     LIMIT 1
   `);
 
-  // WASM-parse the files to obtain raw call sites with receiver info.
-  // symbolsOnly: only `calls` (with receivers) are consumed here.
+  // Re-parse the files to obtain raw call sites with receiver info. Only
+  // `calls` (with receivers) are consumed here.
+  //
+  // The native engine is preferred: this pass only runs after a native
+  // orchestrator build, so the addon is already loaded and re-parses the
+  // hierarchy file set in single-digit milliseconds with the same
+  // receiver-annotated call sites as the WASM extractor. Booting the WASM
+  // runtime here instead cost ~40–110ms per full build (in-process
+  // web-tree-sitter + grammar init dominated) — part of the v3.12.0
+  // publish-gate regression. Files the native engine cannot parse (extension
+  // outside NATIVE_SUPPORTED_EXTENSIONS, e.g. .mts/.cts) and native parse
+  // failures fall back to the WASM backfill path so the sweep stays complete.
   const absFiles = relFiles.map((f) => path.join(rootDir, f));
-  const wasmResults = await parseFilesWasmForBackfill(absFiles, rootDir, { symbolsOnly: true });
+  const nativeAbs = absFiles.filter((f) =>
+    NATIVE_SUPPORTED_EXTENSIONS.has(path.extname(f).toLowerCase()),
+  );
+  const callsByRel = new Map<string, { name: string; receiver?: string; line: number }[]>();
+  let nativeParsed = false;
+  if (nativeAbs.length > 0) {
+    const native = loadNative();
+    if (native) {
+      try {
+        const results = native.parseFiles(nativeAbs, rootDir, false, false) as Array<{
+          file: string;
+          calls?: { name: string; receiver?: string; line: number }[];
+        } | null>;
+        for (const r of results) {
+          if (!r) continue;
+          callsByRel.set(normalizePath(path.relative(rootDir, r.file)), r.calls ?? []);
+        }
+        nativeParsed = true;
+      } catch (e) {
+        debug(`this-dispatch native re-parse failed, falling back to WASM: ${toErrorMessage(e)}`);
+      }
+    }
+  }
+  const wasmAbs = nativeParsed
+    ? absFiles.filter((f) => !NATIVE_SUPPORTED_EXTENSIONS.has(path.extname(f).toLowerCase()))
+    : absFiles;
+  const wasmResults =
+    wasmAbs.length > 0
+      ? await parseFilesWasmForBackfill(wasmAbs, rootDir, { symbolsOnly: true })
+      : new Map<string, ExtractorOutput>();
+  for (const [relPath, symbols] of wasmResults) {
+    callsByRel.set(relPath, symbols.calls ?? []);
+  }
 
   const newEdges: Array<[number, number, string, number, number, string]> = [];
 
-  for (const [relPath, symbols] of wasmResults) {
-    for (const call of symbols.calls) {
+  for (const [relPath, calls] of callsByRel) {
+    for (const call of calls) {
       // Only 'this' and 'super' are class-instance receivers in JS/TS.
       // 'self' refers to WindowOrWorkerGlobalScope — not a class instance — so
       // filtering it here prevents spurious dispatch edges from Worker call sites.
@@ -1018,6 +780,8 @@ async function runPostNativeThisDispatch(
         if (conf <= 0) continue;
         newEdges.push([callerRow.id, t.id, 'calls', conf, 0, 'cha']);
         targetIds.add(t.id);
+        affectedFiles.add(relPath);
+        if (t.file) affectedFiles.add(t.file);
       }
     }
   }
@@ -1041,7 +805,7 @@ async function runPostNativeThisDispatch(
     (symbols as { _tree?: unknown; _langId?: unknown })._langId = undefined;
   }
 
-  return { elapsedMs: Date.now() - t0, targetIds };
+  return { elapsedMs: Date.now() - t0, targetIds, affectedFiles };
 }
 
 /** Format timing result from native orchestrator phases + JS post-processing. */
@@ -1636,52 +1400,52 @@ export async function tryNativeOrchestrator(
   }
 
   // Phase 8.5: expand CHA call edges (interface dispatch → concrete implementations).
-  // Returns the count of newly inserted edges; used to determine whether
-  // a full role re-classification is needed after all edge-writing post-passes complete.
-  const chaEdgeCount = runPostNativeCha(ctx.db as unknown as BetterSqlite3Database);
-
-  // Function-as-object-property post-pass: the Rust engine does not yet recognise
-  // `fn.method = function() {}` patterns. Re-parse only those JS/TS files via
-  // WASM to insert missing method nodes. `Foo.prototype.bar = fn` is now
-  // handled natively by the Rust extractor and no longer needs a WASM re-parse.
-  try {
-    await runPostNativePrototypeMethods(
-      ctx.db as unknown as BetterSqlite3Database,
-      ctx.rootDir,
-      result.changedFiles,
-      !!result.isFullBuild,
-    );
-  } catch (err) {
-    debug(`Function-prop methods post-pass failed: ${toErrorMessage(err)}`);
-  }
+  // Returns the affected files so role re-classification below can be scoped to
+  // the nodes whose fan-in/out actually changed.
+  //
+  // Function-as-object-property methods (`fn.method = function() {}`) are extracted
+  // natively by the Rust engine (#1432) and resolved in-build by its edge builder, so
+  // no WASM re-parse post-pass is needed for them. `Foo.prototype.bar = fn` likewise.
+  const { newEdgeCount: chaEdgeCount, affectedFiles: chaAffectedFiles } = runPostNativeCha(
+    ctx.db as unknown as BetterSqlite3Database,
+  );
 
   // Phase 8.5: this/super dispatch — hybrid WASM re-parse to resolve call sites
   // whose raw receiver info the Rust pipeline does not persist to DB.
-  const { elapsedMs: thisDispatchMs, targetIds: thisDispatchTargetIds } =
-    await runPostNativeThisDispatch(
-      ctx.db as unknown as BetterSqlite3Database,
-      ctx.rootDir,
-      result.changedFiles,
-      !!result.isFullBuild,
-    );
+  const {
+    elapsedMs: thisDispatchMs,
+    targetIds: thisDispatchTargetIds,
+    affectedFiles: thisDispatchAffectedFiles,
+  } = await runPostNativeThisDispatch(
+    ctx.db as unknown as BetterSqlite3Database,
+    ctx.rootDir,
+    result.changedFiles,
+    !!result.isFullBuild,
+  );
 
-  // Full role re-classification after JS edge-writing post-passes.
+  // Role re-classification after JS edge-writing post-passes.
   // The Rust orchestrator classifies roles before these post-passes (CHA,
-  // this-dispatch) add edges, so the Rust-computed roles and the cached
-  // fan-out medians are stale. A full re-classification ensures the final
-  // roles reflect the true fan-in/out with all edges in place.
+  // this-dispatch) add edges, so roles for the edge endpoints are stale.
+  // Scoped to the files containing those endpoints: a new edge only changes
+  // fan-in/out for its own source and target nodes, so re-classifying their
+  // files restores correctness without re-running the classifier over the
+  // whole graph (which cost ~130ms per build on codegraph itself and was a
+  // major part of the v3.12.0 native full-build benchmark regression).
   if (chaEdgeCount > 0 || thisDispatchTargetIds.size > 0) {
-    try {
-      const { classifyNodeRoles } = (await import('../../../../features/structure.js')) as {
-        classifyNodeRoles: (
-          db: BetterSqlite3Database,
-          changedFiles?: string[] | null,
-        ) => Record<string, number>;
-      };
-      classifyNodeRoles(ctx.db as unknown as BetterSqlite3Database, null);
-      debug(`Post-pass full role re-classification complete`);
-    } catch (err) {
-      debug(`Post-pass full role re-classification failed: ${toErrorMessage(err)}`);
+    const affectedFiles = [...new Set([...chaAffectedFiles, ...thisDispatchAffectedFiles])];
+    if (affectedFiles.length > 0) {
+      try {
+        const { classifyNodeRoles } = (await import('../../../../features/structure.js')) as {
+          classifyNodeRoles: (
+            db: BetterSqlite3Database,
+            changedFiles?: string[] | null,
+          ) => Record<string, number>;
+        };
+        classifyNodeRoles(ctx.db as unknown as BetterSqlite3Database, affectedFiles);
+        debug(`Post-pass role re-classification complete (${affectedFiles.length} file(s))`);
+      } catch (err) {
+        debug(`Post-pass role re-classification failed: ${toErrorMessage(err)}`);
+      }
     }
   }
 

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -737,7 +737,8 @@ async function runPostNativeThisDispatch(
           const r = results[i];
           if (!r) {
             // Per-file parse failure — fall back to WASM for this file.
-            if (nativeAbs[i]) nativeNullFiles.add(nativeAbs[i]);
+            const abs = nativeAbs[i];
+            if (abs) nativeNullFiles.add(abs);
             continue;
           }
           callsByRel.set(normalizePath(path.relative(rootDir, r.file)), r.calls ?? []);

--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -350,6 +350,38 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  *   exemption above (which was a WASM metric; this is native). Exempt this
  *   release; remove once 3.12.0+ data confirms the steady-state.
  *
+ * - 3.12.0:Full build — root-caused residual feature cost of the Phase 8.x
+ *   resolution work on the native engine. The v3.12.0 publish gate first
+ *   measured 2231 → 3333 (+49%). Local A/B against a v3.11.2 baseline worktree
+ *   (same machine, release-built addons for each side) attributed the delta to
+ *   three post-pass regressions, all fixed: (a) the func-prop WASM re-parse
+ *   post-pass booted the WASM worker pool on every native full build and
+ *   inserted zero nodes on this corpus (~430ms — removed; the Rust extractor
+ *   now emits func-prop method definitions, #1432); (b) an unscoped full-graph
+ *   role re-classification after the CHA/this-dispatch post-passes (~130ms —
+ *   now scoped to files containing the new edges' endpoints); (c) the
+ *   this-dispatch pass booted the in-process WASM runtime to re-parse hierarchy
+ *   files (~40ms — now re-parsed through the already-loaded native engine).
+ *   The remaining delta (local: 1378ms → ~1745ms, +26% including 630 → 672
+ *   corpus growth) is in-phase Rust extraction cost of the Phase 8.x features
+ *   themselves — parse +28%/file (points-to, return-type, prototype and
+ *   func-prop extraction), insert/edges +10–20% — which lands at the 25%
+ *   threshold boundary under CI runner variance. This is measured feature
+ *   cost, not an undiagnosed regression. Tracking: #1433 (per-PR perf canary),
+ *   #1434 (post-pass phase timings). Remove once 3.13+ data establishes the
+ *   new steady-state baseline.
+ *
+ * - 3.12.0:1-file rebuild — CI methodology noise on the ~100ms native metric:
+ *   the build-benchmark suite measures this tier with no warmup runs (#1440),
+ *   unlike the incremental suite, whose identical metric PASSED in the same
+ *   publish run that flagged this one (86 → 131, +52%, noisy threshold 50%).
+ *   Local A/B on the same machine shows parity: v3.11.2 baseline 84–102ms vs
+ *   dev 97–108ms (overlapping ranges). The only systematic additions on this
+ *   path are the CHA scan (~12ms, scoping tracked in #1441) and the native
+ *   this-dispatch re-parse of the changed file (~2ms). Same shape as the
+ *   3.11.2:1-file rebuild entry above. Remove once #1440 lands warmups and
+ *   3.13+ data confirms the steady state.
+ *
  * NOTE: WASM *timing* noise no longer needs per-version entries here — it is
  * handled structurally by WASM_TIMING_THRESHOLD (see above). The 3.11.x
  * entries that remain are kept because they trip the *native* engine too
@@ -376,6 +408,8 @@ const KNOWN_REGRESSIONS = new Set([
   '3.11.2:No-op rebuild',
   '3.11.2:1-file rebuild',
   '3.11.2:Full build',
+  '3.12.0:Full build',
+  '3.12.0:1-file rebuild',
 ]);
 
 /**


### PR DESCRIPTION
## Problem

The v3.12.0 publish failed its benchmark gate a second time (first round fixed in #1436). Remaining failures, both native engine:

- **Full build: 2231 → 3333ms (+49%, threshold 25%)** — incremental suite
- **1-file rebuild: 86 → 131ms (+52%, threshold 50%)** — build suite

## Root cause (measured)

Local A/B against a v3.11.2 baseline worktree (release-built addons on both sides, same corpus methodology as CI) decomposed the +800ms warm full-build delta. Two-thirds was **untimed post-pass cost** (565–582ms vs 39ms at baseline):

| post-pass | cost | finding |
|---|---|---|
| `runPostNativePrototypeMethods` | **430–480ms** | WASM worker-pool cold start (~185ms) + sequential re-parse of 18 regex-matched files, **inserting zero nodes on this corpus** — every native full build |
| post-pass role re-classification | **~130ms** | `classifyNodeRoles(db, null)` — full graph — whenever CHA/this-dispatch added any edge |
| `runPostNativeThisDispatch` | **40–110ms** | booted the in-process WASM runtime to re-parse 10 hierarchy files |

## Fix

1. **Func-prop methods are now extracted natively (#1432).** The Rust extractor emits `fn.method = function(){}` / arrow definitions (mirroring `handleFuncPropAssignment`: bare-identifier receiver, builtin globals excluded, `.prototype` excluded, params as children, complexity + CFG). Call edges resolve in-build via the existing direct qualified lookup, so the WASM re-parse post-pass is **deleted** — full builds, incremental relinking (save+reconnect #1012), and caller-only files (#1371) are covered by the standard pipeline. 6 new Rust unit tests.
2. **Role re-classification is scoped.** `runPostNativeCha` / `runPostNativeThisDispatch` now return the files containing the new edges' endpoints; the re-class runs the incremental classifier over those files. Neighbour expansion is deliberately kept — dropping it flips roles vs the WASM engine (caught by build-parity "produces identical roles" during development).
3. **This-dispatch re-parses through the already-loaded native addon** (~12ms vs 40–110ms), with WASM fallback for non-native extensions (`.mts`/`.cts`) and parse failures.

## Results (local A/B, warm medians, native)

| metric | v3.11.2 baseline | before | after |
|---|---|---|---|
| full build | 1373–1383ms | 2144–2219ms | **1727–1759ms** |
| 1-file rebuild | 84–102ms | 99–104ms | **97–108ms** (parity) |
| untimed post-pass gap | 39ms | 565–582ms | ~205ms |

The remaining ~+26% (incl. 630→672 corpus growth) is in-phase Rust extraction cost of the Phase 8.x features (parse +28%/file; insert/edges +10–20%) — measured feature cost. Two documented `KNOWN_REGRESSIONS` entries (`3.12.0:Full build`, `3.12.0:1-file rebuild`) cover the CI-noise band around the thresholds, following the 3.11.2 precedent: the 1-file CI failure is methodology noise (no warmups in benchmark.ts — #1440; the incremental suite's identical metric **passed** in the same run) and measures at parity locally.

## Verification

- Full suite: 179 files / 3042 tests pass
- `cargo test --release`: 360 pass (incl. 6 new func-prop tests)
- Parity: build-parity, pts-parity, this-dispatch-scope, phase-8.5-cha-dispatch, func-prop-this-dispatch, func-prop-caller-only-file, prototype-method-resolution all green
- Resolution benchmark: 176 pass (precision/recall floors intact, both engines)
- Regression guard (RUN_REGRESSION_GUARD=1): 17 pass

## Follow-ups filed

- #1439 — Rust edge_builder 4.5 direct qualified lookup lacks the ≥0.5 confidence filter WASM applies (#1427 parity gap, found during this work)
- #1440 — benchmark.ts incremental tiers lack warmup runs
- #1441 — scope `runPostNativeCha` to changed files on incremental builds