### PR TITLE
fix(native): resolve this-dispatch in func-prop methods (#1512)

### DIFF
--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -701,8 +701,13 @@ const THIS_DISPATCH_EXTS = new Set(['.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs'
  * `this`/`super` receivers, then resolves them through the class hierarchy stored
  * in DB `extends` edges — mirroring what `buildChaPostPass` does on the WASM path.
  *
- * Only runs when `extends` edges exist in the DB; if there is no inheritance
- * hierarchy there is nothing to resolve via `this`/`super` dispatch.
+ * Also handles function-as-object-property methods (`f.h = function() { this.g() }`):
+ * these use `this` to reference sibling properties on the same object (`f`), so
+ * `resolveThisDispatch` resolves them by treating the dot-prefix of the caller name
+ * (`f` from `f.h`) as the class and looking up `f.g` directly — no `extends` edge needed.
+ *
+ * Runs when either `extends` edges exist (class inheritance) OR dot-named `method`
+ * nodes exist (func-prop assignments); skips only when neither is present.
  */
 async function runPostNativeThisDispatch(
   db: BetterSqlite3Database,
@@ -715,26 +720,39 @@ async function runPostNativeThisDispatch(
   // Files containing endpoints of newly inserted edges — lets the caller scope
   // role re-classification to the nodes whose fan-in/out actually changed.
   const affectedFiles = new Set<string>();
-  // Fast guard: need at least one extends edge for this/super to have meaning
-  const hasExtends = db.prepare(`SELECT 1 FROM edges WHERE kind = 'extends' LIMIT 1`).get();
-  if (!hasExtends) return { elapsedMs: 0, targetIds, affectedFiles };
 
-  // Build parents map: child class → direct parent class (from `extends` edges)
-  const parentRows = db
-    .prepare(`
-      SELECT src.name AS child_name, tgt.name AS parent_name
-      FROM edges e
-      JOIN nodes src ON e.source_id = src.id
-      JOIN nodes tgt ON e.target_id = tgt.id
-      WHERE e.kind = 'extends'
-    `)
-    .all() as Array<{ child_name: string; parent_name: string }>;
+  // Fast guard: need at least one extends edge (class inheritance) OR a dot-named
+  // method node (func-prop assignment: `f.h = function() { this.g() }`) for
+  // this/super dispatch to produce any edges.
+  const hasExtends = db.prepare(`SELECT 1 FROM edges WHERE kind = 'extends' LIMIT 1`).get();
+  const hasFuncPropMethod = db
+    .prepare(`SELECT 1 FROM nodes WHERE kind = 'method' AND INSTR(name, '.') > 0 LIMIT 1`)
+    .get();
+  if (!hasExtends && !hasFuncPropMethod) return { elapsedMs: 0, targetIds, affectedFiles };
+
+  // Build parents map: child class → direct parent class (from `extends` edges).
+  // May be empty when only func-prop methods exist (no class inheritance) —
+  // resolveThisDispatch handles that case via direct class-prefix lookup.
+  const parentRows = hasExtends
+    ? (db
+        .prepare(`
+          SELECT src.name AS child_name, tgt.name AS parent_name
+          FROM edges e
+          JOIN nodes src ON e.source_id = src.id
+          JOIN nodes tgt ON e.target_id = tgt.id
+          WHERE e.kind = 'extends'
+        `)
+        .all() as Array<{ child_name: string; parent_name: string }>)
+    : [];
 
   const parents = new Map<string, string>();
   for (const row of parentRows) {
     if (!parents.has(row.child_name)) parents.set(row.child_name, row.parent_name);
   }
-  if (parents.size === 0) return { elapsedMs: 0, targetIds, affectedFiles };
+  // Note: parents may be empty when hasFuncPropMethod but !hasExtends — that is
+  // intentional. resolveThisDispatch still resolves `this.g()` inside `f.h` by
+  // treating `f` (the dot-prefix of callerName `f.h`) as the class and looking
+  // up `f.g` directly via lookup.byName(), without traversing the parents chain.
 
   const chaCtx: ChaContext = {
     implementors: new Map(), // not needed for this/super resolution
@@ -747,13 +765,11 @@ async function runPostNativeThisDispatch(
   // On a full build we do NOT re-parse every JS/TS file — that would WASM-parse
   // the entire project on top of the native pass, causing a massive regression
   // (measured: +358% ms/file on codegraph itself). Instead we restrict to files
-  // that are part of the class inheritance hierarchy: both subclass files (which
-  // contain `super.X()` calls dispatching to a parent) and parent-class files
-  // (whose method bodies contain `this.X()` calls that CHA must resolve). Any
-  // file not in the hierarchy has no `extends` relationship, so `this`/`super`
-  // calls in it either resolve locally (same-class dispatch, already handled by
-  // the direct-call edge) or have no class context — and will be skipped by
-  // `resolveThisDispatch` anyway.
+  // that are part of the class inheritance hierarchy (both subclass files with
+  // `super.X()` calls and parent-class files with `this.X()` calls) OR that
+  // contain dot-named method nodes (func-prop assignments whose bodies may call
+  // `this.sibling()`). Any file not in either set has no class or object context
+  // where `this`/`super` dispatch would produce new edges.
   let relFiles: string[];
   if (isFullBuild || !changedFiles) {
     const rows = db
@@ -768,6 +784,9 @@ async function runPostNativeThisDispatch(
           FROM edges e
           JOIN nodes tgt ON e.target_id = tgt.id
           WHERE e.kind = 'extends' AND tgt.file IS NOT NULL
+          UNION
+          SELECT file FROM nodes
+          WHERE kind = 'method' AND INSTR(name, '.') > 0 AND file IS NOT NULL
         )
       `)
       .all() as Array<{ file: string }>;

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -85,6 +85,7 @@ const TECHNIQUE_MAP: Record<string, string> = {
   'class-inheritance': 'cha-rta',
   'class-hierarchy': 'cha-rta',
   'trait-dispatch': 'cha-rta',
+  'this-dispatch-func-prop': 'cha-rta',
   're-export': 'barrel',
   closure: 'points-to',
   'higher-order': 'points-to',


### PR DESCRIPTION
## Summary

- `runPostNativeThisDispatch` had three bugs preventing `this.g()` inside `f.h = function(){}` (func-prop methods) from resolving on the native engine path
- The guard required `extends` edges before even starting — but func-prop `this`-dispatch uses the dot-prefix of the caller name (`f` from `f.h`) as the class prefix, needing no class inheritance at all
- Full-build file selection only unioned files touched by `extends` edges, so func-prop-only files were never re-parsed
- Empty `parents` map caused an early-return, even though `resolveThisDispatch` works correctly with an empty parents map (direct class-prefix lookup)

## Root Cause

`runPostNativeThisDispatch` was designed around class inheritance (`extends` edges) and never accounted for the func-prop pattern. `resolveThisDispatch` already handles it correctly: for caller `f.h`, it extracts class prefix `f`, then looks up `f.g` via `lookup.byName()` — no parents traversal needed. The post-pass just never gave it the right files or the chance to run.

## Fix (`src/domain/graph/builder/stages/native-orchestrator.ts`)

1. **Guard** — fire when `extends` edges exist OR when dot-named `method` nodes exist (`INSTR(name, '.') > 0`); skip the costly `extends` JOIN entirely when no `extends` edges are present
2. **parents map** — remove the `parents.size === 0` early return; an empty parents map is valid and correct for the pure func-prop case
3. **File selection** — add a third `UNION` arm to include files containing any dot-named `method` node

Also adds `this-dispatch-func-prop` to `TECHNIQUE_MAP` in `resolution-benchmark.test.ts` so the mode is correctly bucketed as `cha-rta`.

## Test plan

- `npm run lint` — clean (757 files, no fixes)
- `npm test` — 660 tests pass; the 2 failures are pre-existing from a concurrent open worktree for #1513 (untracked test file, unrelated)
- `jelly-micro/this` fixture (`f.h → f.g`, recall floor `1.0`) tests WASM-only and already passes; native path fix is validated by parity

Closes #1512