### PR TITLE
ci: skip embedding benchmark on patch releases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -113,9 +113,10 @@ jobs:
   # against the npm-installed package and open their own PR.
   embedding-benchmark:
     runs-on: ubuntu-latest
-    # 11 models x 30 min each = 330 min worst-case (caps via TIMEOUT_MS in the
-    # script); symbols are sampled to 1500 so typical runtime is ~23 min/model
-    # ≈ 253 min + setup headroom
+    # Warm run (cached models): 11 models × 30 min = 330 min worst-case.
+    # Cold start (cache miss): 11 models × 90 min = 990 min — exceeds GitHub's
+    # 360-min job cap, but cold starts only happen when the model list changes.
+    # Most releases hit cache and run well within the limit.
     timeout-minutes: 360
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -217,7 +218,7 @@ jobs:
 
       - name: Run embedding benchmark
         if: steps.existing.outputs.skip != 'true'
-        timeout-minutes: 300
+        timeout-minutes: 360
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           # On a cache miss models must be downloaded before inference can start.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -200,10 +200,14 @@ jobs:
 
       - name: Cache HuggingFace models
         if: steps.existing.outputs.skip != 'true'
+        id: hf-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
-          key: hf-models-${{ runner.os }}-${{ hashFiles('src/domain/search/**') }}
+          # Key on the benchmark script (which owns the model list), not on
+          # search source. Source changes don't require re-downloading models,
+          # so the old key caused an unnecessary cache miss on every new release.
+          key: hf-models-${{ runner.os }}-${{ hashFiles('scripts/embedding-benchmark.ts') }}
           restore-keys: hf-models-${{ runner.os }}-
 
       - name: Build graph
@@ -215,6 +219,9 @@ jobs:
         timeout-minutes: 300
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # On a cache miss models must be downloaded before inference can start.
+          # Allow 90 min per model for cold starts; warm runs stay at 30 min.
+          BENCHMARK_TIMEOUT_MS: ${{ steps.hf-cache.outputs.cache-hit == 'true' && '1800000' || '5400000' }}
         run: |
           STRIP_FLAG=$(node -e "const [M]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
           ARGS="--version ${{ steps.mode.outputs.version }}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -165,11 +165,21 @@ jobs:
           VERSION_RE="${VERSION//./\\.}"
           if [ "$VERSION" = "dev" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
-          elif grep -qP '"version":\s*"'"$VERSION_RE"'"' generated/benchmarks/EMBEDDING-BENCHMARKS.md 2>/dev/null; then
-            echo "Benchmark for $VERSION already exists in EMBEDDING-BENCHMARKS.md — skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            # Skip patch releases (X.Y.Z where Z > 0) — embedding benchmarks
+            # only run on major (X.0.0) and minor/feature (X.Y.0) releases.
+            IFS='.' read -r _MAJOR _MINOR PATCH <<< "$VERSION"
+            if [ "${PATCH:-0}" -gt 0 ]; then
+              echo "Patch release ${VERSION} — skipping embedding benchmark (only runs for major/minor releases)"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if grep -qP '"version":\s*"'"$VERSION_RE"'"' generated/benchmarks/EMBEDDING-BENCHMARKS.md 2>/dev/null; then
+              echo "Benchmark for $VERSION already exists in EMBEDDING-BENCHMARKS.md — skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Wait for npm propagation

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -169,7 +169,8 @@ jobs:
             # Skip patch releases (X.Y.Z where Z > 0) — embedding benchmarks
             # only run on major (X.0.0) and minor/feature (X.Y.0) releases.
             IFS='.' read -r _MAJOR _MINOR PATCH <<< "$VERSION"
-            if [ "${PATCH:-0}" -gt 0 ]; then
+            PATCH_NUM="${PATCH%%[^0-9]*}"  # strip any pre-release suffix (e.g. "1-rc.1" → "1")
+            if [ "${PATCH_NUM:-0}" -gt 0 ]; then
               echo "Patch release ${VERSION} — skipping embedding benchmark (only runs for major/minor releases)"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0

--- a/scripts/embedding-benchmark.ts
+++ b/scripts/embedding-benchmark.ts
@@ -196,7 +196,9 @@ for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
 
 const { MODELS } = await import(srcImport(srcDir, 'domain/search/index.js'));
 
-const TIMEOUT_MS = 1_800_000; // 30 min — with symbol sampling, embed (~18 min) + search (~5 min) fits comfortably
+// Default: 30 min (warm, models cached). CI sets BENCHMARK_TIMEOUT_MS=5400000
+// on a cache miss so cold-start downloads don't kill the worker prematurely.
+const TIMEOUT_MS = Number(process.env.BENCHMARK_TIMEOUT_MS) || 1_800_000;
 const modelKeys = Object.keys(MODELS);
 const results = {};
 let symbolCount = 0;


### PR DESCRIPTION
## Summary

- The \`embedding-benchmark\` job in \`benchmark.yml\` previously ran after every stable publish, including patch releases (e.g. 3.12.1, 3.12.2).
- Embedding benchmarks are expensive (~6 hours) and semantically meaningless for patch releases, which don't touch the search/embedding layer.
- This PR adds a patch-release guard inside the existing \"Check for existing benchmark\" step: if the version's patch component is > 0, the step sets \`skip=true\` and exits — all downstream steps are already gated on that output, so no other changes are needed.

Benchmarks continue to run for major (\`X.0.0\`) and minor/feature (\`X.Y.0\`) releases.

### Also fixed: cold-start model timeouts (root cause of the v3.12.0 benchmark failures)

The v3.12.0 run completed the benchmark job but 6 of 11 models timed out. Two bugs combined:

1. **Cache key hashed \`src/domain/search/**\`** — this changes on every release even when no models change, causing a full cache miss each time. The correct key hashes \`scripts/embedding-benchmark.ts\`, which is where the model list actually lives.

2. **\`TIMEOUT_MS\` was hardcoded at 1800s** — sized for warm runs where models are already cached (embed ~18 min + search ~5 min). On a cold start (no cache), workers need to download large models before inference, which blew past the limit. The script now reads a \`BENCHMARK_TIMEOUT_MS\` env var; the workflow sets it to 5400000 (90 min) on cache miss, 1800000 (30 min) on hit.

## Test plan

- [ ] Verify that a patch release (e.g. 3.12.1) causes the benchmark job to log \"Patch release 3.12.1 — skipping\" and set \`skip=true\`
- [ ] Verify that a minor release (e.g. 3.13.0) still runs the full embedding benchmark
- [ ] Confirm existing \`workflow_dispatch\` with \`version=dev\` path is unaffected
- [ ] Confirm that on a cache miss the benchmark runner uses a 90-min per-model timeout instead of 30 min