### PR TITLE
chore(tests): remove unused biome suppression in visitor.test.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 coverage/
 .env
 grammars/*.wasm
+crates/codegraph-core/index.js
+crates/codegraph-core/index.d.ts
+crates/codegraph-core/*.node
 .claude/session-edits.log
 .claude/worktrees/
 generated/DEPENDENCIES.md

--- a/tests/unit/visitor.test.ts
+++ b/tests/unit/visitor.test.ts
@@ -4,7 +4,6 @@
 import { describe, expect, it } from 'vitest';
 
 // We need a tree-sitter tree to test. Use the JS parser.
-// biome-ignore lint/suspicious/noExplicitAny: tree-sitter parser type is complex and not worth typing for tests
 let parse: any;
 
 async function ensureParser() {


### PR DESCRIPTION
Removes the \`// biome-ignore lint/suspicious/noExplicitAny\` comment above \`let parse: any;\` in \`tests/unit/visitor.test.ts\`. The suppression no longer matches a fired rule, causing a permanent \`suppressions/unused\` warning on every \`npm run lint\` run.

Closes #1459
Closes #1464