### PR TITLE
fix(native): add first-write-wins dedup to Rust type-map entry helpers

### DIFF
--- a/crates/codegraph-core/src/extractors/helpers.rs
+++ b/crates/codegraph-core/src/extractors/helpers.rs
@@ -958,22 +958,53 @@ pub fn extract_simple_parameters(
 
 // ── Type-map helpers ───────────────────────────────────────────────────────
 
-/// Record a parameter name → type binding in the type-map sink, using
-/// the default confidence of `0.9` shared by every Rust extractor.
-pub fn push_type_map_entry(
+/// Merge a type-map entry into the sink with first-write-wins semantics,
+/// matching `setTypeMapEntry` in `src/extractors/helpers.ts`.
+///
+/// If the key already exists with equal-or-higher confidence the new entry is
+/// silently dropped; otherwise the old entry is replaced.  This prevents
+/// duplicate entries from accumulating when the same bare key is written
+/// multiple times (e.g. two class expressions in one file that both define a
+/// field with the same name).
+///
+/// Mirrors `setTypeMapEntry` in `src/extractors/helpers.ts`.
+pub fn set_type_map_entry(
     symbols: &mut FileSymbols,
     name: impl Into<String>,
     type_name: impl Into<String>,
+    confidence: f64,
 ) {
     let name = name.into();
     if name.is_empty() {
         return;
     }
+    // Scan for an existing entry with the same key.
+    if let Some(existing) = symbols.type_map.iter_mut().find(|e| e.name == name) {
+        if confidence > existing.confidence {
+            existing.type_name = type_name.into();
+            existing.confidence = confidence;
+        }
+        return;
+    }
     symbols.type_map.push(TypeMapEntry {
         name,
         type_name: type_name.into(),
-        confidence: 0.9,
+        confidence,
     });
+}
+
+/// Record a parameter name → type binding in the type-map sink, using
+/// the default confidence of `0.9` shared by every Rust extractor.
+///
+/// Delegates to [`set_type_map_entry`] so duplicate keys are deduplicated with
+/// first-write-wins semantics, matching `setTypeMapEntry` in
+/// `src/extractors/helpers.ts`.
+pub fn push_type_map_entry(
+    symbols: &mut FileSymbols,
+    name: impl Into<String>,
+    type_name: impl Into<String>,
+) {
+    set_type_map_entry(symbols, name, type_name, 0.9);
 }
 
 /// C-family `declaration` / `parameter_declaration` type-map matcher.

--- a/crates/codegraph-core/src/extractors/helpers.rs
+++ b/crates/codegraph-core/src/extractors/helpers.rs
@@ -958,7 +958,7 @@ pub fn extract_simple_parameters(
 
 // ── Type-map helpers ───────────────────────────────────────────────────────
 
-/// Merge a type-map entry into the sink with first-write-wins semantics,
+/// Merge a type-map entry into the sink with highest-confidence-wins semantics,
 /// matching `setTypeMapEntry` in `src/extractors/helpers.ts`.
 ///
 /// If the key already exists with equal-or-higher confidence the new entry is
@@ -997,8 +997,8 @@ pub fn set_type_map_entry(
 /// the default confidence of `0.9` shared by every Rust extractor.
 ///
 /// Delegates to [`set_type_map_entry`] so duplicate keys are deduplicated with
-/// first-write-wins semantics, matching `setTypeMapEntry` in
-/// `src/extractors/helpers.ts`.
+/// highest-confidence-wins semantics (first-write-wins at the uniform 0.9
+/// confidence), matching `setTypeMapEntry` in `src/extractors/helpers.ts`.
 pub fn push_type_map_entry(
     symbols: &mut FileSymbols,
     name: impl Into<String>,

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -224,28 +224,21 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                             match enclosing_type_map_class(node, source) {
                                 Some(class_name) => {
                                     // Primary: class-scoped key prevents cross-class collision.
-                                    push_type_map_entry(
+                                    set_type_map_entry(
                                         symbols,
                                         format!("{}.{}", class_name, field_name),
                                         type_name.to_string(),
+                                        0.9,
                                     );
                                     // Fallback bare keys at lower confidence.
-                                    symbols.type_map.push(TypeMapEntry {
-                                        name: field_name.clone(),
-                                        type_name: type_name.to_string(),
-                                        confidence: 0.6,
-                                    });
-                                    symbols.type_map.push(TypeMapEntry {
-                                        name: format!("this.{}", field_name),
-                                        type_name: type_name.to_string(),
-                                        confidence: 0.6,
-                                    });
+                                    set_type_map_entry(symbols, field_name.clone(), type_name.to_string(), 0.6);
+                                    set_type_map_entry(symbols, format!("this.{}", field_name), type_name.to_string(), 0.6);
                                 }
                                 None => {
                                     // No enclosing class declaration (e.g. class expression)
                                     // — use bare keys only at full confidence.
-                                    push_type_map_entry(symbols, field_name.clone(), type_name.to_string());
-                                    push_type_map_entry(symbols, format!("this.{}", field_name), type_name.to_string());
+                                    set_type_map_entry(symbols, field_name.clone(), type_name.to_string(), 0.9);
+                                    set_type_map_entry(symbols, format!("this.{}", field_name), type_name.to_string(), 0.9);
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

- Introduce `set_type_map_entry` in `crates/codegraph-core/src/extractors/helpers.rs` — a direct Rust mirror of `setTypeMapEntry` in `src/extractors/helpers.ts`. If a key already exists with equal-or-higher confidence, the new entry is dropped; otherwise the old entry is replaced.
- Rewrite `push_type_map_entry` to delegate to `set_type_map_entry` so all existing call sites across every language extractor automatically gain deduplication.
- In the `field_definition` handler's `None` branch (class expressions), replace the two `push_type_map_entry` calls with explicit `set_type_map_entry` calls at confidence 0.9 — matching the TS `handleFieldDefTypeMap` path exactly.
- In the `Some(class_name)` branch, replace the two direct `symbols.type_map.push(TypeMapEntry { confidence: 0.6 })` calls with `set_type_map_entry` so the fallback bare keys are also deduplicated.

## Test plan

- `cargo check` in `crates/codegraph-core/` — clean compile
- `npm test` — 3048 tests pass; 12 pre-existing Erlang parser failures unaffected

Closes #1501