### PR TITLE
chore: gitignore napi-generated artifacts in crates/codegraph-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 coverage/
 .env
 grammars/*.wasm
+crates/codegraph-core/index.js
+crates/codegraph-core/index.d.ts
+crates/codegraph-core/*.node
 .claude/session-edits.log
 .claude/worktrees/
 generated/DEPENDENCIES.md


### PR DESCRIPTION
Adds `.gitignore` entries for the three artifacts emitted by `npx napi build --platform --release` in `crates/codegraph-core/`:
- `index.js` (napi loader)
- `index.d.ts` (napi type defs)
- `*.node` (platform binary)

These are build products and should receive the same treatment as WASM grammars. Without this, every local native build leaves the working tree dirty with untracked files.

Closes #1462