### PR TITLE
fix(cha): skip CHA expansion for super-dispatch edges

### DIFF
--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -464,13 +464,14 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
 
   const callToMethods = db
     .prepare(
-      `SELECT e.source_id, tgt.name AS method_name
+      `SELECT e.source_id, src.name AS caller_name, tgt.name AS method_name
        FROM edges e
        JOIN nodes tgt ON e.target_id = tgt.id
+       JOIN nodes src ON e.source_id = src.id
        WHERE e.kind = 'calls' AND tgt.kind = 'method'
        AND INSTR(tgt.name, '.') > 0`,
     )
-    .all() as Array<{ source_id: number; method_name: string }>;
+    .all() as Array<{ source_id: number; caller_name: string; method_name: string }>;
 
   const seen = new Set<string>();
   // Scope deduplication to only the source_ids we are about to expand, avoiding
@@ -497,11 +498,24 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
   const findMethodStmt = db.prepare(`SELECT id FROM nodes WHERE name = ? AND kind = 'method'`);
   const newEdges: Array<[number, number, string, number, number, string]> = [];
 
-  for (const { source_id, method_name } of callToMethods) {
+  for (const { source_id, caller_name, method_name } of callToMethods) {
     const dotIdx = method_name.indexOf('.');
     if (dotIdx === -1) continue;
     const typeName = method_name.slice(0, dotIdx);
     const methodSuffix = method_name.slice(dotIdx + 1);
+
+    // Super-dispatch guard: if the caller's class is itself a direct child of
+    // typeName (i.e. callerClass extends typeName), the existing edge is a
+    // super.method() call going up the hierarchy — not an interface dispatch.
+    // Expanding it to sibling subclasses of typeName would produce false edges:
+    // those siblings are unrelated to the caller and would never be invoked by
+    // that super call. Skip CHA expansion entirely for super-dispatch edges.
+    const callerDotIdx = caller_name.indexOf('.');
+    if (callerDotIdx !== -1) {
+      const callerClass = caller_name.slice(0, callerDotIdx);
+      const directChildrenOfType = implementors.get(typeName);
+      if (directChildrenOfType?.includes(callerClass)) continue;
+    }
 
     // BFS over the implementors map — handles multi-level hierarchies where
     // abstract/non-instantiated classes sit between the call-site type and

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -470,7 +470,7 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
        JOIN nodes src ON e.source_id = src.id
        WHERE e.kind = 'calls' AND tgt.kind = 'method'
        AND INSTR(tgt.name, '.') > 0
-       AND (e.technique IS NULL OR e.technique != 'cha')`,
+       AND (e.technique IS NULL OR e.technique != 'super-dispatch')`,
     )
     .all() as Array<{ source_id: number; caller_name: string; method_name: string }>;
 
@@ -499,24 +499,11 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
   const findMethodStmt = db.prepare(`SELECT id FROM nodes WHERE name = ? AND kind = 'method'`);
   const newEdges: Array<[number, number, string, number, number, string]> = [];
 
-  for (const { source_id, caller_name, method_name } of callToMethods) {
+  for (const { source_id, method_name } of callToMethods) {
     const dotIdx = method_name.indexOf('.');
     if (dotIdx === -1) continue;
     const typeName = method_name.slice(0, dotIdx);
     const methodSuffix = method_name.slice(dotIdx + 1);
-
-    // Super-dispatch guard: if the caller's class is itself a direct child of
-    // typeName (i.e. callerClass extends typeName), the existing edge is a
-    // super.method() call going up the hierarchy — not an interface dispatch.
-    // Expanding it to sibling subclasses of typeName would produce false edges:
-    // those siblings are unrelated to the caller and would never be invoked by
-    // that super call. Skip CHA expansion entirely for super-dispatch edges.
-    const callerDotIdx = caller_name.indexOf('.');
-    if (callerDotIdx !== -1) {
-      const callerClass = caller_name.slice(0, callerDotIdx);
-      const directChildrenOfType = implementors.get(typeName);
-      if (directChildrenOfType?.includes(callerClass)) continue;
-    }
 
     // BFS over the implementors map — handles multi-level hierarchies where
     // abstract/non-instantiated classes sit between the call-site type and

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -748,7 +748,10 @@ function buildChaPostPass(
             : computeConfidence(relPath, t.file, null) - CHA_DISPATCH_PENALTY;
           if (conf > 0) {
             seenByPair.add(edgeKey);
-            allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'cha']);
+            // Tag super-dispatch edges distinctly so runChaPostPass can exclude them
+            // from further CHA expansion (super calls are not virtual dispatch).
+            const technique = call.receiver === 'super' ? 'super-dispatch' : 'cha';
+            allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, technique]);
           }
         }
       }

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -572,16 +572,26 @@ function runPostNativeCha(
   // incremental role reclassification; confidence uses CHA_TYPED_DISPATCH_CONFIDENCE matching runChaPostPass.
   // When scopeToChangedFiles is true, restrict to call sites in the changed files
   // (safe because no hierarchy or RTA evidence changed outside those files).
-  let callToMethods: Array<{ source_id: number; method_name: string; caller_file: string | null }>;
+  let callToMethods: Array<{
+    source_id: number;
+    caller_name: string;
+    method_name: string;
+    caller_file: string | null;
+  }>;
   if (scopeToChangedFiles && changedFiles && changedFiles.length > 0) {
     const CHUNK_SIZE = 500;
-    const rows: Array<{ source_id: number; method_name: string; caller_file: string | null }> = [];
+    const rows: Array<{
+      source_id: number;
+      caller_name: string;
+      method_name: string;
+      caller_file: string | null;
+    }> = [];
     for (let i = 0; i < changedFiles.length; i += CHUNK_SIZE) {
       const chunk = changedFiles.slice(i, i + CHUNK_SIZE);
       const ph = chunk.map(() => '?').join(',');
       const chunkRows = db
         .prepare(
-          `SELECT e.source_id, tgt.name AS method_name, src.file AS caller_file
+          `SELECT e.source_id, src.name AS caller_name, tgt.name AS method_name, src.file AS caller_file
            FROM edges e
            JOIN nodes tgt ON e.target_id = tgt.id
            JOIN nodes src ON e.source_id = src.id
@@ -591,6 +601,7 @@ function runPostNativeCha(
         )
         .all(...chunk) as Array<{
         source_id: number;
+        caller_name: string;
         method_name: string;
         caller_file: string | null;
       }>;
@@ -600,14 +611,19 @@ function runPostNativeCha(
   } else {
     callToMethods = db
       .prepare(`
-        SELECT e.source_id, tgt.name AS method_name, src.file AS caller_file
+        SELECT e.source_id, src.name AS caller_name, tgt.name AS method_name, src.file AS caller_file
         FROM edges e
         JOIN nodes tgt ON e.target_id = tgt.id
         JOIN nodes src ON e.source_id = src.id
         WHERE e.kind = 'calls' AND tgt.kind = 'method'
         AND INSTR(tgt.name, '.') > 0
       `)
-      .all() as Array<{ source_id: number; method_name: string; caller_file: string | null }>;
+      .all() as Array<{
+      source_id: number;
+      caller_name: string;
+      method_name: string;
+      caller_file: string | null;
+    }>;
   }
 
   // Seed seen-pairs only from the source_ids we'll be expanding — avoids loading every
@@ -635,11 +651,24 @@ function runPostNativeCha(
   const newEdges: Array<[number, number, string, number, number, string]> = [];
   let newEdgeCount = 0;
 
-  for (const { source_id, method_name, caller_file } of callToMethods) {
+  for (const { source_id, caller_name, method_name, caller_file } of callToMethods) {
     const dotIdx = method_name.indexOf('.');
     if (dotIdx === -1) continue;
     const typeName = method_name.slice(0, dotIdx);
     const methodSuffix = method_name.slice(dotIdx + 1);
+
+    // Super-dispatch guard: if the caller's class is itself a direct child of
+    // typeName (i.e. callerClass extends typeName), the existing edge is a
+    // super.method() call going up the hierarchy — not an interface dispatch.
+    // Expanding it to sibling subclasses of typeName would produce false edges:
+    // those siblings are unrelated to the caller and would never be invoked by
+    // that super call. Skip CHA expansion entirely for super-dispatch edges.
+    const callerDotIdx = caller_name.indexOf('.');
+    if (callerDotIdx !== -1) {
+      const callerClass = caller_name.slice(0, callerDotIdx);
+      const directChildrenOfType = implementors.get(typeName);
+      if (directChildrenOfType?.includes(callerClass)) continue;
+    }
 
     // BFS over the implementors map — handles multi-level hierarchies where
     // abstract/non-instantiated classes sit between the call-site type and

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -597,7 +597,7 @@ function runPostNativeCha(
            JOIN nodes src ON e.source_id = src.id
            WHERE e.kind = 'calls' AND tgt.kind = 'method'
            AND INSTR(tgt.name, '.') > 0
-           AND (e.technique IS NULL OR e.technique != 'cha')
+           AND (e.technique IS NULL OR e.technique != 'super-dispatch')
            AND src.file IN (${ph})`,
         )
         .all(...chunk) as Array<{
@@ -618,7 +618,7 @@ function runPostNativeCha(
         JOIN nodes src ON e.source_id = src.id
         WHERE e.kind = 'calls' AND tgt.kind = 'method'
         AND INSTR(tgt.name, '.') > 0
-        AND (e.technique IS NULL OR e.technique != 'cha')
+        AND (e.technique IS NULL OR e.technique != 'super-dispatch')
       `)
       .all() as Array<{
       source_id: number;
@@ -653,24 +653,11 @@ function runPostNativeCha(
   const newEdges: Array<[number, number, string, number, number, string]> = [];
   let newEdgeCount = 0;
 
-  for (const { source_id, caller_name, method_name, caller_file } of callToMethods) {
+  for (const { source_id, method_name, caller_file } of callToMethods) {
     const dotIdx = method_name.indexOf('.');
     if (dotIdx === -1) continue;
     const typeName = method_name.slice(0, dotIdx);
     const methodSuffix = method_name.slice(dotIdx + 1);
-
-    // Super-dispatch guard: if the caller's class is itself a direct child of
-    // typeName (i.e. callerClass extends typeName), the existing edge is a
-    // super.method() call going up the hierarchy — not an interface dispatch.
-    // Expanding it to sibling subclasses of typeName would produce false edges:
-    // those siblings are unrelated to the caller and would never be invoked by
-    // that super call. Skip CHA expansion entirely for super-dispatch edges.
-    const callerDotIdx = caller_name.indexOf('.');
-    if (callerDotIdx !== -1) {
-      const callerClass = caller_name.slice(0, callerDotIdx);
-      const directChildrenOfType = implementors.get(typeName);
-      if (directChildrenOfType?.includes(callerClass)) continue;
-    }
 
     // BFS over the implementors map — handles multi-level hierarchies where
     // abstract/non-instantiated classes sit between the call-site type and
@@ -979,7 +966,10 @@ async function runPostNativeThisDispatch(
         seen.add(key);
         const conf = computeConfidence(relPath, t.file, null) - CHA_DISPATCH_PENALTY;
         if (conf <= 0) continue;
-        newEdges.push([callerRow.id, t.id, 'calls', conf, 0, 'cha']);
+        // Tag super-dispatch edges distinctly so runPostNativeCha can exclude them
+        // from further CHA expansion (super calls are not virtual dispatch).
+        const technique = call.receiver === 'super' ? 'super-dispatch' : 'cha';
+        newEdges.push([callerRow.id, t.id, 'calls', conf, 0, technique]);
         targetIds.add(t.id);
         affectedFiles.add(relPath);
         if (t.file) affectedFiles.add(t.file);

--- a/tests/fixtures/cha-dispatch/Tiger.ts
+++ b/tests/fixtures/cha-dispatch/Tiger.ts
@@ -1,0 +1,7 @@
+import { Animal } from './Animal.js';
+
+export class Tiger extends Animal {
+  speak(): string {
+    return 'ROAR';
+  }
+}

--- a/tests/integration/phase-8.5-cha-dispatch.test.ts
+++ b/tests/integration/phase-8.5-cha-dispatch.test.ts
@@ -148,6 +148,19 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
     ).toBeDefined();
   });
 
+  it('super-dispatch: does NOT CHA-expand Lion.speak to sibling Tiger.speak', () => {
+    // Tiger is also a subclass of Animal (sibling to Lion). A super.speak() call
+    // in Lion.speak goes to Animal.speak — it must NOT be CHA-expanded to
+    // Tiger.speak (a sibling), which Lion would never invoke.
+    const edge = callEdges.find(
+      (e) => e.caller_name === 'Lion.speak' && e.callee_name === 'Tiger.speak',
+    );
+    expect(
+      edge,
+      `Expected NO Lion.speak → Tiger.speak edge (super-dispatch must not expand to sibling subclasses).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeUndefined();
+  });
+
   // ── transitive multi-level CHA (issue #1311) ───────────────────────────
   // Hierarchy: IJob → AbstractJob (non-instantiated) → PrintJob / ScanJob
   // resolveChaTargets must BFS through AbstractJob to reach the concrete types.


### PR DESCRIPTION
## Summary

- `runChaPostPass` (WASM path) and `runPostNativeCha` (native orchestrator path) incorrectly expanded `super.method()` dispatch edges to sibling subclasses of the target type, producing 6 false `PostMixin.* → B.*` call edges in the `super4` jelly-micro fixture
- Root cause: both functions BFS-expand any `caller → TypeName.method` edge to all implementors of `TypeName`, without checking whether the caller itself is a direct subclass of `TypeName` (which would mean the edge was a `super.method()` call going *up*, not virtual dispatch going *down*)
- Fix: before the BFS expansion loop, extract `callerClass` from `caller_name` and skip expansion if `callerClass` is in `implementors.get(typeName)` — i.e., the caller is a direct child of the target type

## Test plan

- [ ] `node scripts/parity-compare.mjs --langs jelly-micro` no longer reports the 6 `PostMixin` false edges
- [ ] `npm test` — all 3048 tests pass
- [ ] `npm run lint` — no issues

Closes #1544