### PR TITLE
feat(config): auto-enable TypeScript compiler resolver for TS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ const { results: fused } = await multiSearchData(
 
 ## ⚠️ Limitations
 
-- **TypeScript compiler integration is opt-in** — set `"build": { "typescriptResolver": true }` in `.codegraphrc.json` to enable the TypeScript compiler API pass; heuristic type inference (annotations, `new` expressions, assignment chains) is always active without it
+- **TypeScript compiler integration is auto-enabled** — when `typescript` is installed and a `tsconfig.json` is found, the TypeScript compiler API pass runs automatically; disable with `"build": { "typescriptResolver": false }` in `.codegraphrc.json` if you want faster builds without it; heuristic type inference (annotations, `new` expressions, assignment chains) is always active as a baseline
 - **Dynamic calls are best-effort** — complex computed property access and `eval` patterns are not resolved
 - **Python imports** — resolves relative imports but doesn't follow `sys.path` or virtual environment packages
 - **Dataflow analysis** — intraprocedural (single-function scope), not interprocedural

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1408,7 +1408,7 @@ The single highest-ROI improvement. Currently codegraph treats TypeScript as "Ja
 
 **Progress (v3.12.0):**
 - ✅ `src/domain/graph/resolver/ts-resolver.ts` — build-time enrichment pass using `ts.createProgram` + `getTypeChecker`; heuristic typeMap entries replaced with compiler-verified confidence 1.0 values ([#1278](https://github.com/optave/ops-codegraph-tool/pull/1278))
-- ✅ Gated on `config.build.typescriptResolver` (default: `false`) — set to `true` in `.codegraphrc.json` to enable ([#1278](https://github.com/optave/ops-codegraph-tool/pull/1278))
+- ✅ Auto-enabled when `typescript` is installed and `tsconfig.json` is found — disable with `"build": { "typescriptResolver": false }` in `.codegraphrc.json` ([#1278](https://github.com/optave/ops-codegraph-tool/pull/1278))
 - ✅ Native Rust engine: `returnTypeMap` and `callAssignments` extracted in Rust, closing the enrichment gap ([#1283](https://github.com/optave/ops-codegraph-tool/pull/1283))
 
 ### 8.2 -- Inter-Procedural Type Propagation

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -24,7 +24,7 @@ export const DEFAULTS = {
     dbPath: '.codegraph/graph.db',
     driftThreshold: 0.2,
     smallFilesThreshold: 5,
-    typescriptResolver: false,
+    typescriptResolver: true,
   },
   query: {
     defaultDepth: 3,

--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -239,7 +239,7 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  *   per-PR gate for the Phase 8.1 TypeScript resolver PR (#1278) re-measured
  *   dev on a fresh runner and landed at 212ms (+155%, threshold 50%) on run
  *   26793082961. The same PR modifies only: (a) a new ts-resolver.ts module
- *   gated behind `typescriptResolver: false` (default), (b) an import of
+ *   gated behind `typescriptResolver: false` (was the default at the time), (b) an import of
  *   that module in build-edges.ts, and (c) a config field — none of which
  *   execute on the incremental hot path. Locally the same PR measures 86ms
  *   (within noise of the 83ms baseline). The 3.11.0:1-file rebuild exemption


### PR DESCRIPTION
## Summary

- Flip `typescriptResolver` default from `false` to `true` in `src/infrastructure/config.ts`
- The pass already lazy-loads `typescript` and silently skips when unavailable or no `tsconfig.json` is found — JS-only projects and environments without `typescript` are unaffected
- TS projects now automatically get compiler-verified (1.0 confidence) type resolution: `this.field.method()` dispatch, typed-parameter call edges, return-type propagation

Users who want to opt out can set `"build": { "typescriptResolver": false }` in `.codegraphrc.json`.

Closes #1460

## Test plan

- [ ] `npx vitest run tests/unit/ts-resolver.test.ts` — all 21 tests pass
- [ ] Build a TS project without `typescriptResolver` in config — verify pass runs automatically
- [ ] Build a JS-only project — verify pass is silently skipped
- [ ] Set `"typescriptResolver": false` explicitly — verify pass is skipped