### PR TITLE
fix(perf): guard post-native passes on 1-file incremental rebuilds

### DIFF
--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1524,28 +1524,18 @@ export async function tryNativeOrchestrator(
   // stale native binaries). WASM handles those — backfill via WASM so both
   // engines process the same file set (#967).
   //
-  // Detect the gap once (fs walk + 2 DB queries, ~20–30ms) and use it for
-  // both gating and the backfill itself. On dirty incrementals/full builds
-  // the orchestrator signals trigger backfill, so the walk happens once
-  // (instead of redundantly inside backfill). On quiet incrementals we
-  // still pay the walk so we can detect brand-new files in dropped-language
-  // extensions — a gap that the orchestrator's `detect_removed_files`
-  // filter (#1070) leaves open (#1083, #1091). The pre-check is cheap
-  // because the expensive part (WASM re-parse of the missing set) is
-  // gated below.
-  const removedCount = result.removedCount ?? 0;
-  const changedCount = result.changedCount ?? 0;
+  // Detect the gap once (fs walk + 2 DB queries) and use it for both gating
+  // and the backfill itself. On quiet incrementals we still pay the walk so
+  // we can detect brand-new files in dropped-language extensions — a gap that
+  // the orchestrator's `detect_removed_files` filter (#1070) leaves open
+  // (#1083, #1091). The pre-check is cheap because the expensive part (WASM
+  // re-parse of the missing set) is gated below.
   const gapDetectStart = performance.now();
   const gap = detectDroppedLanguageGap(ctx);
-  if (
-    result.isFullBuild ||
-    removedCount > 0 ||
-    changedCount > 0 ||
-    gap.missingAbs.length > 0 ||
-    gap.staleRel.length > 0
-  ) {
+  if (gap.missingAbs.length > 0 || gap.staleRel.length > 0) {
     await backfillNativeDroppedFiles(ctx, gap);
   }
+  const backfillHappened = gap.missingAbs.length > 0 || gap.staleRel.length > 0;
   const gapDetectMs = performance.now() - gapDetectStart;
 
   // Phase 8.5: expand CHA call edges (interface dispatch → concrete implementations).
@@ -1624,19 +1614,27 @@ export async function tryNativeOrchestrator(
   // Re-count nodes/edges now that all edge-writing post-passes have run: the
   // Rust orchestrator captured its counts before the JS post-passes added
   // edges, so both its summary and build_meta under-report (#1452).
+  //
+  // Fast path: skip the COUNT(*) scan when no post-pass wrote any edges.
+  // COUNT(*) on large tables (50K+ edges) is non-trivial, especially via the
+  // NativeDbProxy napi-rs round-trip. When all post-passes were no-ops, the
+  // Rust orchestrator's counts are still accurate — no re-count needed.
   let finalNodeCount = result.nodeCount ?? 0;
   let finalEdgeCount = result.edgeCount ?? 0;
-  try {
-    const counts = (ctx.db as unknown as BetterSqlite3Database)
-      .prepare('SELECT (SELECT COUNT(*) FROM nodes) AS n, (SELECT COUNT(*) FROM edges) AS e')
-      .get() as { n: number; e: number };
-    if (counts.n !== finalNodeCount || counts.e !== finalEdgeCount) {
-      finalNodeCount = counts.n;
-      finalEdgeCount = counts.e;
-      setBuildMeta(ctx.db, { node_count: finalNodeCount, edge_count: finalEdgeCount });
+  const postPassWroteData = backfillHappened || chaEdgeCount > 0 || thisDispatchTargetIds.size > 0;
+  if (postPassWroteData) {
+    try {
+      const counts = (ctx.db as unknown as BetterSqlite3Database)
+        .prepare('SELECT (SELECT COUNT(*) FROM nodes) AS n, (SELECT COUNT(*) FROM edges) AS e')
+        .get() as { n: number; e: number };
+      if (counts.n !== finalNodeCount || counts.e !== finalEdgeCount) {
+        finalNodeCount = counts.n;
+        finalEdgeCount = counts.e;
+        setBuildMeta(ctx.db, { node_count: finalNodeCount, edge_count: finalEdgeCount });
+      }
+    } catch (err) {
+      debug(`Post-pass node/edge re-count failed: ${toErrorMessage(err)}`);
     }
-  } catch (err) {
-    debug(`Post-pass node/edge re-count failed: ${toErrorMessage(err)}`);
   }
   info(
     `Native build orchestrator completed: ${finalNodeCount} nodes, ${finalEdgeCount} edges, ${result.fileCount ?? 0} files`,

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1532,10 +1532,10 @@ export async function tryNativeOrchestrator(
   // re-parse of the missing set) is gated below.
   const gapDetectStart = performance.now();
   const gap = detectDroppedLanguageGap(ctx);
-  if (gap.missingAbs.length > 0 || gap.staleRel.length > 0) {
+  const backfillHappened = gap.missingAbs.length > 0 || gap.staleRel.length > 0;
+  if (backfillHappened) {
     await backfillNativeDroppedFiles(ctx, gap);
   }
-  const backfillHappened = gap.missingAbs.length > 0 || gap.staleRel.length > 0;
   const gapDetectMs = performance.now() - gapDetectStart;
 
   // Phase 8.5: expand CHA call edges (interface dispatch → concrete implementations).


### PR DESCRIPTION
Native 1-file incremental rebuilds were 11–14x slower than WASM (1901ms vs 171ms) with ~1823ms unaccounted in phase timings. Two post-native passes ran unconditionally even when they had no work to do:

- **`backfillNativeDroppedFiles` call gate**: Previously called whenever `changedCount > 0` (i.e. any incremental with changes), even when `detectDroppedLanguageGap` returned an empty gap. `backfillNativeDroppedFiles` already has an internal early-exit for empty gaps, but removing the spurious outer conditions (`isFullBuild || removedCount > 0 || changedCount > 0`) eliminates the wasted call entirely. Now only called when `gap.missingAbs.length > 0 || gap.staleRel.length > 0`.

- **Node/edge `COUNT(*)` re-count**: Ran unconditionally after all post-passes, even when none of them wrote any new edges. `COUNT(*)` over 50K+ edge tables is non-trivial, especially via the `NativeDbProxy` napi-rs round-trip. Now gated on `postPassWroteData` — true only when the backfill, CHA expansion, or this/super dispatch actually inserted edges. On a typical 1-file incremental (no class hierarchy, no WASM-only files), all three are zero — the scan is skipped entirely.

Combined with the related fixes already in this branch stack (phase timings visibility #1434, CHA incremental scoping #1441, symbolsOnly inline #1437, threshold #1435), native 1-file incremental should approach the expected ~43ms from v3.9.6.

Closes #1454