### PR TITLE
fix(triage): normalize JSON output to use 'items' key at all levels

### DIFF
--- a/src/cli/commands/batch.ts
+++ b/src/cli/commands/batch.ts
@@ -18,6 +18,7 @@ export const command: CommandDefinition = {
     ['-k, --kind <kind>', 'Filter by symbol kind'],
     ['-T, --no-tests', 'Exclude test/spec files from results'],
     ['--include-tests', 'Include test/spec files (overrides excludeTests config)'],
+    ['-j, --json', 'Accepted for script compatibility (batch always outputs JSON)'],
   ],
   validate([_command, _targets], opts) {
     if (opts.kind && !(EVERY_SYMBOL_KIND as readonly string[]).includes(opts.kind)) {

--- a/src/cli/commands/triage.ts
+++ b/src/cli/commands/triage.ts
@@ -31,7 +31,7 @@ async function runHotspots(opts: CommandOpts, ctx: CliContext): Promise<void> {
     offset: opts.offset ? parseInt(opts.offset as string, 10) : undefined,
     noTests: ctx.resolveNoTests(opts),
   });
-  if (!ctx.outputResult(data, 'hotspots', opts)) {
+  if (!ctx.outputResult(data, 'items', opts)) {
     console.log(formatHotspots(data));
   }
 }

--- a/src/features/structure-query.ts
+++ b/src/features/structure-query.ts
@@ -324,7 +324,7 @@ export function hotspotsData(
   metric: string;
   level: string;
   limit: number;
-  hotspots: unknown[];
+  items: unknown[];
 } {
   const { db, nativeDb, close } = openReadonlyWithNative(customDbPath);
   try {
@@ -337,19 +337,19 @@ export function hotspotsData(
     // ── Native fast path: single query instead of 4 eagerly prepared ──
     if (nativeDb?.getHotspots) {
       const rows = nativeDb.getHotspots(kind, metric, noTests, limit);
-      const hotspots = rows.map(mapNativeHotspotRow);
-      const base = { metric, level, limit, hotspots };
-      return paginateResult(base, 'hotspots', { limit: opts.limit, offset: opts.offset });
+      const items = rows.map(mapNativeHotspotRow);
+      const base = { metric, level, limit, items };
+      return paginateResult(base, 'items', { limit: opts.limit, offset: opts.offset });
     }
 
     // ── JS fallback ───────────────────────────────────────────────────
     const testFilter = testFilterSQL('n.name', noTests && kind === 'file');
     const stmt = db.prepare(buildHotspotQuery(metric, testFilter));
     const rows = stmt.all(kind, limit) as HotspotRow[];
-    const hotspots = rows.map(mapJsHotspotRow);
+    const items = rows.map(mapJsHotspotRow);
 
-    const base = { metric, level, limit, hotspots };
-    return paginateResult(base, 'hotspots', { limit: opts.limit, offset: opts.offset });
+    const base = { metric, level, limit, items };
+    return paginateResult(base, 'items', { limit: opts.limit, offset: opts.offset });
   } finally {
     close();
   }

--- a/src/presentation/structure.ts
+++ b/src/presentation/structure.ts
@@ -53,15 +53,15 @@ interface HotspotsResult {
   metric: string;
   level: string;
   limit: number;
-  hotspots: any[];
+  items: any[];
 }
 
 export function formatHotspots(data: HotspotsResult): string {
-  if (data.hotspots.length === 0) return 'No hotspots found. Run "codegraph build" first.';
+  if (data.items.length === 0) return 'No hotspots found. Run "codegraph build" first.';
 
   const lines = [`\nHotspots by ${data.metric} (${data.level}-level, top ${data.limit}):\n`];
   let rank = 1;
-  for (const h of data.hotspots) {
+  for (const h of data.items) {
     const extra =
       h.kind === 'directory'
         ? `${h.fileCount} files, cohesion=${h.cohesion !== null ? h.cohesion!.toFixed(2) : 'n/a'}`

--- a/tests/integration/batch.test.ts
+++ b/tests/integration/batch.test.ts
@@ -231,6 +231,34 @@ describe('batch CLI', () => {
     expect(parsed.results).toHaveLength(1);
   });
 
+  test('accepts --json flag without error (no-op)', () => {
+    const out = execFileSync(
+      'node',
+      [...NODE_TS_FLAGS, cliPath, 'batch', 'query', 'authenticate', '--db', dbPath, '--json'],
+      {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      },
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.command).toBe('query');
+    expect(parsed.total).toBe(1);
+  });
+
+  test('accepts -j flag without error (no-op)', () => {
+    const out = execFileSync(
+      'node',
+      [...NODE_TS_FLAGS, cliPath, 'batch', 'query', 'authenticate', '--db', dbPath, '-j'],
+      {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      },
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.command).toBe('query');
+    expect(parsed.total).toBe(1);
+  });
+
   test('batch accepts comma-separated positional targets', () => {
     const out = execFileSync(
       'node',

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -163,10 +163,10 @@ describe('CLI smoke tests', () => {
   });
 
   // ─── Triage --level (formerly hotspots) ─────────────────────────────
-  test('triage --level file --json returns valid JSON with hotspots', () => {
+  test('triage --level file --json returns valid JSON with items', () => {
     const out = run('triage', '--level', 'file', '--db', dbPath, '--json');
     const data = JSON.parse(out);
-    expect(data).toHaveProperty('hotspots');
+    expect(data).toHaveProperty('items');
     expect(data).toHaveProperty('metric');
     expect(data).toHaveProperty('level');
   });

--- a/tests/integration/structure.test.ts
+++ b/tests/integration/structure.test.ts
@@ -163,19 +163,19 @@ describe('structureData file limit', () => {
 describe('hotspotsData', () => {
   test('returns file hotspots ranked by fan-in', () => {
     const data = hotspotsData(dbPath, { metric: 'fan-in', level: 'file', limit: 5 });
-    expect(data).toHaveProperty('hotspots');
-    expect(data.hotspots.length).toBeGreaterThan(0);
-    expect(data.hotspots.length).toBeLessThanOrEqual(5);
+    expect(data).toHaveProperty('items');
+    expect(data.items.length).toBeGreaterThan(0);
+    expect(data.items.length).toBeLessThanOrEqual(5);
     // Should be sorted descending by fan-in
-    for (let i = 1; i < data.hotspots.length; i++) {
-      expect(data.hotspots[i - 1].fanIn).toBeGreaterThanOrEqual(data.hotspots[i].fanIn);
+    for (let i = 1; i < data.items.length; i++) {
+      expect(data.items[i - 1].fanIn).toBeGreaterThanOrEqual(data.items[i].fanIn);
     }
   });
 
   test('returns directory hotspots', () => {
     const data = hotspotsData(dbPath, { metric: 'fan-in', level: 'directory', limit: 5 });
-    expect(data).toHaveProperty('hotspots');
-    for (const h of data.hotspots) {
+    expect(data).toHaveProperty('items');
+    for (const h of data.items) {
       expect(h.kind).toBe('directory');
     }
   });
@@ -183,7 +183,7 @@ describe('hotspotsData', () => {
   test('supports coupling metric', () => {
     const data = hotspotsData(dbPath, { metric: 'coupling', level: 'file', limit: 3 });
     expect(data.metric).toBe('coupling');
-    expect(data.hotspots.length).toBeGreaterThan(0);
+    expect(data.items.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- \`triage --level file --json\` and \`triage --level directory --json\` were returning \`{ "hotspots": [...], "metric": "...", "level": "...", "limit": N }\` while \`triage --level function --json\` returned \`{ "items": [...] }\` — the inconsistent array key broke scripts that process triage output across levels.
- Renamed the \`hotspots\` array key to \`items\` in \`hotspotsData()\` return value so the JSON shape is uniform: all triage levels now use \`items\` for the result array. The \`metric\`, \`level\`, and \`limit\` metadata fields on the file/directory output are preserved.
- Also includes a minor fix for \`batch\` command: accepts \`-j, --json\` flag as a no-op (batch always outputs JSON anyway), fixing scripts that pass \`--json\` out of habit. Closes #1561.

## Changed files

- \`src/features/structure-query.ts\` — renamed \`hotspots\` → \`items\` in return object and both \`paginateResult\` calls
- \`src/presentation/structure.ts\` — updated \`HotspotsResult\` interface and \`formatHotspots\` to use \`items\`
- \`src/cli/commands/triage.ts\` — updated \`outputResult\` second argument from \`'hotspots'\` to \`'items'\`
- \`src/cli/commands/batch.ts\` — added \`-j, --json\` no-op flag for script compatibility
- \`tests/integration/structure.test.ts\` — updated \`hotspotsData\` assertions to use \`items\`
- \`tests/integration/cli.test.ts\` — updated CLI JSON output assertion to use \`items\`
- \`tests/integration/batch.test.ts\` — two new tests for \`--json\` / \`-j\` flags on batch command

## Test plan

- [ ] \`npx vitest run tests/integration/structure.test.ts tests/integration/cli.test.ts tests/integration/batch.test.ts\` — all tests pass
- [ ] \`npx vitest run\` — full suite passes (pre-existing unrelated build.test.ts failure not introduced by this PR)
- [ ] \`triage --level file --json\` output contains \`items\` key alongside \`metric\`, \`level\`, \`limit\`
- [ ] \`triage --level function --json\` output still contains \`items\` key (unchanged)
- [ ] \`codegraph batch query foo --json\` no longer errors on the \`--json\` flag

Closes #1562