### PR TITLE
fix(test): smoke-test erlang grammar compatibility to prevent false failures

### DIFF
--- a/tests/parsers/erlang.test.ts
+++ b/tests/parsers/erlang.test.ts
@@ -9,7 +9,23 @@ describe('Erlang parser', () => {
 
   beforeAll(async () => {
     parsers = await createParsers();
-    erlangAvailable = !!parsers.get('erlang');
+    if (!parsers.get('erlang')) {
+      erlangAvailable = false;
+      return;
+    }
+    // Smoke-test: verify the loaded grammar is the expected WhatsApp/tree-sitter-erlang
+    // variant whose AST uses specific node types (module_attribute, fun_decl, etc.).
+    // A stale WASM from a different vendor (e.g. enolib/tree-sitter-erlang) loads
+    // successfully but produces generic `attribute` nodes, causing all extractions to
+    // return empty. Treat that as "unavailable" so tests skip rather than fail.
+    try {
+      const parser = parsers.get('erlang');
+      const tree = parser.parse('-module(probe).');
+      const result = extractErlangSymbols(tree, 'probe.erl');
+      erlangAvailable = result.definitions.some((d) => d.name === 'probe' && d.kind === 'module');
+    } catch {
+      erlangAvailable = false;
+    }
   });
 
   function parseErlang(code) {

--- a/tests/parsers/erlang.test.ts
+++ b/tests/parsers/erlang.test.ts
@@ -9,7 +9,8 @@ describe('Erlang parser', () => {
 
   beforeAll(async () => {
     parsers = await createParsers();
-    if (!parsers.get('erlang')) {
+    const erlangParser = parsers.get('erlang');
+    if (!erlangParser) {
       erlangAvailable = false;
       return;
     }
@@ -19,8 +20,7 @@ describe('Erlang parser', () => {
     // successfully but produces generic `attribute` nodes, causing all extractions to
     // return empty. Treat that as "unavailable" so tests skip rather than fail.
     try {
-      const parser = parsers.get('erlang');
-      const tree = parser.parse('-module(probe).');
+      const tree = erlangParser.parse('-module(probe).');
       const result = extractErlangSymbols(tree, 'probe.erl');
       erlangAvailable = result.definitions.some((d) => d.name === 'probe' && d.kind === 'module');
     } catch {


### PR DESCRIPTION
## Problem

After `cf18c027` removed the malicious `tree-sitter-erlang` devDependency, skip guards were added to `tests/parsers/erlang.test.ts` so tests skip when the grammar is absent. However, the guard only checked `!!parsers.get('erlang')` — whether the WASM *loaded*, not whether it produces the expected node types.

On developer machines that ran `npm install` before the devDep removal, a stale `grammars/tree-sitter-erlang.wasm` from a different grammar vendor (e.g. enolib/tree-sitter-erlang) remains on disk. That WASM loads successfully, so `erlangAvailable = true`, but it emits generic `attribute` nodes instead of the `module_attribute`/`fun_decl`/`pp_define`/`pp_include`/etc. nodes that the WhatsApp-grammar extractor expects. Every extraction returns empty, and all 12 content tests fail rather than skip.

## Fix

Add a grammar compatibility probe in `beforeAll`: parse the minimal snippet `-module(probe).` and run `extractErlangSymbols` against the result. If a `module` definition named `probe` is found, the grammar is the right variant and tests run. If not — whether the file is absent, fails to load, or is the wrong vendor — `erlangAvailable` is set to `false` and all 14 tests skip cleanly.

This is robust against:
- Grammar file absent (fresh CI checkout after devDep removal)
- Grammar file present but from a different vendor (stale developer machine)
- Any future grammar load error

## Testing

Verified three scenarios locally:
- Grammar absent → 14 skipped
- Wrong-vendor WASM present → 14 skipped (smoke-test detects mismatch)
- Correct WhatsApp WASM present → tests run and pass

Full suite: 180 passed, 1 skipped (the Erlang file), 0 failures.

Closes #1502
Closes #1504