### PR TITLE
feat(config): user-level (global) config with per-repo consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,8 @@ Copy `.github/workflows/codegraph-impact.yml` to your repo, and every PR will ge
 
 Create a `.codegraphrc.json` in your project root to customize behavior. The snippets below cover the most-used keys — see **[docs/guides/configuration.md](docs/guides/configuration.md)** for the full reference (every group, every key, every default).
 
+**Global (user-level) config:** you can also define personal defaults once at `~/.config/codegraph/config.json` and opt individual repos into it with `codegraph config --enable-global`. The global layer merges below the project config so repos always win, and non-interactive contexts (CI, MCP) never apply it without explicit consent. See [docs/guides/configuration.md#user-level-global-configuration](docs/guides/configuration.md#user-level-global-configuration).
+
 ```json
 {
   "include": ["src/**", "lib/**"],

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -32,6 +32,97 @@ Leaves `build.dbPath`, `build.driftThreshold`, etc. at their defaults. Arrays ar
 
 ---
 
+## User-level (global) configuration
+
+You can define **personal config defaults once** and reuse them across repositories — without committing anything to any repo, and without ever silently changing a repo's behavior.
+
+**The defining property:** a global config file is inert until a specific repository explicitly consents to it. There is no blanket "apply everywhere" switch.
+
+### Global config file location
+
+Codegraph resolves the global config file in this order:
+
+1. `CODEGRAPH_USER_CONFIG=<path>` env var (location override only — does not force application)
+2. `$XDG_CONFIG_HOME/codegraph/config.json` (Unix/macOS), or `%APPDATA%\codegraph\config.json` (Windows), falling back to `~/.config/codegraph/config.json`
+3. `~/.codegraph/config.json` (legacy fallback, next to `registry.json`)
+
+### Format
+
+The global config file uses the same schema as `.codegraphrc.json`. Two shapes are accepted:
+
+```jsonc
+// Plain config — applies to any repo that has consented
+{ "query": { "defaultLimit": 50 }, "exclude": ["**/*.generated.*"] }
+```
+
+```jsonc
+// With appliesTo — auto-consent for matching repo paths (power-user)
+{
+  "appliesTo": ["~/work/**", "/Users/me/oss/*"],
+  "config": { "query": { "defaultLimit": 50 } }
+}
+```
+
+### Consent model
+
+A global config file has no effect until a repository consents to it. Consent is per-repo and per-machine (stored in `~/.codegraph/registry.json`, never committed):
+
+| Command | Effect |
+|---------|--------|
+| `codegraph config --enable-global` | Record `enabled` consent for the current repo |
+| `codegraph config --disable-global` | Record `disabled` consent for the current repo |
+| `codegraph config --list-global` | List every repo with a recorded decision |
+| `codegraph build` (interactive) | Prompts once if the repo is undecided and a global file exists |
+
+**Non-interactive contexts** (CI, MCP, programmatic use, hooks) never get prompted and default to *off*, keeping builds reproducible.
+
+**Per-run overrides** (do not record consent):
+- `--user-config [path]` — force-on for this run (optional custom path)
+- `--no-user-config` — force-off for this run
+
+### Precedence
+
+```
+DEFAULTS → global (if consented) → project (.codegraphrc.json) → env vars → secrets
+```
+
+- Objects are **deep-merged** (later layers win per key)
+- Arrays and scalars **replace** (project `ignoreDirs` fully replaces global `ignoreDirs`)
+- A project that omits a key inherits from the global layer
+
+### Safety guard
+
+If the global file sets `build.dbPath` to an **absolute path**, codegraph drops that key with a warning (it would make every repo share one database). Relative `dbPath` values are allowed through unchanged.
+
+### Transparency
+
+- `codegraph config` — print the effective config; shows a discovery hint when a global file exists but is not applied
+- `codegraph config --explain` — per-key provenance (`default` / `user` / `project` / `env`) plus consent state and applied file paths
+- Build notice — when the global layer contributes build-affecting keys, codegraph prints a one-line notice: `ℹ global config applied (<path>) — injecting: ...  · --no-user-config to ignore`
+
+### Programmatic API
+
+```typescript
+import { loadConfig, loadConfigWithProvenance } from '@optave/codegraph';
+
+// Normal: honour per-repo consent from registry
+loadConfig('/path/to/repo');
+
+// Force-on: apply the default global file
+loadConfig('/path/to/repo', { userConfig: true });
+
+// Force-on with explicit file
+loadConfig('/path/to/repo', { userConfig: '/path/to/global.json' });
+
+// Force-off
+loadConfig('/path/to/repo', { userConfig: false });
+
+// With provenance info (for tooling)
+const { config, provenance, appliedGlobalPath } = loadConfigWithProvenance('/path/to/repo');
+```
+
+---
+
 ## File selection
 
 Controls which files codegraph parses.

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -16,7 +16,10 @@ export const command: CommandDefinition = {
   ],
   async execute([dir], opts, ctx) {
     const root = path.resolve(dir || '.');
-    const engine = ctx.program.opts().engine;
+    const globalOpts = ctx.program.opts();
+    const engine = globalOpts.engine;
+    // Prompt for global-config consent on interactive TTY builds (§4.3).
+    const promptForConsent = !process.env.CI && !!process.stdin.isTTY && !!process.stdout.isTTY;
     await buildGraph(root, {
       incremental: opts.incremental as boolean,
       ast: opts.ast as boolean,
@@ -25,6 +28,8 @@ export const command: CommandDefinition = {
       dataflow: opts.dataflow as boolean,
       cfg: opts.cfg as boolean,
       dbPath: opts.db ? path.resolve(opts.db as string) : undefined,
+      userConfig: globalOpts.userConfig as string | boolean | undefined,
+      promptForConsent,
     });
   },
 };

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,156 @@
+import path from 'node:path';
+import {
+  clearConfigCache,
+  loadConfig,
+  loadConfigWithProvenance,
+  resolveUserConfigPath,
+} from '../../infrastructure/config.js';
+import {
+  getUserConfigConsent,
+  listUserConfigConsent,
+  REGISTRY_PATH,
+  setUserConfigConsent,
+} from '../../infrastructure/registry.js';
+import type { CommandDefinition } from '../types.js';
+
+export const command: CommandDefinition = {
+  name: 'config',
+  description: 'Show or manage codegraph configuration (project + user-level global config)',
+  options: [
+    ['-j, --json', 'Output as JSON'],
+    ['--explain', 'Show per-key provenance (default / user / project / env)'],
+    ['--enable-global', 'Record consent to apply the global config to this repo'],
+    ['--disable-global', 'Record consent to skip the global config for this repo'],
+    ['--list-global', 'List all repos with a recorded consent decision'],
+  ],
+  execute(_args, opts, ctx) {
+    const rootDir = path.resolve('.');
+
+    // ── Consent management ─────────────────────────────────────────────
+
+    if (opts.enableGlobal) {
+      setUserConfigConsent(rootDir, 'enabled');
+      clearConfigCache();
+      const globalPath = resolveUserConfigPath();
+      if (!globalPath) {
+        process.stderr.write(
+          `Consent recorded: "enabled" for ${rootDir}\n` +
+            `Note: no global config file found. Create one at ~/.config/codegraph/config.json\n`,
+        );
+      } else {
+        process.stderr.write(
+          `Consent recorded: "enabled" for ${rootDir}\n` + `Global config: ${globalPath}\n`,
+        );
+      }
+      return;
+    }
+
+    if (opts.disableGlobal) {
+      setUserConfigConsent(rootDir, 'disabled');
+      clearConfigCache();
+      process.stderr.write(`Consent recorded: "disabled" for ${rootDir}\n`);
+      return;
+    }
+
+    if (opts.listGlobal) {
+      const entries = listUserConfigConsent(REGISTRY_PATH);
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(entries, null, 2)}\n`);
+        return;
+      }
+      if (entries.length === 0) {
+        process.stdout.write('No repos have a recorded global-config consent decision.\n');
+        return;
+      }
+      process.stdout.write('Global config consent decisions:\n\n');
+      for (const { path: p, decision } of entries) {
+        process.stdout.write(
+          `  ${decision === 'enabled' ? '✔' : '✘'} ${decision.padEnd(8)} ${p}\n`,
+        );
+      }
+      return;
+    }
+
+    // ── Explain mode ───────────────────────────────────────────────────
+
+    if (opts.explain) {
+      const { config, provenance, appliedGlobalPath, consentDecision } = loadConfigWithProvenance(
+        rootDir,
+        {
+          userConfig: ctx.program.opts().userConfig,
+        },
+      );
+      const globalPath = resolveUserConfigPath();
+      const consent = getUserConfigConsent(rootDir);
+
+      if (opts.json) {
+        process.stdout.write(
+          `${JSON.stringify(
+            {
+              config,
+              provenance,
+              appliedGlobalPath,
+              globalFilePath: globalPath,
+              consentDecision: consentDecision ?? consent ?? 'undecided',
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        return;
+      }
+
+      // Human-readable explain output
+      process.stdout.write('=== Codegraph config provenance ===\n\n');
+
+      const consentStr = consentDecision ?? consent ?? 'undecided';
+      process.stdout.write(`Global config file : ${globalPath ?? '(none found)'}\n`);
+      process.stdout.write(`Applied this run   : ${appliedGlobalPath ? 'yes' : 'no'}\n`);
+      process.stdout.write(`Consent for repo   : ${consentStr}\n`);
+      process.stdout.write(
+        `  (change with \`codegraph config --enable-global\` or \`--disable-global\`)\n`,
+      );
+
+      if (!globalPath) {
+        process.stdout.write(
+          `\nDiscovery hint: create a global config at ~/.config/codegraph/config.json\n` +
+            `then run \`codegraph config --enable-global\` in repos where you want it applied.\n`,
+        );
+      } else if (!appliedGlobalPath) {
+        process.stdout.write(
+          `\nDiscovery hint: global config exists but is not applied to this repo.\n` +
+            `Run \`codegraph config --enable-global\` to enable it here.\n`,
+        );
+      }
+
+      process.stdout.write('\n--- Per-key provenance ---\n\n');
+      const provenanceEntries = Object.entries(provenance).sort(([a], [b]) => a.localeCompare(b));
+      for (const [key, source] of provenanceEntries) {
+        process.stdout.write(`  ${source.padEnd(8)} ${key}\n`);
+      }
+      return;
+    }
+
+    // ── Default: print effective config ────────────────────────────────
+
+    const globalPath = resolveUserConfigPath();
+    const consent = getUserConfigConsent(rootDir);
+    const config = loadConfig(rootDir, { userConfig: ctx.program.opts().userConfig });
+
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
+      return;
+    }
+
+    // Print a short summary with a discovery hint if relevant
+    process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
+
+    if (globalPath && !consent) {
+      process.stderr.write(
+        `\nℹ Global config found at ${globalPath} — not applied to this repo.\n` +
+          `  Run \`codegraph config --enable-global\` to opt in, or\n` +
+          `  \`codegraph config --disable-global\` to dismiss this notice.\n`,
+      );
+    }
+  },
+};

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -137,15 +137,10 @@ export const command: CommandDefinition = {
     const consent = getUserConfigConsent(rootDir);
     const config = loadConfig(rootDir, { userConfig: ctx.program.opts().userConfig });
 
-    if (opts.json) {
-      process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
-      return;
-    }
-
-    // Print a short summary with a discovery hint if relevant
+    // Print effective config — always JSON; discovery hint only in non-JSON mode
     process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
 
-    if (globalPath && !consent) {
+    if (!opts.json && globalPath && !consent) {
       process.stderr.write(
         `\nℹ Global config found at ${globalPath} — not applied to this repo.\n` +
           `  Run \`codegraph config --enable-global\` to opt in, or\n` +

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Command } from 'commander';
+import { setUserConfigOverride } from '../infrastructure/config.js';
 import { setVerbose } from '../infrastructure/logger.js';
 import { checkForUpdates, printUpdateNotification } from '../infrastructure/update-check.js';
 import { ConfigError } from '../shared/errors.js';
@@ -25,9 +26,16 @@ program
   .version(pkg.version)
   .option('-v, --verbose', 'Enable verbose/debug output')
   .option('--engine <engine>', 'Parser engine: native, wasm, or auto (default: auto)', 'auto')
+  .option('--user-config [path]', 'Apply global user config for this run (optional custom path)')
+  .option('--no-user-config', 'Skip global user config for this run')
   .hook('preAction', (thisCommand) => {
     const opts = thisCommand.opts();
     if (opts.verbose) setVerbose(true);
+    // Wire user-config flags into the config loader before any command runs.
+    // Commander sets opts.userConfig = true (bare flag), a string (path), or undefined.
+    // opts.userConfig is false when --no-user-config is passed (Commander negation).
+    const uc = opts.userConfig as string | boolean | undefined;
+    setUserConfigOverride(uc);
   })
   .hook('postAction', async (_thisCommand, actionCommand) => {
     const name = actionCommand.name();

--- a/src/cli/shared/options.ts
+++ b/src/cli/shared/options.ts
@@ -1,8 +1,18 @@
 import type { Command } from 'commander';
 import { loadConfig } from '../../infrastructure/config.js';
+import type { CodegraphConfig } from '../../types.js';
 import type { CommandOpts } from '../types.js';
 
-const config = loadConfig(process.cwd());
+// Deferred so global --user-config / --no-user-config flags are parsed
+// before config is first accessed (Commander parses flags before any command
+// action runs, but module-level code executes at import time).
+let _config: CodegraphConfig | undefined;
+const config: CodegraphConfig = new Proxy({} as CodegraphConfig, {
+  get(_t, prop: string) {
+    if (_config === undefined) _config = loadConfig(process.cwd());
+    return _config[prop as keyof CodegraphConfig];
+  },
+}) as CodegraphConfig;
 
 /**
  * Attach the common query options shared by most analysis commands.

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -18,6 +18,7 @@ import {
 import {
   computeConfigHash,
   detectWorkspaces,
+  getLastAppliedGlobalConfig,
   getLastAppliedGlobalPath,
   loadConfig,
   promptForConsentIfNeeded,
@@ -203,6 +204,8 @@ function setupPipeline(ctx: PipelineContext): void {
     ctx.opts.incremental !== false && ctx.config.build && ctx.config.build.incremental !== false;
 
   // ── Build-time global-config notice ──────────────────────────────
+  // Use the already-parsed and sanitized global config cached by loadConfig —
+  // avoids a second disk read and the TOCTOU window between loadConfig and here.
   const appliedGlobalPath = getLastAppliedGlobalPath();
   if (appliedGlobalPath) {
     const buildAffectingKeys = [
@@ -213,21 +216,14 @@ function setupPipeline(ctx: PipelineContext): void {
       'aliases',
       'build',
     ];
-    try {
-      const raw = JSON.parse(fs.readFileSync(appliedGlobalPath, 'utf-8')) as Record<
-        string,
-        unknown
-      >;
-      const globalData: Record<string, unknown> =
-        'appliesTo' in raw && raw.config ? (raw.config as Record<string, unknown>) : raw;
+    const globalData = getLastAppliedGlobalConfig();
+    if (globalData) {
       const injectedKeys = buildAffectingKeys.filter((k) => k in globalData);
       if (injectedKeys.length > 0) {
         process.stderr.write(
           `ℹ global config applied (${appliedGlobalPath}) — injecting: ${injectedKeys.join(', ')} · --no-user-config to ignore\n`,
         );
       }
-    } catch {
-      // Non-critical — skip on any read error
     }
   }
 

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -15,7 +15,13 @@ import {
   MIGRATIONS,
   openDb,
 } from '../../../db/index.js';
-import { detectWorkspaces, loadConfig } from '../../../infrastructure/config.js';
+import {
+  computeConfigHash,
+  detectWorkspaces,
+  getLastAppliedGlobalPath,
+  loadConfig,
+  promptForConsentIfNeeded,
+} from '../../../infrastructure/config.js';
 import { debug, info, warn } from '../../../infrastructure/logger.js';
 import { loadNative } from '../../../infrastructure/native.js';
 import { toErrorMessage } from '../../../shared/errors.js';
@@ -114,6 +120,16 @@ function checkEngineSchemaMismatch(ctx: PipelineContext): void {
     );
     ctx.forceFullRebuild = true;
   }
+
+  // Config hash — promotes to full rebuild when build-relevant config changes
+  // (include/exclude/ignoreDirs/extensions/aliases/build.*).
+  // This closes the pre-existing config-change gap and covers the new global-config layer.
+  const currentConfigHash = computeConfigHash(ctx.config);
+  const prevConfigHash = meta('config_hash');
+  if (prevConfigHash && prevConfigHash !== currentConfigHash) {
+    info('Build-relevant config changed, promoting to full rebuild.');
+    ctx.forceFullRebuild = true;
+  }
 }
 
 function warnOnEmbeddingsWipe(ctx: PipelineContext): void {
@@ -172,7 +188,7 @@ function setupPipeline(ctx: PipelineContext): void {
   ctx.db = openDb(ctx.dbPath);
   initSchema(ctx.db);
 
-  ctx.config = loadConfig(ctx.rootDir);
+  ctx.config = loadConfig(ctx.rootDir, { userConfig: ctx.opts.userConfig });
   // Merge caller-supplied excludes on top of the file-config excludes so
   // programmatic callers (e.g. benchmark scripts) can extend exclusion
   // without mutating .codegraphrc.json. Native orchestrator picks this up
@@ -185,6 +201,35 @@ function setupPipeline(ctx: PipelineContext): void {
   }
   ctx.incremental =
     ctx.opts.incremental !== false && ctx.config.build && ctx.config.build.incremental !== false;
+
+  // ── Build-time global-config notice ──────────────────────────────
+  const appliedGlobalPath = getLastAppliedGlobalPath();
+  if (appliedGlobalPath) {
+    const buildAffectingKeys = [
+      'include',
+      'exclude',
+      'ignoreDirs',
+      'extensions',
+      'aliases',
+      'build',
+    ];
+    try {
+      const raw = JSON.parse(fs.readFileSync(appliedGlobalPath, 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+      const globalData: Record<string, unknown> =
+        'appliesTo' in raw && raw.config ? (raw.config as Record<string, unknown>) : raw;
+      const injectedKeys = buildAffectingKeys.filter((k) => k in globalData);
+      if (injectedKeys.length > 0) {
+        process.stderr.write(
+          `ℹ global config applied (${appliedGlobalPath}) — injecting: ${injectedKeys.join(', ')} · --no-user-config to ignore\n`,
+        );
+      }
+    } catch {
+      // Non-critical — skip on any read error
+    }
+  }
 
   initializeEngine(ctx);
   checkEngineSchemaMismatch(ctx);
@@ -348,6 +393,12 @@ export async function buildGraph(
   ctx.rootDir = rootDir;
 
   try {
+    // Interactive consent prompt — only fires when the caller opts in (build
+    // command with TTY), a global file exists, and the repo is undecided.
+    if (opts.promptForConsent) {
+      await promptForConsentIfNeeded(rootDir);
+    }
+
     setupPipeline(ctx);
 
     // ── JS-side fast-skip for native incremental (#1054) ──────────────

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -496,7 +496,7 @@ function handleFullBuild(ctx: PipelineContext): void {
   const hasEmbeddings = detectHasEmbeddings(db, ctx.nativeDb);
   ctx.hasEmbeddings = hasEmbeddings;
   const deletions =
-    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM nodes; PRAGMA foreign_keys = ON;';
+    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM nodes; DELETE FROM file_hashes; PRAGMA foreign_keys = ON;';
   db.exec(
     hasEmbeddings
       ? `${deletions.replace('PRAGMA foreign_keys = ON;', '')} DELETE FROM embeddings; PRAGMA foreign_keys = ON;`

--- a/src/domain/graph/builder/stages/finalize.ts
+++ b/src/domain/graph/builder/stages/finalize.ts
@@ -13,6 +13,7 @@ import {
   getBuildMeta,
   setBuildMeta,
 } from '../../../../db/index.js';
+import { computeConfigHash } from '../../../../infrastructure/config.js';
 import { debug, info, warn } from '../../../../infrastructure/logger.js';
 import { CODEGRAPH_VERSION } from '../../../../shared/version.js';
 import { writeJournalHeader } from '../../journal.js';
@@ -105,6 +106,7 @@ function persistBuildMetadata(
   } catch {
     /* realpath can fail (e.g. path no longer exists); fall back to resolve() */
   }
+  const configHash = computeConfigHash(ctx.config);
   try {
     if (useNativeDb) {
       ctx.nativeDb!.setBuildMeta(
@@ -117,6 +119,7 @@ function persistBuildMetadata(
           node_count: String(nodeCount),
           edge_count: String(actualEdgeCount),
           root_dir: rootDirToWrite,
+          config_hash: configHash,
         }).map(([key, value]) => ({ key, value: String(value) })),
       );
     } else {
@@ -129,6 +132,7 @@ function persistBuildMetadata(
         node_count: nodeCount,
         edge_count: actualEdgeCount,
         root_dir: rootDirToWrite,
+        config_hash: configHash,
       });
     }
   } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,11 @@ export { ownersData } from './features/owners.js';
 export { sequenceData } from './features/sequence.js';
 export { hotspotsData, moduleBoundariesData, structureData } from './features/structure.js';
 export { triageData } from './features/triage.js';
-export { loadConfig } from './infrastructure/config.js';
+export {
+  loadConfig,
+  loadConfigWithProvenance,
+  resolveUserConfigPath,
+} from './infrastructure/config.js';
 export type { ArrayCompatSet } from './shared/constants.js';
 export { EXTENSIONS, IGNORE_DIRS } from './shared/constants.js';
 export {

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -215,17 +215,19 @@ export function resolveUserConfigPath(): string | null {
 
   const home = os.homedir();
 
+  // XDG_CONFIG_HOME takes priority on all platforms when explicitly set.
+  // Falls back to %APPDATA% on Windows, or ~/.config on Unix/macOS.
   let platformDefault: string;
-  if (process.platform === 'win32') {
+  const xdgConfig = process.env.XDG_CONFIG_HOME;
+  if (xdgConfig) {
+    platformDefault = path.join(xdgConfig, 'codegraph', 'config.json');
+  } else if (process.platform === 'win32') {
     const appdata = process.env.APPDATA;
     platformDefault = appdata
       ? path.join(appdata, 'codegraph', 'config.json')
       : path.join(home, '.config', 'codegraph', 'config.json');
   } else {
-    const xdgConfig = process.env.XDG_CONFIG_HOME;
-    platformDefault = xdgConfig
-      ? path.join(xdgConfig, 'codegraph', 'config.json')
-      : path.join(home, '.config', 'codegraph', 'config.json');
+    platformDefault = path.join(home, '.config', 'codegraph', 'config.json');
   }
 
   if (fs.existsSync(platformDefault)) return platformDefault;
@@ -390,10 +392,16 @@ function resolveConsent(
   return { applied: false, globalPath, consentDecision: undefined };
 }
 
-// Last applied global path — exposed so pipeline can emit the build-time notice.
+// Last applied global path and parsed data — exposed so pipeline.ts and
+// loadConfigWithProvenance can reuse the already-parsed file contents without a
+// second disk read (eliminating the TOCTOU window between loadConfig and callers).
 let _lastAppliedGlobalPath: string | null = null;
+let _lastAppliedGlobalConfig: Record<string, unknown> | null = null;
 export function getLastAppliedGlobalPath(): string | null {
   return _lastAppliedGlobalPath;
+}
+export function getLastAppliedGlobalConfig(): Record<string, unknown> | null {
+  return _lastAppliedGlobalConfig;
 }
 
 // ── Build-relevant config hash ──────────────────────────────────────────
@@ -508,10 +516,14 @@ export function loadConfig(cwd?: string, opts?: LoadConfigOpts): CodegraphConfig
 
   // Cache key includes applied global path and override flag so toggled consent is reflected
   const cacheKey = `${cwd}::${applied ? (globalPath ?? 'default') : 'none'}`;
+  // Always update _lastAppliedGlobalPath/_lastAppliedGlobalConfig before returning —
+  // on a cache hit the previous call may have been for a different repo or different
+  // opts, so stale values here would misbehave for programmatic callers making
+  // multiple buildGraph calls in the same process.
+  _lastAppliedGlobalPath = applied ? globalPath : null;
+  _lastAppliedGlobalConfig = null; // updated below if a global file is loaded
   const cached = _configCache.get(cacheKey);
   if (cached) return structuredClone(cached);
-
-  _lastAppliedGlobalPath = applied ? globalPath : null;
 
   // ── Layer 0: DEFAULTS ─────────────────────────────────────────────
   let merged = DEFAULTS as unknown as Record<string, unknown>;
@@ -522,6 +534,9 @@ export function loadConfig(cwd?: string, opts?: LoadConfigOpts): CodegraphConfig
     if (userFileData) {
       debug(`Applying global user config from ${globalPath}`);
       const sanitized = sanitizeUserLayer(userFileData.globalConfig);
+      // Cache the sanitized global data so pipeline.ts and loadConfigWithProvenance
+      // can use it without a second disk read (eliminates TOCTOU window).
+      _lastAppliedGlobalConfig = sanitized;
       merged = mergeConfig(merged, sanitized);
       merged = applyExcludeTestsShorthand(merged, sanitized);
     }
@@ -563,6 +578,10 @@ export function clearConfigCache(): void {
 /**
  * Load config and return it together with per-key provenance information.
  * Used by `codegraph config --explain`.
+ *
+ * Calls loadConfig first so _lastAppliedGlobalConfig is populated, then uses
+ * that cached data for the global-layer provenance — avoiding a second disk
+ * read and eliminating the TOCTOU window between the two reads.
  */
 export function loadConfigWithProvenance(
   cwd?: string,
@@ -576,30 +595,28 @@ export function loadConfigWithProvenance(
     opts?.registryPath,
   );
 
+  // Load (or return from cache) the merged config first — this also populates
+  // _lastAppliedGlobalConfig with the already-parsed and sanitized global layer.
+  const config = loadConfig(cwd, opts);
+
   // Build provenance by tracking which layer supplies each top-level key
   const provenance: Record<string, ConfigSource> = {};
 
   // Layer 0: defaults — everything starts as 'default'
   for (const k of Object.keys(DEFAULTS)) provenance[k] = 'default';
 
-  // Layer 1: global
-  let globalRaw: Record<string, unknown> | null = null;
-  if (applied && globalPath) {
-    const userFileData = loadUserConfigFile(globalPath);
-    if (userFileData) {
-      globalRaw = sanitizeUserLayer(userFileData.globalConfig);
-      for (const k of Object.keys(globalRaw)) provenance[k] = 'user';
-    }
+  // Layer 1: global — reuse the data loadConfig already parsed (no second disk read)
+  const globalRaw = applied && globalPath ? _lastAppliedGlobalConfig : null;
+  if (globalRaw) {
+    for (const k of Object.keys(globalRaw)) provenance[k] = 'user';
   }
 
   // Layer 2: project
-  let projectRaw: Record<string, unknown> | null = null;
   for (const name of CONFIG_FILES) {
     const filePath = path.join(cwd, name);
     if (fs.existsSync(filePath)) {
       try {
         const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
-        projectRaw = raw;
         for (const k of Object.keys(raw)) provenance[k] = 'project';
         break;
       } catch {
@@ -614,10 +631,6 @@ export function loadConfigWithProvenance(
     provenance.llm = 'env';
   }
 
-  void globalRaw;
-  void projectRaw; // used for provenance tracking above
-
-  const config = loadConfig(cwd, opts);
   return { config, provenance, appliedGlobalPath: applied ? globalPath : null, consentDecision };
 }
 

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -1,9 +1,13 @@
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { ConfigError, toErrorMessage } from '../shared/errors.js';
-import type { CodegraphConfig } from '../types.js';
+import { compileGlobs, matchesAny } from '../shared/globs.js';
+import type { CodegraphConfig, ConfigSource, ConsentDecision } from '../types.js';
 import { debug, warn } from './logger.js';
+import { getUserConfigConsent, REGISTRY_PATH, setUserConfigConsent } from './registry.js';
 
 export type { CodegraphConfig } from '../types.js';
 
@@ -166,43 +170,385 @@ export const DEFAULTS = {
   },
 } satisfies CodegraphConfig;
 
+// ── Per-process user-config override (set by CLI flags) ────────────────
+// Set once by the preAction hook before any command runs; cleared when changed.
+let _userConfigOverride: string | boolean | undefined;
+
+/**
+ * Set the per-run user-config override from CLI flags.
+ * Called by the CLI preAction hook before any command executes.
+ * - false  → --no-user-config
+ * - string → --user-config <path>
+ * - true   → --user-config (bare, use default global file)
+ * - undefined → clear override, revert to consent-based resolution
+ */
+export function setUserConfigOverride(v: string | boolean | undefined): void {
+  _userConfigOverride = v;
+  _configCache.clear();
+}
+
 // Per-cwd config cache — avoids re-reading the config file on every query call.
-// The config file rarely changes within a single process lifetime.
+// Key includes the applied global path so toggled flags/consent are reflected.
 const _configCache = new Map<string, CodegraphConfig>();
+
+// ── Global config file location ─────────────────────────────────────────
+
+/**
+ * Resolve the absolute path to the user-level global config file.
+ *
+ * Priority:
+ * 1. CODEGRAPH_USER_CONFIG env var (location override only — not forced-on)
+ * 2. $XDG_CONFIG_HOME/codegraph/config.json  (Unix/macOS)
+ *    %APPDATA%\codegraph\config.json          (Windows)
+ *    fallback: ~/.config/codegraph/config.json
+ * 3. ~/.codegraph/config.json  (legacy, next to registry.json)
+ *
+ * Returns the path of the first existing file, or null if none exist.
+ */
+export function resolveUserConfigPath(): string | null {
+  const envPath = process.env.CODEGRAPH_USER_CONFIG;
+  if (envPath) {
+    if (fs.existsSync(envPath)) return envPath;
+    debug(`CODEGRAPH_USER_CONFIG points to missing file: ${envPath}`);
+    return null;
+  }
+
+  const home = os.homedir();
+
+  let platformDefault: string;
+  if (process.platform === 'win32') {
+    const appdata = process.env.APPDATA;
+    platformDefault = appdata
+      ? path.join(appdata, 'codegraph', 'config.json')
+      : path.join(home, '.config', 'codegraph', 'config.json');
+  } else {
+    const xdgConfig = process.env.XDG_CONFIG_HOME;
+    platformDefault = xdgConfig
+      ? path.join(xdgConfig, 'codegraph', 'config.json')
+      : path.join(home, '.config', 'codegraph', 'config.json');
+  }
+
+  if (fs.existsSync(platformDefault)) return platformDefault;
+
+  const legacyPath = path.join(home, '.codegraph', 'config.json');
+  if (fs.existsSync(legacyPath)) return legacyPath;
+
+  return null;
+}
+
+// ── Global config file loading ──────────────────────────────────────────
+
+interface ParsedUserConfig {
+  globalConfig: Record<string, unknown>;
+  appliesToGlobs: string[];
+}
+
+/**
+ * Read and parse a user-level global config file.
+ * Handles both plain-config and appliesTo-wrapper formats.
+ * Returns null on missing or malformed files (never throws).
+ */
+function loadUserConfigFile(filePath: string): ParsedUserConfig | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    // Wrapper format: { appliesTo: [...], config: {...} }
+    if ('appliesTo' in parsed && typeof parsed.config === 'object' && parsed.config !== null) {
+      const globs = Array.isArray(parsed.appliesTo)
+        ? (parsed.appliesTo as unknown[]).filter((g): g is string => typeof g === 'string')
+        : [];
+      return { globalConfig: parsed.config as Record<string, unknown>, appliesToGlobs: globs };
+    }
+    // Plain config (no appliesTo wrapper)
+    return { globalConfig: parsed, appliesToGlobs: [] };
+  } catch (err) {
+    debug(`Failed to load user config at ${filePath}: ${toErrorMessage(err)}`);
+    return null;
+  }
+}
+
+// ── Safety sanitisation ─────────────────────────────────────────────────
+
+/**
+ * Drop any unsafe keys from the global layer before merging.
+ * Currently: absolute build.dbPath (would make all repos share one DB).
+ * Relative dbPaths resolve per-repo and are allowed through unchanged.
+ */
+function sanitizeUserLayer(raw: Record<string, unknown>): Record<string, unknown> {
+  const build = raw.build as Record<string, unknown> | undefined;
+  if (build && typeof build.dbPath === 'string' && path.isAbsolute(build.dbPath)) {
+    warn(
+      `User config: build.dbPath "${build.dbPath}" is absolute and was ignored ` +
+        '(an absolute dbPath would share one database across all repos).',
+    );
+    const sanitizedBuild = { ...build };
+    delete sanitizedBuild.dbPath;
+    return { ...raw, build: sanitizedBuild };
+  }
+  return raw;
+}
+
+// ── excludeTests shorthand (per-layer) ─────────────────────────────────
+
+/**
+ * Hoist a top-level `excludeTests` key from a raw layer into `query.excludeTests`.
+ * If the layer already has `query.excludeTests`, that value wins (no-op).
+ * Also removes any stale `excludeTests` key that may have leaked into `merged`.
+ */
+function applyExcludeTestsShorthand(
+  merged: Record<string, unknown>,
+  rawLayer: Record<string, unknown>,
+): Record<string, unknown> {
+  if ('excludeTests' in rawLayer) {
+    // Only hoist if this layer doesn't also set query.excludeTests
+    if (!(rawLayer.query && 'excludeTests' in (rawLayer.query as object))) {
+      (merged.query as Record<string, unknown>).excludeTests = Boolean(rawLayer.excludeTests);
+    }
+    const result = { ...merged };
+    delete result.excludeTests;
+    return result;
+  }
+  if ('excludeTests' in merged) {
+    const result = { ...merged };
+    delete result.excludeTests;
+    return result;
+  }
+  return merged;
+}
+
+// ── Consent resolution ──────────────────────────────────────────────────
+
+interface ConsentResolutionResult {
+  applied: boolean;
+  globalPath: string | null;
+  consentDecision: ConsentDecision | undefined;
+}
+
+/**
+ * Resolve whether the global user config should be applied for a given repo.
+ * Implements the §4.1/§4.2 precedence chain from the spec.
+ *
+ * @param rootDir  Absolute repo root.
+ * @param override Per-run override from CLI flags (_userConfigOverride).
+ * @param registryPath  Optional registry path (for tests).
+ */
+function resolveConsent(
+  rootDir: string,
+  override: string | boolean | undefined,
+  registryPath: string = REGISTRY_PATH,
+): ConsentResolutionResult {
+  // §4.1 step 1: --no-user-config
+  if (override === false) {
+    return { applied: false, globalPath: null, consentDecision: undefined };
+  }
+
+  // §4.1 steps 2–3: explicit path or bare --user-config
+  if (override !== undefined) {
+    const explicitPath = typeof override === 'string' ? override : resolveUserConfigPath();
+    if (explicitPath && fs.existsSync(explicitPath)) {
+      return { applied: true, globalPath: explicitPath, consentDecision: undefined };
+    }
+    if (typeof override === 'string') {
+      warn(`--user-config path "${override}" does not exist; skipping global layer.`);
+    }
+    return { applied: false, globalPath: null, consentDecision: undefined };
+  }
+
+  // §4.1 step 4: resolve global file — if none, NOT applied
+  const globalPath = resolveUserConfigPath();
+  if (!globalPath) {
+    return { applied: false, globalPath: null, consentDecision: undefined };
+  }
+
+  // §4.2: check per-repo decision
+  const consentDecision = getUserConfigConsent(rootDir, registryPath);
+
+  // §4.2 step 1: recorded disabled
+  if (consentDecision === 'disabled') {
+    return { applied: false, globalPath, consentDecision };
+  }
+
+  // §4.2 step 2: recorded enabled
+  if (consentDecision === 'enabled') {
+    return { applied: true, globalPath, consentDecision };
+  }
+
+  // §4.2 step 3: appliesTo glob match (dynamic, never persisted)
+  const parsed = loadUserConfigFile(globalPath);
+  if (parsed?.appliesToGlobs.length) {
+    const expanded = parsed.appliesToGlobs.map((g) =>
+      g.startsWith('~') ? path.join(os.homedir(), g.slice(1)) : g,
+    );
+    const regexes = compileGlobs(expanded);
+    const absRoot = path.resolve(rootDir);
+    if (matchesAny(regexes, absRoot)) {
+      return { applied: true, globalPath, consentDecision: undefined };
+    }
+  }
+
+  // §4.2 steps 4–5: undecided — caller decides whether to prompt
+  return { applied: false, globalPath, consentDecision: undefined };
+}
+
+// Last applied global path — exposed so pipeline can emit the build-time notice.
+let _lastAppliedGlobalPath: string | null = null;
+export function getLastAppliedGlobalPath(): string | null {
+  return _lastAppliedGlobalPath;
+}
+
+// ── Build-relevant config hash ──────────────────────────────────────────
+
+const BUILD_HASH_KEYS: ReadonlyArray<keyof CodegraphConfig> = [
+  'include',
+  'exclude',
+  'ignoreDirs',
+  'extensions',
+  'aliases',
+  'build',
+];
+
+/**
+ * Compute a short stable hash of the build-relevant config subset.
+ * Used by the pipeline to detect config changes that require a full rebuild.
+ */
+export function computeConfigHash(config: CodegraphConfig): string {
+  const subset: Partial<CodegraphConfig> = {};
+  for (const k of BUILD_HASH_KEYS) {
+    (subset as Record<string, unknown>)[k] = config[k];
+  }
+  return createHash('sha256').update(JSON.stringify(subset)).digest('hex').slice(0, 16);
+}
+
+// ── Interactive consent prompt ──────────────────────────────────────────
+
+/**
+ * When called from the build command, check whether we should prompt the user
+ * for global-config consent and, if so, prompt and persist the answer.
+ *
+ * Only fires when ALL of:
+ *   - A global config file exists
+ *   - The repo is undecided (no recorded consent)
+ *   - Not matched by appliesTo globs
+ *   - process.stdin.isTTY && process.stdout.isTTY
+ *   - CI env is not set
+ *   - No per-run --user-config / --no-user-config flag is active
+ */
+export async function promptForConsentIfNeeded(
+  rootDir: string,
+  registryPath: string = REGISTRY_PATH,
+): Promise<void> {
+  // No-op if per-run override is active
+  if (_userConfigOverride !== undefined) return;
+
+  const globalPath = resolveUserConfigPath();
+  if (!globalPath) return;
+
+  const consentDecision = getUserConfigConsent(rootDir, registryPath);
+  if (consentDecision !== undefined) return; // already decided
+
+  // Check appliesTo globs (dynamic consent — no prompt needed)
+  const parsed = loadUserConfigFile(globalPath);
+  if (parsed?.appliesToGlobs.length) {
+    const expanded = parsed.appliesToGlobs.map((g) =>
+      g.startsWith('~') ? path.join(os.homedir(), g.slice(1)) : g,
+    );
+    const regexes = compileGlobs(expanded);
+    const absRoot = path.resolve(rootDir);
+    if (matchesAny(regexes, absRoot)) return; // covered by appliesTo
+  }
+
+  // Only prompt in fully interactive sessions
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return;
+  if (process.env.CI) return;
+
+  const { createInterface } = await import('node:readline');
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(
+      `\nA global codegraph config was found at ${globalPath}.\n` +
+        `Apply it to this repository (${path.resolve(rootDir)})? [y/N]\n` +
+        `(remembered per-repo; change later with \`codegraph config --enable-global|--disable-global\`)\n` +
+        `> `,
+      (ans) => {
+        rl.close();
+        resolve(ans.trim().toLowerCase());
+      },
+    );
+  });
+
+  const decided = answer === 'y' || answer === 'yes' ? 'enabled' : 'disabled';
+  setUserConfigConsent(rootDir, decided, registryPath);
+  process.stderr.write(`Global config consent recorded: ${decided}\n`);
+}
+
+// ── Main config loader ──────────────────────────────────────────────────
+
+/** Options for loadConfig. */
+export interface LoadConfigOpts {
+  /** Per-run user-config override (from CLI flags or programmatic call). */
+  userConfig?: string | boolean;
+  /** Registry path override (mainly for tests). */
+  registryPath?: string;
+}
 
 /**
  * Load project configuration from a .codegraphrc.json or similar file.
- * Returns merged config with defaults. Results are cached per cwd.
+ * Returns merged config with defaults: defaults → global (if applied) → project → env → secrets.
+ * Results are cached per cwd + applied global path.
  */
-export function loadConfig(cwd?: string): CodegraphConfig {
-  cwd = cwd || process.cwd();
-  const cached = _configCache.get(cwd);
+export function loadConfig(cwd?: string, opts?: LoadConfigOpts): CodegraphConfig {
+  cwd = path.resolve(cwd || process.cwd());
+
+  // Determine effective override: explicit opts win over module-level variable
+  const override = opts?.userConfig !== undefined ? opts.userConfig : _userConfigOverride;
+
+  // Resolve consent and global path
+  const { applied, globalPath } = resolveConsent(cwd, override, opts?.registryPath);
+
+  // Cache key includes applied global path and override flag so toggled consent is reflected
+  const cacheKey = `${cwd}::${applied ? (globalPath ?? 'default') : 'none'}`;
+  const cached = _configCache.get(cacheKey);
   if (cached) return structuredClone(cached);
 
+  _lastAppliedGlobalPath = applied ? globalPath : null;
+
+  // ── Layer 0: DEFAULTS ─────────────────────────────────────────────
+  let merged = DEFAULTS as unknown as Record<string, unknown>;
+
+  // ── Layer 1: global (if applied) ──────────────────────────────────
+  if (applied && globalPath) {
+    const userFileData = loadUserConfigFile(globalPath);
+    if (userFileData) {
+      debug(`Applying global user config from ${globalPath}`);
+      const sanitized = sanitizeUserLayer(userFileData.globalConfig);
+      merged = mergeConfig(merged, sanitized);
+      merged = applyExcludeTestsShorthand(merged, sanitized);
+    }
+  }
+
+  // ── Layer 2: project ──────────────────────────────────────────────
   for (const name of CONFIG_FILES) {
     const filePath = path.join(cwd, name);
     if (fs.existsSync(filePath)) {
       try {
         const raw = fs.readFileSync(filePath, 'utf-8');
-        const config = JSON.parse(raw);
-        debug(`Loaded config from ${filePath}`);
-        const merged = mergeConfig(DEFAULTS as unknown as Record<string, unknown>, config);
-        if ('excludeTests' in config && !(config.query && 'excludeTests' in config.query)) {
-          (merged.query as Record<string, unknown>).excludeTests = Boolean(config.excludeTests);
-        }
-        delete merged.excludeTests;
-        const result = resolveSecrets(applyEnvOverrides(merged as unknown as CodegraphConfig));
-        _configCache.set(cwd, structuredClone(result));
-        return result;
+        const projectConfig = JSON.parse(raw) as Record<string, unknown>;
+        debug(`Loaded project config from ${filePath}`);
+        merged = mergeConfig(merged, projectConfig);
+        merged = applyExcludeTestsShorthand(merged, projectConfig);
+        break;
       } catch (err: unknown) {
         if (err instanceof ConfigError) throw err;
         debug(`Failed to parse config ${filePath}: ${toErrorMessage(err)}`);
       }
     }
   }
-  const defaults = resolveSecrets(applyEnvOverrides({ ...DEFAULTS }));
-  _configCache.set(cwd, structuredClone(defaults));
-  return defaults;
+
+  // ── Layers 3–4: env overrides + secret resolution ─────────────────
+  const result = resolveSecrets(applyEnvOverrides(merged as unknown as CodegraphConfig));
+  _configCache.set(cacheKey, structuredClone(result));
+  return result;
 }
 
 /**
@@ -212,6 +558,67 @@ export function loadConfig(cwd?: string): CodegraphConfig {
  */
 export function clearConfigCache(): void {
   _configCache.clear();
+}
+
+/**
+ * Load config and return it together with per-key provenance information.
+ * Used by `codegraph config --explain`.
+ */
+export function loadConfigWithProvenance(
+  cwd?: string,
+  opts?: LoadConfigOpts,
+): import('../types.js').ConfigWithProvenance {
+  cwd = path.resolve(cwd || process.cwd());
+  const override = opts?.userConfig !== undefined ? opts.userConfig : _userConfigOverride;
+  const { applied, globalPath, consentDecision } = resolveConsent(
+    cwd,
+    override,
+    opts?.registryPath,
+  );
+
+  // Build provenance by tracking which layer supplies each top-level key
+  const provenance: Record<string, ConfigSource> = {};
+
+  // Layer 0: defaults — everything starts as 'default'
+  for (const k of Object.keys(DEFAULTS)) provenance[k] = 'default';
+
+  // Layer 1: global
+  let globalRaw: Record<string, unknown> | null = null;
+  if (applied && globalPath) {
+    const userFileData = loadUserConfigFile(globalPath);
+    if (userFileData) {
+      globalRaw = sanitizeUserLayer(userFileData.globalConfig);
+      for (const k of Object.keys(globalRaw)) provenance[k] = 'user';
+    }
+  }
+
+  // Layer 2: project
+  let projectRaw: Record<string, unknown> | null = null;
+  for (const name of CONFIG_FILES) {
+    const filePath = path.join(cwd, name);
+    if (fs.existsSync(filePath)) {
+      try {
+        const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+        projectRaw = raw;
+        for (const k of Object.keys(raw)) provenance[k] = 'project';
+        break;
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  // Layer 3+: env overrides (LLM keys)
+  const ENV_LLM_KEYS = ['CODEGRAPH_LLM_PROVIDER', 'CODEGRAPH_LLM_API_KEY', 'CODEGRAPH_LLM_MODEL'];
+  if (ENV_LLM_KEYS.some((k) => process.env[k] !== undefined)) {
+    provenance.llm = 'env';
+  }
+
+  void globalRaw;
+  void projectRaw; // used for provenance tracking above
+
+  const config = loadConfig(cwd, opts);
+  return { config, provenance, appliedGlobalPath: applied ? globalPath : null, consentDecision };
 }
 
 const ENV_LLM_MAP: Record<string, string> = {

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -185,11 +185,15 @@ let _userConfigOverride: string | boolean | undefined;
 export function setUserConfigOverride(v: string | boolean | undefined): void {
   _userConfigOverride = v;
   _configCache.clear();
+  _globalConfigCache.clear();
 }
 
 // Per-cwd config cache — avoids re-reading the config file on every query call.
 // Key includes the applied global path so toggled flags/consent are reflected.
 const _configCache = new Map<string, CodegraphConfig>();
+// Parallel cache for the sanitized global layer — needed so loadConfigWithProvenance
+// can correctly attribute global-layer keys even on a _configCache hit.
+const _globalConfigCache = new Map<string, Record<string, unknown> | null>();
 
 // ── Global config file location ─────────────────────────────────────────
 
@@ -523,7 +527,11 @@ export function loadConfig(cwd?: string, opts?: LoadConfigOpts): CodegraphConfig
   _lastAppliedGlobalPath = applied ? globalPath : null;
   _lastAppliedGlobalConfig = null; // updated below if a global file is loaded
   const cached = _configCache.get(cacheKey);
-  if (cached) return structuredClone(cached);
+  if (cached) {
+    // Restore global config so loadConfigWithProvenance gets correct provenance on cache hits.
+    _lastAppliedGlobalConfig = _globalConfigCache.get(cacheKey) ?? null;
+    return structuredClone(cached);
+  }
 
   // ── Layer 0: DEFAULTS ─────────────────────────────────────────────
   let merged = DEFAULTS as unknown as Record<string, unknown>;
@@ -563,6 +571,7 @@ export function loadConfig(cwd?: string, opts?: LoadConfigOpts): CodegraphConfig
   // ── Layers 3–4: env overrides + secret resolution ─────────────────
   const result = resolveSecrets(applyEnvOverrides(merged as unknown as CodegraphConfig));
   _configCache.set(cacheKey, structuredClone(result));
+  _globalConfigCache.set(cacheKey, _lastAppliedGlobalConfig);
   return result;
 }
 
@@ -573,6 +582,7 @@ export function loadConfig(cwd?: string, opts?: LoadConfigOpts): CodegraphConfig
  */
 export function clearConfigCache(): void {
   _configCache.clear();
+  _globalConfigCache.clear();
 }
 
 /**

--- a/src/infrastructure/registry.ts
+++ b/src/infrastructure/registry.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import type { ConsentDecision } from '../types.js';
 import { debug, warn } from './logger.js';
 
 export const REGISTRY_PATH: string =
@@ -16,8 +17,15 @@ interface RegistryEntry {
   lastAccessedAt?: string;
 }
 
+interface UserConfigSection {
+  /** Per-repo consent decisions keyed by absolute repo path. */
+  consent: Record<string, ConsentDecision>;
+}
+
 interface Registry {
   repos: Record<string, RegistryEntry>;
+  /** User-level global config consent store — separate from MCP repo listings. */
+  userConfig?: UserConfigSection;
 }
 
 /**
@@ -160,6 +168,67 @@ export function resolveRepoDbPath(
   return entry.dbPath;
 }
 
+// ── User-config consent ────────────────────────────────────────────────
+
+/**
+ * Read the per-repo consent decision for the global user config.
+ * Returns `undefined` when the repo is undecided (no recorded decision).
+ */
+export function getUserConfigConsent(
+  rootDir: string,
+  registryPath: string = REGISTRY_PATH,
+): ConsentDecision | undefined {
+  const registry = loadRegistry(registryPath);
+  const absRoot = path.resolve(rootDir);
+  return registry.userConfig?.consent?.[absRoot];
+}
+
+/**
+ * Persist a per-repo consent decision. Atomic write via temp+rename.
+ */
+export function setUserConfigConsent(
+  rootDir: string,
+  decision: ConsentDecision,
+  registryPath: string = REGISTRY_PATH,
+): void {
+  const registry = loadRegistry(registryPath);
+  const absRoot = path.resolve(rootDir);
+  if (!registry.userConfig) registry.userConfig = { consent: {} };
+  if (!registry.userConfig.consent) registry.userConfig.consent = {};
+  registry.userConfig.consent[absRoot] = decision;
+  saveRegistry(registry, registryPath);
+  debug(`User-config consent for "${absRoot}" set to "${decision}"`);
+}
+
+/**
+ * List every repo with a recorded consent decision, sorted by path.
+ */
+export function listUserConfigConsent(
+  registryPath: string = REGISTRY_PATH,
+): Array<{ path: string; decision: ConsentDecision }> {
+  const registry = loadRegistry(registryPath);
+  const consent = registry.userConfig?.consent ?? {};
+  return Object.entries(consent)
+    .map(([p, decision]) => ({ path: p, decision }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/**
+ * Revert a repo to undecided state. Returns true if a decision was removed.
+ */
+export function clearUserConfigConsent(
+  rootDir: string,
+  registryPath: string = REGISTRY_PATH,
+): boolean {
+  const registry = loadRegistry(registryPath);
+  const absRoot = path.resolve(rootDir);
+  const consent = registry.userConfig?.consent;
+  if (!consent || !(absRoot in consent)) return false;
+  delete consent[absRoot];
+  saveRegistry(registry, registryPath);
+  return true;
+}
+
 interface PrunedEntry {
   name: string;
   path: string;
@@ -200,7 +269,19 @@ export function pruneRegistry(
     }
   }
 
-  if (!dryRun && pruned.length > 0) {
+  // Prune consent entries whose repo paths no longer exist on disk.
+  // Consent entries are TTL-exempt — only the missing-path rule applies.
+  let consentChanged = false;
+  if (!dryRun && registry.userConfig?.consent) {
+    for (const p of Object.keys(registry.userConfig.consent)) {
+      if (!fs.existsSync(p)) {
+        delete registry.userConfig.consent[p];
+        consentChanged = true;
+      }
+    }
+  }
+
+  if (!dryRun && (pruned.length > 0 || consentChanged)) {
     saveRegistry(registry, registryPath);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1254,6 +1254,20 @@ export interface BuildGraphOpts {
    * `findDbPath` for every other DB-scoped command.
    */
   dbPath?: string;
+  /**
+   * User-config override for this build (from --user-config / --no-user-config).
+   * - false          → --no-user-config: skip global layer for this run
+   * - string         → --user-config <path>: apply the given file
+   * - true           → --user-config (bare): apply the default global file
+   * - undefined      → honour per-repo consent from the registry (normal)
+   */
+  userConfig?: string | boolean;
+  /**
+   * When true, an interactive consent prompt may fire on first build for
+   * repos whose global-config consent is undecided. Only set by the CLI
+   * build command when stdin/stdout are TTYs and CI is not set.
+   */
+  promptForConsent?: boolean;
 }
 
 /** Build timing result from buildGraph. */
@@ -1475,6 +1489,25 @@ export interface McpDefaults {
   ast_query: number;
   implementations: number;
   interfaces: number;
+}
+
+/** Per-repo consent decision for the user-level global config. */
+export type ConsentDecision = 'enabled' | 'disabled';
+
+/** Which layer contributed a resolved config value. */
+export type ConfigSource = 'default' | 'user' | 'project' | 'env';
+
+/** Maps config key paths (dot notation) to the layer that supplied the value. */
+export type ConfigProvenance = Record<string, ConfigSource>;
+
+/** Result of loadConfigWithProvenance. */
+export interface ConfigWithProvenance {
+  config: CodegraphConfig;
+  provenance: ConfigProvenance;
+  /** Absolute path of the applied global file, or null if none was applied. */
+  appliedGlobalPath: string | null;
+  /** This repo's recorded consent decision (may be undefined if undecided). */
+  consentDecision: ConsentDecision | undefined;
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/tests/unit/config-user.test.ts
+++ b/tests/unit/config-user.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for user-level (global) config: §5 location resolution,
+ * §8 merge pipeline, §8.1 sanitizeUserLayer, §10 config hash.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  clearConfigCache,
+  computeConfigHash,
+  loadConfig,
+  loadConfigWithProvenance,
+  resolveUserConfigPath,
+  setUserConfigOverride,
+} from '../../src/infrastructure/config.js';
+import { setUserConfigConsent } from '../../src/infrastructure/registry.js';
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-config-user-'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  clearConfigCache();
+  setUserConfigOverride(undefined);
+  // Clean env overrides
+  delete process.env.CODEGRAPH_USER_CONFIG;
+  delete process.env.XDG_CONFIG_HOME;
+});
+
+// ── resolveUserConfigPath ──────────────────────────────────────────────
+
+describe('resolveUserConfigPath', () => {
+  it('returns null when no global file exists', () => {
+    // Redirect env to a temp dir that has nothing in it
+    const emptyHome = fs.mkdtempSync(path.join(tmpDir, 'home-'));
+    process.env.CODEGRAPH_USER_CONFIG = path.join(emptyHome, 'nonexistent.json');
+    expect(resolveUserConfigPath()).toBeNull();
+  });
+
+  it('returns CODEGRAPH_USER_CONFIG when file exists', () => {
+    const cfgPath = path.join(tmpDir, 'explicit.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({ query: { defaultLimit: 99 } }));
+    process.env.CODEGRAPH_USER_CONFIG = cfgPath;
+    expect(resolveUserConfigPath()).toBe(cfgPath);
+  });
+
+  it('uses XDG_CONFIG_HOME when set', () => {
+    const xdgDir = fs.mkdtempSync(path.join(tmpDir, 'xdg-'));
+    const cfgDir = path.join(xdgDir, 'codegraph');
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(path.join(cfgDir, 'config.json'), '{}');
+    process.env.XDG_CONFIG_HOME = xdgDir;
+    const result = resolveUserConfigPath();
+    expect(result).toBe(path.join(cfgDir, 'config.json'));
+  });
+});
+
+// ── loadConfig with global layer ──────────────────────────────────────
+
+describe('loadConfig — global layer', () => {
+  it('skips global layer when --no-user-config (override=false)', () => {
+    const globalFile = path.join(tmpDir, 'global.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 99 } }));
+    process.env.CODEGRAPH_USER_CONFIG = globalFile;
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+    const config = loadConfig(repoDir, { userConfig: false });
+    expect(config.query.defaultLimit).toBe(20); // DEFAULTS value
+  });
+
+  it('applies global layer when --user-config <path>', () => {
+    const globalFile = path.join(tmpDir, 'global2.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 77 } }));
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    expect(config.query.defaultLimit).toBe(77);
+  });
+
+  it('applies global layer via recorded "enabled" consent', () => {
+    const globalFile = path.join(tmpDir, 'global3.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 55 } }));
+    process.env.CODEGRAPH_USER_CONFIG = globalFile;
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+    const regPath = path.join(tmpDir, 'registry3.json');
+    setUserConfigConsent(repoDir, 'enabled', regPath);
+
+    const config = loadConfig(repoDir, { registryPath: regPath });
+    expect(config.query.defaultLimit).toBe(55);
+  });
+
+  it('skips global layer when consent is "disabled"', () => {
+    const globalFile = path.join(tmpDir, 'global4.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 88 } }));
+    process.env.CODEGRAPH_USER_CONFIG = globalFile;
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+    const regPath = path.join(tmpDir, 'registry4.json');
+    setUserConfigConsent(repoDir, 'disabled', regPath);
+
+    const config = loadConfig(repoDir, { registryPath: regPath });
+    expect(config.query.defaultLimit).toBe(20); // DEFAULTS
+  });
+
+  it('project layer overrides global layer', () => {
+    const globalFile = path.join(tmpDir, 'global5.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 99 } }));
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+    fs.writeFileSync(
+      path.join(repoDir, '.codegraphrc.json'),
+      JSON.stringify({ query: { defaultLimit: 10 } }),
+    );
+
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    expect(config.query.defaultLimit).toBe(10); // project wins
+  });
+
+  it('global layer preserves sibling keys when project partially overrides', () => {
+    const globalFile = path.join(tmpDir, 'global6.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 50, defaultDepth: 7 } }));
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+    fs.writeFileSync(
+      path.join(repoDir, '.codegraphrc.json'),
+      JSON.stringify({ query: { defaultLimit: 5 } }),
+    );
+
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    expect(config.query.defaultLimit).toBe(5); // project overrides
+    expect(config.query.defaultDepth).toBe(7); // global contrib survives
+  });
+
+  it('handles malformed global JSON gracefully — falls back to project+defaults', () => {
+    const globalFile = path.join(tmpDir, 'bad.json');
+    fs.writeFileSync(globalFile, '{ bad json ');
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-'));
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    expect(config.query.defaultLimit).toBe(20); // DEFAULTS
+  });
+
+  it('reads appliesTo wrapper format', () => {
+    const globalFile = path.join(tmpDir, 'wrapped.json');
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-applies-'));
+    const absRepo = path.resolve(repoDir);
+    fs.writeFileSync(
+      globalFile,
+      JSON.stringify({
+        appliesTo: [absRepo],
+        config: { query: { defaultLimit: 42 } },
+      }),
+    );
+    process.env.CODEGRAPH_USER_CONFIG = globalFile;
+    const regPath = path.join(tmpDir, 'registry-applies.json');
+    // No consent recorded — appliesTo glob should match
+    const config = loadConfig(repoDir, { registryPath: regPath });
+    expect(config.query.defaultLimit).toBe(42);
+  });
+
+  it('disabled consent overrides appliesTo glob match', () => {
+    const globalFile = path.join(tmpDir, 'wrapped2.json');
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-disabled-'));
+    const absRepo = path.resolve(repoDir);
+    fs.writeFileSync(
+      globalFile,
+      JSON.stringify({
+        appliesTo: [absRepo],
+        config: { query: { defaultLimit: 42 } },
+      }),
+    );
+    process.env.CODEGRAPH_USER_CONFIG = globalFile;
+    const regPath = path.join(tmpDir, 'registry-disabled.json');
+    setUserConfigConsent(repoDir, 'disabled', regPath);
+    // disabled beats appliesTo
+    const config = loadConfig(repoDir, { registryPath: regPath });
+    expect(config.query.defaultLimit).toBe(20); // DEFAULTS
+  });
+});
+
+// ── sanitizeUserLayer (absolute dbPath) ───────────────────────────────
+
+describe('sanitizeUserLayer via loadConfig', () => {
+  it('drops absolute build.dbPath from global layer', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const globalFile = path.join(tmpDir, 'absolute-db.json');
+    fs.writeFileSync(
+      globalFile,
+      JSON.stringify({ build: { dbPath: '/shared/graph.db', incremental: false } }),
+    );
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-san-'));
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    // Absolute dbPath was dropped; relative fallback from DEFAULTS applies
+    expect(path.isAbsolute(config.build.dbPath)).toBe(false);
+    // But incremental:false should still come through (only dbPath was dropped)
+    expect(config.build.incremental).toBe(false);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('absolute'));
+    stderrSpy.mockRestore();
+  });
+
+  it('allows relative build.dbPath from global layer', () => {
+    const globalFile = path.join(tmpDir, 'rel-db.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ build: { dbPath: '.cg/graph.db' } }));
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-rel-'));
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    expect(config.build.dbPath).toBe('.cg/graph.db');
+  });
+});
+
+// ── excludeTests shorthand from global layer ─────────────────────────
+
+describe('excludeTests shorthand in global layer', () => {
+  it('hoists top-level excludeTests from global layer', () => {
+    const globalFile = path.join(tmpDir, 'excl-global.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ excludeTests: true }));
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-excl-'));
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    expect(config.query.excludeTests).toBe(true);
+  });
+
+  it('project-level excludeTests overrides global', () => {
+    const globalFile = path.join(tmpDir, 'excl-global2.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ excludeTests: true }));
+
+    const repoDir = fs.mkdtempSync(path.join(tmpDir, 'repo-excl2-'));
+    fs.writeFileSync(
+      path.join(repoDir, '.codegraphrc.json'),
+      JSON.stringify({ excludeTests: false }),
+    );
+    const config = loadConfig(repoDir, { userConfig: globalFile });
+    expect(config.query.excludeTests).toBe(false);
+  });
+});
+
+// ── computeConfigHash ─────────────────────────────────────────────────
+
+describe('computeConfigHash', () => {
+  it('returns a 16-char hex string', () => {
+    const config = loadConfig(fs.mkdtempSync(path.join(tmpDir, 'hash-')));
+    const h = computeConfigHash(config);
+    expect(h).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is stable for identical configs', () => {
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'hash-stable-'));
+    const c1 = loadConfig(dir);
+    const c2 = loadConfig(dir);
+    expect(computeConfigHash(c1)).toBe(computeConfigHash(c2));
+  });
+
+  it('differs when include changes', () => {
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'hash-diff-'));
+    const c1 = loadConfig(dir);
+    const c2 = { ...c1, include: ['src/**'] };
+    expect(computeConfigHash(c1)).not.toBe(computeConfigHash(c2));
+  });
+
+  it('differs when build settings change', () => {
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'hash-build-'));
+    const c1 = loadConfig(dir);
+    const c2 = { ...c1, build: { ...c1.build, incremental: false } };
+    expect(computeConfigHash(c1)).not.toBe(computeConfigHash(c2));
+  });
+});
+
+// ── loadConfigWithProvenance ──────────────────────────────────────────
+
+describe('loadConfigWithProvenance', () => {
+  it('returns default provenance when no files exist', () => {
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'prov-empty-'));
+    const { provenance, appliedGlobalPath, consentDecision } = loadConfigWithProvenance(dir);
+    expect(provenance.include).toBe('default');
+    expect(provenance.build).toBe('default');
+    expect(appliedGlobalPath).toBeNull();
+    expect(consentDecision).toBeUndefined();
+  });
+
+  it('marks project keys as "project" source', () => {
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'prov-proj-'));
+    fs.writeFileSync(
+      path.join(dir, '.codegraphrc.json'),
+      JSON.stringify({ ignoreDirs: ['vendor'] }),
+    );
+    const { provenance } = loadConfigWithProvenance(dir);
+    expect(provenance.ignoreDirs).toBe('project');
+    expect(provenance.include).toBe('default');
+  });
+
+  it('marks user-layer keys as "user" source', () => {
+    const globalFile = path.join(tmpDir, 'prov-global.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ exclude: ['**/*.gen.*'] }));
+
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'prov-user-'));
+    const { provenance, appliedGlobalPath } = loadConfigWithProvenance(dir, {
+      userConfig: globalFile,
+    });
+    expect(provenance.exclude).toBe('user');
+    expect(appliedGlobalPath).toBe(globalFile);
+  });
+
+  it('project overwrites user provenance for same key', () => {
+    const globalFile = path.join(tmpDir, 'prov-both.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ exclude: ['**/*.gen.*'] }));
+
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'prov-both-'));
+    fs.writeFileSync(path.join(dir, '.codegraphrc.json'), JSON.stringify({ exclude: ['dist/**'] }));
+    const { provenance } = loadConfigWithProvenance(dir, { userConfig: globalFile });
+    expect(provenance.exclude).toBe('project');
+  });
+});
+
+// ── setUserConfigOverride integration ────────────────────────────────
+
+describe('setUserConfigOverride', () => {
+  it('false forces the global layer off', () => {
+    const globalFile = path.join(tmpDir, 'override-off.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 99 } }));
+    process.env.CODEGRAPH_USER_CONFIG = globalFile;
+
+    setUserConfigOverride(false);
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'repo-override-'));
+    const config = loadConfig(dir);
+    expect(config.query.defaultLimit).toBe(20); // DEFAULTS — global suppressed
+  });
+
+  it('string forces a specific global file', () => {
+    const globalFile = path.join(tmpDir, 'override-path.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ query: { defaultLimit: 33 } }));
+
+    setUserConfigOverride(globalFile);
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'repo-override-path-'));
+    const config = loadConfig(dir);
+    expect(config.query.defaultLimit).toBe(33);
+  });
+});

--- a/tests/unit/config-user.test.ts
+++ b/tests/unit/config-user.test.ts
@@ -319,6 +319,20 @@ describe('loadConfigWithProvenance', () => {
     const { provenance } = loadConfigWithProvenance(dir, { userConfig: globalFile });
     expect(provenance.exclude).toBe('project');
   });
+
+  it('returns correct user provenance even when loadConfig was called first (cache-hit path)', () => {
+    const globalFile = path.join(tmpDir, 'prov-cache-hit.json');
+    fs.writeFileSync(globalFile, JSON.stringify({ exclude: ['**/*.gen.*'] }));
+
+    const dir = fs.mkdtempSync(path.join(tmpDir, 'prov-cache-'));
+    const opts = { userConfig: globalFile };
+
+    // Prime the cache
+    loadConfig(dir, opts);
+    // Second call hits the cache — _lastAppliedGlobalConfig must be restored
+    const { provenance } = loadConfigWithProvenance(dir, opts);
+    expect(provenance.exclude).toBe('user');
+  });
 });
 
 // ── setUserConfigOverride integration ────────────────────────────────

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -4,14 +4,18 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  clearUserConfigConsent,
   DEFAULT_TTL_DAYS,
+  getUserConfigConsent,
   listRepos,
+  listUserConfigConsent,
   loadRegistry,
   pruneRegistry,
   REGISTRY_PATH,
   registerRepo,
   resolveRepoDbPath,
   saveRegistry,
+  setUserConfigConsent,
   unregisterRepo,
 } from '../../src/infrastructure/registry.js';
 
@@ -596,5 +600,106 @@ describe('resolveRepoDbPath updates lastAccessedAt', () => {
     const updated = loadRegistry(registryPath);
     expect(updated.repos.proj.lastAccessedAt).not.toBe('2025-01-01T00:00:00.000Z');
     expect(new Date(updated.repos.proj.lastAccessedAt).getFullYear()).toBeGreaterThanOrEqual(2026);
+  });
+});
+
+// ─── User-config consent ────────────────────────────────────────────
+
+describe('getUserConfigConsent', () => {
+  it('returns undefined for unknown repo (undecided)', () => {
+    const dir = path.join(tmpDir, 'new-repo');
+    expect(getUserConfigConsent(dir, registryPath)).toBeUndefined();
+  });
+
+  it('returns the recorded decision', () => {
+    const dir = path.join(tmpDir, 'repo-a');
+    setUserConfigConsent(dir, 'enabled', registryPath);
+    expect(getUserConfigConsent(dir, registryPath)).toBe('enabled');
+  });
+});
+
+describe('setUserConfigConsent', () => {
+  it('records enabled consent', () => {
+    const dir = path.join(tmpDir, 'enable-repo');
+    setUserConfigConsent(dir, 'enabled', registryPath);
+    const reg = loadRegistry(registryPath);
+    const absDir = path.resolve(dir);
+    expect(reg.userConfig?.consent?.[absDir]).toBe('enabled');
+  });
+
+  it('records disabled consent', () => {
+    const dir = path.join(tmpDir, 'disable-repo');
+    setUserConfigConsent(dir, 'disabled', registryPath);
+    const reg = loadRegistry(registryPath);
+    const absDir = path.resolve(dir);
+    expect(reg.userConfig?.consent?.[absDir]).toBe('disabled');
+  });
+
+  it('overwrites a previous decision', () => {
+    const dir = path.join(tmpDir, 'flip-repo');
+    setUserConfigConsent(dir, 'enabled', registryPath);
+    setUserConfigConsent(dir, 'disabled', registryPath);
+    expect(getUserConfigConsent(dir, registryPath)).toBe('disabled');
+  });
+
+  it('does not touch repos section', () => {
+    const dir = path.join(tmpDir, 'consent-isolated');
+    fs.mkdirSync(dir, { recursive: true });
+    registerRepo(dir, 'consent-isolated', registryPath);
+    setUserConfigConsent(dir, 'enabled', registryPath);
+    const reg = loadRegistry(registryPath);
+    expect(reg.repos['consent-isolated']).toBeDefined();
+  });
+});
+
+describe('listUserConfigConsent', () => {
+  it('returns empty array when no consent exists', () => {
+    expect(listUserConfigConsent(registryPath)).toEqual([]);
+  });
+
+  it('returns all decisions sorted by path', () => {
+    const dirZ = path.join(tmpDir, 'zzz-repo');
+    const dirA = path.join(tmpDir, 'aaa-repo');
+    setUserConfigConsent(dirZ, 'disabled', registryPath);
+    setUserConfigConsent(dirA, 'enabled', registryPath);
+    const list = listUserConfigConsent(registryPath);
+    expect(list).toHaveLength(2);
+    expect(list[0].path).toBe(path.resolve(dirA));
+    expect(list[0].decision).toBe('enabled');
+    expect(list[1].path).toBe(path.resolve(dirZ));
+    expect(list[1].decision).toBe('disabled');
+  });
+});
+
+describe('clearUserConfigConsent', () => {
+  it('removes the decision and returns true', () => {
+    const dir = path.join(tmpDir, 'clear-repo');
+    setUserConfigConsent(dir, 'enabled', registryPath);
+    expect(clearUserConfigConsent(dir, registryPath)).toBe(true);
+    expect(getUserConfigConsent(dir, registryPath)).toBeUndefined();
+  });
+
+  it('returns false if repo had no decision', () => {
+    const dir = path.join(tmpDir, 'no-decision-repo');
+    expect(clearUserConfigConsent(dir, registryPath)).toBe(false);
+  });
+});
+
+describe('pruneRegistry cleans stale consent entries', () => {
+  it('removes consent for missing repo paths', () => {
+    const dir = path.join(tmpDir, 'vanished-consent');
+    fs.mkdirSync(dir, { recursive: true });
+    setUserConfigConsent(dir, 'enabled', registryPath);
+    fs.rmSync(dir, { recursive: true, force: true });
+    pruneRegistry(registryPath);
+    expect(getUserConfigConsent(dir, registryPath)).toBeUndefined();
+  });
+
+  it('keeps consent for existing repo paths', () => {
+    const dir = path.join(tmpDir, 'alive-consent');
+    fs.mkdirSync(dir, { recursive: true });
+    setUserConfigConsent(dir, 'disabled', registryPath);
+    pruneRegistry(registryPath);
+    expect(getUserConfigConsent(dir, registryPath)).toBe('disabled');
   });
 });


### PR DESCRIPTION
## Summary

Implements the global user-level config layer from [spec docs/tasks/1448-user-level-config.md](https://github.com/optave/ops-codegraph-tool/blob/main/docs/tasks/1448-user-level-config.md).

- **Registry consent store**: `userConfig.consent` section in `~/.codegraph/registry.json` (separate from MCP repos, TTL-exempt, cleaned by missing-path pruning)
- **Global config file**: resolved via `CODEGRAPH_USER_CONFIG` → XDG / APPDATA → `~/.config/codegraph/config.json` → `~/.codegraph/config.json` fallback
- **Consent model** (§4.1/4.2): `disabled` > `enabled` > `appliesTo` glob > undecided. Non-interactive contexts never prompt.
- **Layered merge**: DEFAULTS → global (if consented) → project → env → secrets. Objects deep-merge, arrays replace.
- **Safety guard**: absolute `build.dbPath` in global file is dropped with a warning.
- **`loadConfigWithProvenance`**: per-key source map (`default` / `user` / `project` / `env`) for `--explain`.
- **Config hash invalidation** (`config_hash` in `build_meta`): full rebuild when build-relevant config changes — closes the pre-existing project-config gap (filed as #1557).
- **Interactive consent prompt**: async, TTY + non-CI + `build`-only, fired before pipeline setup.
- **CLI additions**: `codegraph config [--explain|--enable-global|--disable-global|--list-global]`; global `--user-config [path]` / `--no-user-config` flags; lazy config in `options.ts`.
- **Build pipeline**: threads `userConfig` opt; emits `ℹ global config applied` notice; stores `config_hash` in finalize.
- **Tests**: 26 new unit tests (`config-user.test.ts`) + 18 new consent tests in `registry.test.ts`
- **Docs**: `configuration.md` global config section + README pointer

## No Rust changes

Native engine is a pure consumer — it receives `loadConfig(rootDir)` via JSON in the TS pipeline. The merge happens once in TS and reaches native automatically. Per CLAUDE.md and spec §9: no Rust changes, no two-source divergence risk.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run tests/unit/config.test.ts` — 54 pass
- [x] `npx vitest run tests/unit/config-user.test.ts` — 26 pass (new)
- [x] `npx vitest run tests/unit/registry.test.ts` — 51 pass (18 new)
- [x] `npx vitest run tests/unit/index-exports.test.ts` — 3 pass
- [x] Full unit suite: 1112 pass
- [ ] Engine parity test (§14.3) — runs in CI via build-parity.test.ts

## Deferred (per spec §16)

- #1558 — `codegraph config --init / --edit` scaffolding helpers
- Array concat/union merge opt-in convention
- System-level config layer

Closes #1448