### PR TITLE
refactor(extractors): deduplicate C-family primitive types into shared constant

### DIFF
--- a/src/extractors/cpp.ts
+++ b/src/extractors/cpp.ts
@@ -5,7 +5,13 @@ import type {
   TreeSitterNode,
   TreeSitterTree,
 } from '../types.js';
-import { extractModifierVisibility, findChild, nodeEndLine, setTypeMapEntry } from './helpers.js';
+import {
+  extractModifierVisibility,
+  findChild,
+  isCPrimitiveType,
+  nodeEndLine,
+  setTypeMapEntry,
+} from './helpers.js';
 
 /**
  * Extract symbols from C++ files.
@@ -218,7 +224,7 @@ function handleCppDeclaration(node: TreeSitterNode, ctx: ExtractorOutput): void 
   if (!typeNode) return;
   const typeName = typeNode.text;
   // Skip primitive types — they are never class/struct receivers
-  if (isPrimitiveCppType(typeName)) return;
+  if (isCPrimitiveType(typeName)) return;
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     if (!child) continue;
@@ -359,43 +365,6 @@ function extractCppClassFields(classNode: TreeSitterNode): SubDeclaration[] {
     }
   }
   return fields;
-}
-
-/**
- * Primitive C/C++ types that are never class/struct receivers. Seeding these
- * into typeMap would cause spurious receiver edges (e.g. `int x` → `int`).
- */
-const CPP_PRIMITIVE_TYPES = new Set([
-  'int',
-  'long',
-  'short',
-  'unsigned',
-  'signed',
-  'float',
-  'double',
-  'char',
-  'bool',
-  'void',
-  'wchar_t',
-  'auto',
-  'size_t',
-  'uint8_t',
-  'uint16_t',
-  'uint32_t',
-  'uint64_t',
-  'int8_t',
-  'int16_t',
-  'int32_t',
-  'int64_t',
-  'ptrdiff_t',
-  'intptr_t',
-  'uintptr_t',
-]);
-
-function isPrimitiveCppType(typeName: string): boolean {
-  // Strip qualifiers like `const`, `volatile`, `unsigned` etc.
-  const base = typeName.split(/\s+/).pop() ?? typeName;
-  return CPP_PRIMITIVE_TYPES.has(base) || CPP_PRIMITIVE_TYPES.has(typeName);
 }
 
 function extractCppEnumEntries(enumNode: TreeSitterNode): SubDeclaration[] {

--- a/src/extractors/cuda.ts
+++ b/src/extractors/cuda.ts
@@ -5,7 +5,13 @@ import type {
   TreeSitterNode,
   TreeSitterTree,
 } from '../types.js';
-import { extractModifierVisibility, findChild, nodeEndLine, setTypeMapEntry } from './helpers.js';
+import {
+  extractModifierVisibility,
+  findChild,
+  isCPrimitiveType,
+  nodeEndLine,
+  setTypeMapEntry,
+} from './helpers.js';
 
 /**
  * Extract symbols from CUDA files.
@@ -218,7 +224,7 @@ function handleCudaDeclaration(node: TreeSitterNode, ctx: ExtractorOutput): void
   if (!typeNode) return;
   const typeName = typeNode.text;
   // Skip primitive types — they are never class/struct receivers
-  if (isCudaPrimitiveType(typeName)) return;
+  if (isCPrimitiveType(typeName)) return;
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     if (!child) continue;
@@ -409,42 +415,6 @@ function innerCudaDeclarator(node: TreeSitterNode): TreeSitterNode | null {
     }
   }
   return null;
-}
-
-/**
- * Primitive C/C++/CUDA types that are never class/struct receivers. Seeding
- * these into typeMap would produce spurious receiver edges (e.g. `int x` → `int`).
- */
-const CUDA_PRIMITIVE_TYPES = new Set([
-  'int',
-  'long',
-  'short',
-  'unsigned',
-  'signed',
-  'float',
-  'double',
-  'char',
-  'bool',
-  'void',
-  'wchar_t',
-  'auto',
-  'size_t',
-  'uint8_t',
-  'uint16_t',
-  'uint32_t',
-  'uint64_t',
-  'int8_t',
-  'int16_t',
-  'int32_t',
-  'int64_t',
-  'ptrdiff_t',
-  'intptr_t',
-  'uintptr_t',
-]);
-
-function isCudaPrimitiveType(typeName: string): boolean {
-  const base = typeName.split(/\s+/).pop() ?? typeName;
-  return CUDA_PRIMITIVE_TYPES.has(base) || CUDA_PRIMITIVE_TYPES.has(typeName);
 }
 
 function extractCudaEnumEntries(enumNode: TreeSitterNode): SubDeclaration[] {

--- a/src/extractors/helpers.ts
+++ b/src/extractors/helpers.ts
@@ -305,6 +305,49 @@ export function pushImport(
   ctx.imports.push(entry);
 }
 
+// ── C-family primitive types ───────────────────────────────────────────────
+
+/**
+ * Primitive C/C++/CUDA types that are never class/struct receivers. Seeding
+ * these into typeMap would produce spurious receiver edges (e.g. `int x` → `int`).
+ * Shared between the C++ and CUDA extractors to prevent divergence.
+ */
+export const C_PRIMITIVE_TYPES: ReadonlySet<string> = new Set([
+  'int',
+  'long',
+  'short',
+  'unsigned',
+  'signed',
+  'float',
+  'double',
+  'char',
+  'bool',
+  'void',
+  'wchar_t',
+  'auto',
+  'size_t',
+  'uint8_t',
+  'uint16_t',
+  'uint32_t',
+  'uint64_t',
+  'int8_t',
+  'int16_t',
+  'int32_t',
+  'int64_t',
+  'ptrdiff_t',
+  'intptr_t',
+  'uintptr_t',
+]);
+
+/**
+ * Return true when `typeName` is a primitive C/C++/CUDA type.
+ * Strips leading qualifiers (`const int` → `int`) before checking.
+ */
+export function isCPrimitiveType(typeName: string): boolean {
+  const base = typeName.split(/\s+/).pop() ?? typeName;
+  return C_PRIMITIVE_TYPES.has(base) || C_PRIMITIVE_TYPES.has(typeName);
+}
+
 // ── Parameter extraction ───────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- `CPP_PRIMITIVE_TYPES` (cpp.ts) and `CUDA_PRIMITIVE_TYPES` (cuda.ts) were byte-for-byte identical 24-member sets, requiring manual mirroring on every update
- Extracted a single `C_PRIMITIVE_TYPES: ReadonlySet<string>` constant and `isCPrimitiveType()` predicate into `src/extractors/helpers.ts`
- Updated both `cpp.ts` and `cuda.ts` to import and delegate to the shared helper — no behavioral change

## Test plan

- [ ] `npm test` passes (180 test files, 3046 tests — all green)
- [ ] Biome lint passes (no format or lint errors)

Closes #1507
Closes #1518