### PR TITLE
fix(receiver): local function constructors block cross-file class receiver edges

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -649,7 +649,7 @@ fn process_file<'a>(
             }
         }
 
-        emit_receiver_edge(ctx, call, caller_id, rel_path, &type_map, &mut seen_edges, edges);
+        emit_receiver_edge(ctx, call, caller_id, rel_path, &type_map, &imported_names, &mut seen_edges, edges);
     }
 
     emit_hierarchy_edges(ctx, file_input, rel_path, edges);
@@ -1025,6 +1025,7 @@ fn emit_call_edges(
 fn emit_receiver_edge(
     ctx: &EdgeContext, call: &CallInfo, caller_id: u32, rel_path: &str,
     type_map: &HashMap<&str, (&str, f64)>,
+    imported_names: &HashMap<&str, &str>,
     seen_edges: &mut HashSet<u64>, edges: &mut Vec<ComputedEdge>,
 ) {
     let Some(ref receiver) = call.receiver else { return };
@@ -1035,18 +1036,21 @@ fn emit_receiver_edge(
     let type_entry = type_map.get(receiver.as_str());
     let effective_receiver = type_entry.map(|&(t, _)| t).unwrap_or(receiver.as_str());
 
-    // Filter-before: apply receiver_kinds to same-file candidates first, then
-    // fall back to global candidates (also filtered) only when same-file yields
-    // nothing.  This prevents an imported name emitted as kind='function' in the
-    // importing file from blocking the fallback to the actual class/struct/etc.
-    // node in the defining file.
-    let samefile_candidates: Vec<&NodeInfo> = ctx.nodes_by_name_and_file
+    // Block global fallback only when the same-file node is a local definition,
+    // not when it's an import artifact (e.g. `const { C } = require(…)` seeds a
+    // kind="function" node in the importer but the real class lives elsewhere).
+    // A locally-defined `function C(){}` owns the name — no cross-file class
+    // should shadow it (issue #1539).  Mirror of JS resolveReceiverEdge logic.
+    let samefile_all: Vec<&NodeInfo> = ctx.nodes_by_name_and_file
         .get(&(effective_receiver, rel_path))
-        .cloned().unwrap_or_default()
-        .into_iter()
+        .cloned().unwrap_or_default();
+    let is_local_definition = !samefile_all.is_empty()
+        && !imported_names.contains_key(effective_receiver);
+    let samefile_candidates: Vec<&NodeInfo> = samefile_all.iter()
+        .copied()
         .filter(|n| ctx.receiver_kinds.contains(n.kind.as_str()))
         .collect();
-    let receiver_nodes: Vec<&NodeInfo> = if !samefile_candidates.is_empty() {
+    let receiver_nodes: Vec<&NodeInfo> = if is_local_definition {
         samefile_candidates
     } else {
         ctx.nodes_by_name.get(effective_receiver).cloned().unwrap_or_default()
@@ -1816,11 +1820,13 @@ mod call_edge_tests {
     }
 
     /// Regression: when the same file has a `kind="function"` node for the
-    /// effective receiver (e.g. `Calculator` imported via destructuring), the
-    /// same-file "function" node must NOT block the fallback to the global
-    /// class node in another file.  Filter-before semantics required.
+    /// effective receiver created by a destructured import (e.g.
+    /// `const { Calculator } = require('./utils')`), that import artifact must
+    /// NOT block the fallback to the global class node in another file.
+    /// The import must be listed in `imported_names` so the resolver knows it
+    /// is an import artifact, not a local function-constructor definition.
     #[test]
-    fn receiver_edge_filter_before_skips_same_file_function_node() {
+    fn receiver_edge_imported_function_node_falls_through_to_global_class() {
         let all_nodes = vec![
             node(1, "main",       "function", "index.js", 3),
             // Destructured import `const { Calculator } = require('./utils')` → kind "function" in index.js
@@ -1829,12 +1835,49 @@ mod call_edge_tests {
             node(3, "compute",    "method",   "utils.js", 3),
         ];
 
-        let files = vec![make_file(
+        let mut file = make_file(
             "index.js",
             10,
             vec![def("main", "function", 3, 8)],
             vec![call("compute", 7, Some("calc"))],
             vec![type_map_entry("calc", "Calculator", 1.0)],
+            vec![],
+        );
+        // Mark `Calculator` as an imported name so the resolver treats the
+        // same-file kind="function" node as an import artifact and falls through.
+        file.imported_names = vec![ImportedName { name: "Calculator".to_string(), file: "utils.js".to_string() }];
+
+        let edges = build_call_edges(vec![file], all_nodes, vec![]);
+
+        let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
+        assert!(
+            receiver_edge.is_some(),
+            "imported 'function' node must not block fallback to global class; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+        let re = receiver_edge.unwrap();
+        assert_eq!(re.target_id, 2, "receiver edge must point to Calculator class (id=2), not import artifact (id=4)");
+    }
+
+    /// Issue #1539: `function C(){}` (function constructor) in the same file as
+    /// `var v = new C(); v.foo()` must block the global fallback to any cross-file
+    /// class `C`.  A locally-defined function constructor owns the name in its
+    /// file — no cross-file class should win over it.
+    #[test]
+    fn receiver_edge_local_function_ctor_blocks_global_class() {
+        let all_nodes = vec![
+            node(1, "C",     "function", "prototypes.js", 1),  // local function constructor
+            node(2, "C.foo", "method",   "prototypes.js", 3),
+            node(3, "C",     "class",    "classes.js",    1),  // cross-file class with same name
+        ];
+
+        // No imported_names — `C` is locally defined.
+        let files = vec![make_file(
+            "prototypes.js",
+            10,
+            vec![def("C", "function", 1, 2)],
+            vec![call("foo", 8, Some("v"))],
+            vec![type_map_entry("v", "C", 1.0)],
             vec![],
         )];
 
@@ -1842,12 +1885,10 @@ mod call_edge_tests {
 
         let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
         assert!(
-            receiver_edge.is_some(),
-            "same-file 'function' node must not block fallback to global class; got: {:?}",
+            receiver_edge.is_none(),
+            "local function constructor must block global class fallback — no receiver edge expected; got: {:?}",
             edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
         );
-        let re = receiver_edge.unwrap();
-        assert_eq!(re.target_id, 2, "receiver edge must point to Calculator class (id=2), not function (id=4)");
     }
 
     /// Issue #1453: `this.logger.error()` inside `UserService.create` where the

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -355,13 +355,17 @@ export function resolveCallTargets(
  * Returns the edge tuple to insert, or null if nothing matched or the edge
  * was already seen.  Callers are responsible for the actual DB/array insert.
  *
- * Receiver resolution collects all same-file candidates first (no kind
- * filter), falls back to global candidates only when the same-file set is
- * entirely empty, then filters the chosen set by RECEIVER_KINDS.  This
- * matches the native Rust build path: if a file imports a name that happens
- * to be emitted as `kind='function'` in the importer, the same-file set is
- * non-empty and blocks the global fallback, so no receiver edge is emitted.
- * Keeping this behaviour identical to the Rust path maintains engine parity.
+ * Receiver resolution:
+ * 1. Look up same-file nodes for `effectiveReceiver` (unfiltered by kind).
+ * 2. If any same-file node exists AND `effectiveReceiver` is not in `importedNames`
+ *    (i.e. it is a locally-defined symbol, not an import artifact), apply
+ *    RECEIVER_KINDS and return the filtered set — no global fallback.
+ *    A local `function C(){}` means this file owns `C`; no cross-file class
+ *    should win over it (issue #1539).
+ * 3. If the same-file node IS an import artifact (e.g. destructured require),
+ *    or no same-file node exists at all, fall back to global candidates filtered
+ *    by RECEIVER_KINDS.  This preserves the pre-#1539 behaviour for cases where
+ *    an imported name appears as kind='function' in the importer file.
  */
 export function resolveReceiverEdge(
   lookup: CallNodeLookup,
@@ -370,6 +374,7 @@ export function resolveReceiverEdge(
   relPath: string,
   typeMap: Map<string, unknown>,
   seenCallEdges: Set<string>,
+  importedNames?: ReadonlyMap<string, string>,
 ): { callerId: number; receiverId: number; confidence: number } | null {
   const typeEntry = typeMap.get(call.receiver);
   const typeName = typeEntry
@@ -382,18 +387,15 @@ export function resolveReceiverEdge(
       ? ((typeEntry as { confidence?: number }).confidence ?? null)
       : null;
   const effectiveReceiver = typeName || call.receiver;
-  // Filter-before: apply RECEIVER_KINDS to same-file candidates first, then
-  // fall back to global candidates (also filtered) only when same-file yields
-  // nothing.  This prevents an imported name emitted as kind='function' in the
-  // importing file from blocking the fallback to the actual class/struct/etc.
-  // node in the defining file.
-  const sameFileCandidates = lookup
-    .byNameAndFile(effectiveReceiver, relPath)
-    .filter((n) => RECEIVER_KINDS.has(n.kind ?? ''));
-  const candidates =
-    sameFileCandidates.length > 0
-      ? sameFileCandidates
-      : lookup.byName(effectiveReceiver).filter((n) => RECEIVER_KINDS.has(n.kind ?? ''));
+  // Block global fallback only when the same-file node is a local definition,
+  // not when it's an import artifact (e.g. `const { C } = require(…)` seeds a
+  // kind='function' node in the importer but the real class lives elsewhere).
+  const sameFileAll = lookup.byNameAndFile(effectiveReceiver, relPath);
+  const isLocalDefinition = sameFileAll.length > 0 && !importedNames?.has(effectiveReceiver);
+  const sameFileCandidates = sameFileAll.filter((n) => RECEIVER_KINDS.has(n.kind ?? ''));
+  const candidates = isLocalDefinition
+    ? sameFileCandidates
+    : lookup.byName(effectiveReceiver).filter((n) => RECEIVER_KINDS.has(n.kind ?? ''));
   if (candidates.length === 0) return null;
   const recvTarget = candidates[0]!;
   const recvKey = `recv|${caller.id}|${recvTarget.id}`;

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -374,7 +374,7 @@ export function resolveReceiverEdge(
   relPath: string,
   typeMap: Map<string, unknown>,
   seenCallEdges: Set<string>,
-  importedNames?: ReadonlyMap<string, string>,
+  importedNames: ReadonlyMap<string, string>,
 ): { callerId: number; receiverId: number; confidence: number } | null {
   const typeEntry = typeMap.get(call.receiver);
   const typeName = typeEntry

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -620,6 +620,7 @@ function buildCallEdges(
         relPath,
         typeMap,
         seenCallEdges,
+        importedNames,
       );
       if (recv) {
         stmts.insertEdge.run(recv.callerId, recv.receiverId, 'receiver', recv.confidence, 0);

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1293,6 +1293,7 @@ function buildFileCallEdges(
         relPath,
         typeMap as Map<string, unknown>,
         seenCallEdges,
+        importedNames,
       );
       if (recv) {
         allEdgeRows.push([recv.callerId, recv.receiverId, 'receiver', recv.confidence, 0, null]);

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -16,7 +16,10 @@
  */
 import { describe, expect, it } from 'vitest';
 import type { CallNodeLookup } from '../../src/domain/graph/builder/call-resolver.js';
-import { resolveByMethodOrGlobal } from '../../src/domain/graph/builder/call-resolver.js';
+import {
+  resolveByMethodOrGlobal,
+  resolveReceiverEdge,
+} from '../../src/domain/graph/builder/call-resolver.js';
 
 function makeLookup(
   methodMap: Record<string, Array<{ id: number; file: string; kind: string }>>,
@@ -206,5 +209,82 @@ describe('resolveByMethodOrGlobal — bare-call JS/TS module-scope guard (#1407)
     );
     // C# is not module-scoped → same-class fallback runs → Processor.Flush found
     expect(result).toEqual([csMethod]);
+  });
+});
+
+// ── resolveReceiverEdge ──────────────────────────────────────────────────────
+
+/**
+ * Build a CallNodeLookup where:
+ *  - `sameFile` is keyed by `"name:file"` and returned by `byNameAndFile`
+ *  - `global` is keyed by `"name"` and returned by `byName`
+ */
+function makeReceiverLookup(
+  sameFile: Record<string, Array<{ id: number; file: string; kind: string }>>,
+  global: Record<string, Array<{ id: number; file: string; kind: string }>>,
+): CallNodeLookup {
+  return {
+    byNameAndFile(name, file) {
+      return sameFile[`${name}:${file}`] ?? [];
+    },
+    byName(name) {
+      return global[name] ?? [];
+    },
+    isBarrel() {
+      return false;
+    },
+    resolveBarrel() {
+      return null;
+    },
+    nodeId() {
+      return undefined;
+    },
+  };
+}
+
+describe('resolveReceiverEdge — local function constructor blocks global class (#1539)', () => {
+  // Scenario: file "a.ts" defines `function Cache(){}` (kind='function').
+  // File "b.ts" has a class `Cache` (kind='class').
+  // A call in "a.ts" uses `new Cache()` — the same-file function constructor must
+  // win; the cross-file class must NOT become the receiver edge target.
+  const localFn = { id: 1, file: 'a.ts', kind: 'function' };
+  const globalClass = { id: 2, file: 'b.ts', kind: 'class' };
+
+  it('local function constructor blocks cross-file class when not an import artifact', () => {
+    const lookup = makeReceiverLookup(
+      { 'Cache:a.ts': [localFn] },
+      { Cache: [localFn, globalClass] },
+    );
+    const result = resolveReceiverEdge(
+      lookup,
+      { name: 'get', receiver: 'Cache' },
+      { id: 99 },
+      'a.ts',
+      new Map(),
+      new Set(),
+      new Map(), // Cache is NOT in importedNames — it is locally defined
+    );
+    // isLocalDefinition=true → candidates = sameFileCandidates filtered by RECEIVER_KINDS
+    // localFn.kind='function' is not in RECEIVER_KINDS → candidates empty → null
+    expect(result).toBeNull();
+  });
+
+  it('cross-file class wins when same-file node is an import artifact', () => {
+    // `Cache` appears in `a.ts` only because of `const { Cache } = require('./b')`
+    // — it seeds a kind='function' node in the importer. importedNames records it.
+    const lookup = makeReceiverLookup({ 'Cache:a.ts': [localFn] }, { Cache: [globalClass] });
+    const result = resolveReceiverEdge(
+      lookup,
+      { name: 'get', receiver: 'Cache' },
+      { id: 99 },
+      'a.ts',
+      new Map(),
+      new Set(),
+      new Map([['Cache', './b']]), // Cache IS in importedNames — it is an import artifact
+    );
+    // isLocalDefinition=false → candidates = global byName filtered by RECEIVER_KINDS
+    // globalClass.kind='class' IS in RECEIVER_KINDS → edge to id=2
+    expect(result).not.toBeNull();
+    expect(result?.receiverId).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- `resolveReceiverEdge` (both WASM and native paths) was applying `RECEIVER_KINDS` as a pre-filter *before* deciding whether to fall back to global candidates. When a file contains `function C(){}` (kind=`'function'`), the same-file `C` node was filtered out, leaving the same-file set empty, which triggered the global fallback and picked an unrelated cross-file `C(class)`.
- Fix: check same-file presence (unfiltered) first. If the same-file node is a **locally-defined** symbol (not listed in `importedNames`), use the kind-filtered same-file set — no global fallback. If the same-file node is an **import artifact** (`importedNames` has the name), fall through to global candidates so the real class in the defining file wins.
- Both TypeScript (WASM path: `call-resolver.ts`, `build-edges.ts`, `incremental.ts`) and Rust (native path: `build_edges.rs`) are updated with identical logic.

## Test plan

- [ ] `npm test` — all 180 test files pass, all 3048 tests pass
- [ ] `node scripts/parity-compare.mjs --langs jelly-micro` — `prototypes/prototypes.js` receiver edge divergence is gone; remaining divergences are pre-existing issues tracked in #1506, #1510, #1538
- [ ] `node scripts/parity-compare.mjs --langs javascript` — PARITY OK
- [ ] New Rust unit test `receiver_edge_local_function_ctor_blocks_global_class` — verifies function constructor blocks global class fallback
- [ ] Updated Rust unit test `receiver_edge_imported_function_node_falls_through_to_global_class` — verifies import artifacts still fall through to the global class correctly (seeds `imported_names` in the test fixture)

Closes #1539