### PR TITLE
fix(native): expand super-dispatch edges into CHA sibling overrides (#1544)

### DIFF
--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -48,9 +48,9 @@ export const BUILTIN_RECEIVERS: Set<string> = new Set([
   'require',
 ]);
 
-/** Phase 8.5: confidence penalty applied to CHA-dispatch edges. */
+/** Phase 8.6: confidence penalty applied to CHA-dispatch edges. */
 export const CHA_DISPATCH_PENALTY = 0.1;
-/** Phase 8.5: fixed confidence for typed-receiver (interface/CHA) dispatch edges.
+/** Phase 8.6: fixed confidence for typed-receiver (interface/CHA) dispatch edges.
  *  File proximity is not meaningful for virtual dispatch — all three engine paths
  *  (WASM inline, WASM post-pass, native post-pass) must agree on this value. */
 export const CHA_TYPED_DISPATCH_CONFIDENCE = 0.8;

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -469,7 +469,7 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
        JOIN nodes tgt ON e.target_id = tgt.id
        WHERE e.kind = 'calls' AND tgt.kind = 'method'
        AND INSTR(tgt.name, '.') > 0
-       AND (e.technique IS NULL OR e.technique != 'cha')`,
+       AND (e.technique IS NULL OR e.technique != 'cha-expanded')`,
     )
     .all() as Array<{ source_id: number; method_name: string }>;
 
@@ -532,7 +532,7 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
               'calls',
               CHA_TYPED_DISPATCH_CONFIDENCE,
               0,
-              'cha',
+              'cha-expanded',
             ]);
           }
         }

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -587,7 +587,7 @@ function runPostNativeCha(
            JOIN nodes src ON e.source_id = src.id
            WHERE e.kind = 'calls' AND tgt.kind = 'method'
            AND INSTR(tgt.name, '.') > 0
-           AND (e.technique IS NULL OR e.technique != 'cha')
+           AND (e.technique IS NULL OR e.technique != 'cha-expanded')
            AND src.file IN (${ph})`,
         )
         .all(...chunk) as Array<{
@@ -607,7 +607,7 @@ function runPostNativeCha(
         JOIN nodes src ON e.source_id = src.id
         WHERE e.kind = 'calls' AND tgt.kind = 'method'
         AND INSTR(tgt.name, '.') > 0
-        AND (e.technique IS NULL OR e.technique != 'cha')
+        AND (e.technique IS NULL OR e.technique != 'cha-expanded')
       `)
       .all() as Array<{ source_id: number; method_name: string; caller_file: string | null }>;
   }
@@ -669,7 +669,7 @@ function runPostNativeCha(
             if (seen.has(key)) continue;
             seen.add(key);
             const conf = CHA_TYPED_DISPATCH_CONFIDENCE;
-            newEdges.push([source_id, methodNode.id, 'calls', conf, 0, 'cha']);
+            newEdges.push([source_id, methodNode.id, 'calls', conf, 0, 'cha-expanded']);
             newEdgeCount++;
             if (caller_file) affectedFiles.add(caller_file);
             if (methodNode.method_file) affectedFiles.add(methodNode.method_file);
@@ -1581,9 +1581,30 @@ export async function tryNativeOrchestrator(
   }
   const gapDetectMs = performance.now() - gapDetectStart;
 
+  // Phase 8.5: this/super dispatch — hybrid WASM re-parse to resolve call sites
+  // whose raw receiver info the Rust pipeline does not persist to DB.
+  // Runs BEFORE the CHA expansion pass so that super.method() → Parent.method edges
+  // (technique='cha') are in the DB when runPostNativeCha expands them to sibling
+  // class overrides (e.g. PostMixin.m → B.m when PostMixin and B both extend A).
+  const {
+    elapsedMs: thisDispatchMs,
+    targetIds: thisDispatchTargetIds,
+    affectedFiles: thisDispatchAffectedFiles,
+  } = await runPostNativeThisDispatch(
+    ctx.db as unknown as BetterSqlite3Database,
+    ctx.rootDir,
+    result.changedFiles,
+    !!result.isFullBuild,
+  );
+
   // Phase 8.5: expand CHA call edges (interface dispatch → concrete implementations).
   // Returns the affected files so role re-classification below can be scoped to
   // the nodes whose fan-in/out actually changed.
+  //
+  // Runs AFTER this/super dispatch so super.method() edges are already in the DB.
+  // The 'cha-expanded' technique tag on this pass's own output prevents re-expansion
+  // of those edges in subsequent incremental builds, while 'cha'-tagged edges from
+  // this/super dispatch remain eligible for expansion here.
   //
   // Function-as-object-property methods (`fn.method = function() {}`) are extracted
   // natively by the Rust engine (#1432) and resolved in-build by its edge builder, so
@@ -1595,19 +1616,6 @@ export async function tryNativeOrchestrator(
     result.isFullBuild ? null : (result.changedFiles ?? null),
   );
   const chaMs = performance.now() - chaStart;
-
-  // Phase 8.5: this/super dispatch — hybrid WASM re-parse to resolve call sites
-  // whose raw receiver info the Rust pipeline does not persist to DB.
-  const {
-    elapsedMs: thisDispatchMs,
-    targetIds: thisDispatchTargetIds,
-    affectedFiles: thisDispatchAffectedFiles,
-  } = await runPostNativeThisDispatch(
-    ctx.db as unknown as BetterSqlite3Database,
-    ctx.rootDir,
-    result.changedFiles,
-    !!result.isFullBuild,
-  );
 
   // Role re-classification after JS edge-writing post-passes.
   // The Rust orchestrator classifies roles before these post-passes (CHA,

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -390,7 +390,7 @@ async function runPostNativeAnalysis(
 }
 
 /**
- * Phase 8.5: CHA expansion post-pass for the native orchestrator path.
+ * Phase 8.6: CHA expansion post-pass for the native orchestrator path.
  *
  * The Rust build pipeline resolves typed receiver calls (e.g. `worker.doWork()`
  * where `worker: IWorker`) to the interface method declaration only.  This
@@ -1616,7 +1616,7 @@ export async function tryNativeOrchestrator(
     !!result.isFullBuild,
   );
 
-  // Phase 8.5: expand CHA call edges (interface dispatch → concrete implementations).
+  // Phase 8.6: expand CHA call edges (interface dispatch → concrete implementations).
   // Returns the affected files so role re-classification below can be scoped to
   // the nodes whose fan-in/out actually changed.
   //


### PR DESCRIPTION
## Summary

- `runPostNativeCha` was filtering out edges with `technique='cha'`, preventing it from expanding `super.method() → Parent.method` edges already inserted by `runPostNativeThisDispatch` (which also tags its edges as `technique='cha'`)
- Additionally, `runPostNativeCha` was running **before** `runPostNativeThisDispatch`, so the super-dispatch seed edges weren't yet in the DB when the BFS expansion ran
- Fixed by: (1) reordering so `runPostNativeThisDispatch` runs first, and (2) renaming the CHA expansion output to `technique='cha-expanded'` and updating both filter queries to exclude `'cha-expanded'` instead of `'cha'`

After this fix, native produces 6 CHA edges matching WASM (e.g. `PostMixin.m → B.m` across jelly-micro fixtures where `PostMixin` and `B` both extend `A`).

## Test plan

- [x] Ran full test suite (`npm test`): same 3 pre-existing failures (filed as #1552), 0 new regressions
- [x] Manually verified that native now produces all 6 expected CHA edges in the jelly-micro/super4 fixture (`cha-expanded` technique, 967 total edges matching pre-fix count)

Closes #1544