### PR TITLE
fix(cli): accept --json flag in batch command as no-op

### DIFF
--- a/src/cli/commands/batch.ts
+++ b/src/cli/commands/batch.ts
@@ -18,6 +18,7 @@ export const command: CommandDefinition = {
     ['-k, --kind <kind>', 'Filter by symbol kind'],
     ['-T, --no-tests', 'Exclude test/spec files from results'],
     ['--include-tests', 'Include test/spec files (overrides excludeTests config)'],
+    ['-j, --json', 'Accepted for script compatibility (batch always outputs JSON)'],
   ],
   validate([_command, _targets], opts) {
     if (opts.kind && !(EVERY_SYMBOL_KIND as readonly string[]).includes(opts.kind)) {

--- a/tests/integration/batch.test.ts
+++ b/tests/integration/batch.test.ts
@@ -231,6 +231,34 @@ describe('batch CLI', () => {
     expect(parsed.results).toHaveLength(1);
   });
 
+  test('accepts --json flag without error (no-op)', () => {
+    const out = execFileSync(
+      'node',
+      [...NODE_TS_FLAGS, cliPath, 'batch', 'query', 'authenticate', '--db', dbPath, '--json'],
+      {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      },
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.command).toBe('query');
+    expect(parsed.total).toBe(1);
+  });
+
+  test('accepts -j flag without error (no-op)', () => {
+    const out = execFileSync(
+      'node',
+      [...NODE_TS_FLAGS, cliPath, 'batch', 'query', 'authenticate', '--db', dbPath, '-j'],
+      {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      },
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.command).toBe('query');
+    expect(parsed.total).toBe(1);
+  });
+
   test('batch accepts comma-separated positional targets', () => {
     const out = execFileSync(
       'node',


### PR DESCRIPTION
## Summary

- The `batch` command was rejecting `--json` / `-j` flags with "error: unknown option '--json'"
- Every other codegraph command that outputs JSON accepts these flags
- Since `batch` always outputs JSON, the flag is added as an accepted no-op to prevent script errors

## Changes

- `src/cli/commands/batch.ts`: Added `['-j, --json', 'Accepted for script compatibility (batch always outputs JSON)']` to the options array
- `tests/integration/batch.test.ts`: Added two CLI smoke tests verifying `--json` and `-j` flags are accepted without error

## Test plan

- [x] `node_modules/.bin/vitest run tests/integration/batch.test.ts` — all 26 tests pass (including 2 new ones covering `--json` and `-j` flag acceptance)
- [x] `biome check src/ tests/` — no lint issues

Closes #1561