### PR TITLE
fix(native): skip callback-reference calls for this()/super() call expressions

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -4254,25 +4254,25 @@ mod tests {
         );
     }
 
-    /// `super(a)` must NOT emit `a` as a dynamic callback-reference call.
+    /// `super(a, b)` must NOT emit `a` or `b` as dynamic callback-reference calls.
     /// Same root cause as this(b): the callee `super` is not a named identifier,
     /// so extract_callback_reference_calls must not run on the arguments.
     #[test]
     fn super_call_args_do_not_emit_callback_reference_calls() {
         let s = parse_js(
-            "class E { constructor(c) { this.cc = c; } }\n\
+            "class E { constructor(c, d) { this.cc = c; this.dd = d; } }\n\
              class G extends E {\n\
-               constructor(a, b) { super(a); this.bb = b; }\n\
+               constructor(a, b) { super(a, b); }\n\
              }",
         );
         assert!(
             !s.calls.iter().any(|c| c.name == "a"),
-            "argument `a` of super(a) must not become a callback-reference call; got: {:?}",
+            "argument `a` of super(a, b) must not become a callback-reference call; got: {:?}",
             s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
         );
         assert!(
             !s.calls.iter().any(|c| c.name == "b"),
-            "argument `b` of this.bb = b must not become a callback-reference call; got: {:?}",
+            "argument `b` of super(a, b) must not become a callback-reference call; got: {:?}",
             s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
         );
     }

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1215,6 +1215,19 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         handle_dynamic_import(node, &fn_node, source, symbols);
         return;
     }
+    // `this(args)` and `super(args)` — the callee is `this`/`super` used as a
+    // function, not a named identifier.  The `this` call record is emitted by
+    // collect_this_call_and_bindings (called from match_js_pts_bindings).
+    // Neither case should emit callback-reference calls for the arguments, because
+    // those arguments are values passed *to* the rebound function — not callbacks
+    // of the enclosing scope.  Without this guard, identifier arguments like `b`
+    // in `this(b)` or `a` in `super(a)` become spurious dynamic calls that the
+    // pts resolver resolves to globally-defined functions with the same name in
+    // other files, producing false cross-file call edges.
+    // Mirrors the early-return guard in the TS handleCallExpr (javascript.ts:1135).
+    if fn_node.kind() == "this" || fn_node.kind() == "super" {
+        return;
+    }
     if let Some(call_info) = extract_call_info(&fn_node, node, source) {
         symbols.calls.push(call_info);
     }
@@ -4088,6 +4101,51 @@ mod tests {
         let b = s.this_call_bindings.iter().find(|b| b.callee == "invoker");
         assert!(b.is_some(), "this_call_bindings should contain invoker→handler; got: {:?}", s.this_call_bindings);
         assert_eq!(b.unwrap().this_arg, "handler");
+    }
+
+    /// `this(b)` must NOT emit `b` as a dynamic callback-reference call.
+    /// Without the early-return guard, `b` would be emitted as a dynamic call
+    /// and the pts resolver would match any globally-defined function named `b`,
+    /// producing false cross-file call edges (issue #1543).
+    #[test]
+    fn this_call_args_do_not_emit_callback_reference_calls() {
+        let s = parse_js(
+            "function foo(b) { return this(b); }\n\
+             foo.call((a) => a, () => {});",
+        );
+        assert!(
+            s.calls.iter().any(|c| c.name == "this"),
+            "this() must be recorded; got: {:?}",
+            s.calls.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        assert!(
+            !s.calls.iter().any(|c| c.name == "b"),
+            "argument `b` of this(b) must not become a callback-reference call; got: {:?}",
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+        );
+    }
+
+    /// `super(a)` must NOT emit `a` as a dynamic callback-reference call.
+    /// Same root cause as this(b): the callee `super` is not a named identifier,
+    /// so extract_callback_reference_calls must not run on the arguments.
+    #[test]
+    fn super_call_args_do_not_emit_callback_reference_calls() {
+        let s = parse_js(
+            "class E { constructor(c) { this.cc = c; } }\n\
+             class G extends E {\n\
+               constructor(a, b) { super(a); this.bb = b; }\n\
+             }",
+        );
+        assert!(
+            !s.calls.iter().any(|c| c.name == "a"),
+            "argument `a` of super(a) must not become a callback-reference call; got: {:?}",
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+        );
+        assert!(
+            !s.calls.iter().any(|c| c.name == "b"),
+            "argument `b` of this.bb = b must not become a callback-reference call; got: {:?}",
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- In `handle_call_expr` (Rust JS extractor), when the callee node is `this` or `super` used as a function (`this(b)`, `super(a)`), `extract_callback_reference_calls` was running and emitting identifier arguments as spurious dynamic calls
- The pts resolver then matched those names globally, producing false cross-file call edges (e.g. `fun/fun.js:foo → spread/spread.js:b`, `classes2/classes2.js:G.constructor → prototypes3/prototypes3.js:a`)
- Fix: add an early return in `handle_call_expr` for `fn_node.kind() == "this" || fn_node.kind() == "super"`, mirroring the existing guard in the TS `handleCallExpr` (`javascript.ts:1135`)
- Add two regression tests covering both `this(b)` and `super(a)` argument non-emission

## Root cause

The JS extractor (`javascript.ts`) has an early return at line 1135 when the function node type is `this`:
```typescript
if (fn.type === 'this') {
  ctx.calls.push({ name: 'this', line: nodeStartLine(node) });
  return; // no further processing needed for this()-style calls
}
```

The Rust extractor (`javascript.rs`) only checked for `fn_node.kind() == "import"` before calling `extract_callback_reference_calls`, so `this(b)` / `super(a)` calls would emit `b` and `a` as dynamic calls. The pts resolver then resolved those names globally, finding same-named functions in sibling fixture files.

## Test plan

- [x] Two new Rust unit tests pass: `this_call_args_do_not_emit_callback_reference_calls`, `super_call_args_do_not_emit_callback_reference_calls`
- [x] All 408 Rust unit tests pass
- [x] All 180 JS test files pass (3048 tests)
- [x] `node scripts/parity-compare.mjs --langs jelly-micro` eliminates all 6 targeted false-positive edges (13 → 12 divergences; the 6 fixed are the exact ones listed in #1543; the remaining 12 are pre-existing issues)

Closes #1543