### PR TITLE
fix(native): don't warn when a natively-supported file produces 0 symbols via WASM

### DIFF
--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1237,10 +1237,16 @@ async function backfillNativeDroppedFiles(
   // backfilled — only the former triggers a WARN (#1566).
   const wasmResults = await parseFilesWasmForBackfill(missingAbs, ctx.rootDir);
 
-  // Build a set of rel-paths where WASM found at least one symbol, so we can
-  // tell real extractor failures apart from intentionally-skipped files.
+  // Build two sets from wasmResults:
+  //   wasmParsedFiles  — rel-paths present in wasmResults (WASM succeeded, even 0 symbols)
+  //   wasmFoundSymbols — subset where WASM found ≥1 symbol
+  // Files absent from wasmParsedFiles were skipped by WASM entirely (extension
+  // not in _extToLang, wasmExtractSymbols returned null, or a read error).
+  // Those files do NOT end up in the batchInsertNodes loop below.
+  const wasmParsedFiles = new Set<string>();
   const wasmFoundSymbols = new Set<string>();
   for (const [relPath, symbols] of wasmResults) {
+    wasmParsedFiles.add(relPath);
     if ((symbols.definitions?.length ?? 0) > 0 || (symbols.exports?.length ?? 0) > 0) {
       wasmFoundSymbols.add(relPath);
     }
@@ -1261,29 +1267,33 @@ async function backfillNativeDroppedFiles(
     );
   }
   if (totals['native-extractor-failure'] > 0) {
-    // Split into real failures (WASM found symbols) and no-op drops (0 symbols
-    // in both engines — likely gitignored or truly empty files the Rust engine
-    // intentionally skipped while the JS filesystem walk found them on disk).
+    // Three-way split of native-extractor-failure files:
+    //   realFailureBuckets  — WASM found symbols → real Rust extractor bug (WARN)
+    //   emptyFileBuckets    — WASM parsed but found 0 symbols → gitignored/empty (debug)
+    //                         These DO receive a file-node insert in the loop below.
+    //   wasmSkipBuckets     — WASM skipped entirely (ext unknown or parse error) →
+    //                         no file-node insert, and no WARN (debug only, distinct
+    //                         message to avoid overstating backfill coverage).
     const realFailurePaths = byReason['native-extractor-failure'];
     const realFailureBuckets = new Map<string, string[]>();
-    const silentDropBuckets = new Map<string, string[]>();
+    const emptyFileBuckets = new Map<string, string[]>();
+    const wasmSkipBuckets = new Map<string, string[]>();
     for (const [ext, paths] of realFailurePaths) {
       for (const relPath of paths) {
+        let bucket: Map<string, string[]>;
         if (wasmFoundSymbols.has(relPath)) {
-          let list = realFailureBuckets.get(ext);
-          if (!list) {
-            list = [];
-            realFailureBuckets.set(ext, list);
-          }
-          list.push(relPath);
+          bucket = realFailureBuckets;
+        } else if (wasmParsedFiles.has(relPath)) {
+          bucket = emptyFileBuckets;
         } else {
-          let list = silentDropBuckets.get(ext);
-          if (!list) {
-            list = [];
-            silentDropBuckets.set(ext, list);
-          }
-          list.push(relPath);
+          bucket = wasmSkipBuckets;
         }
+        let list = bucket.get(ext);
+        if (!list) {
+          list = [];
+          bucket.set(ext, list);
+        }
+        list.push(relPath);
       }
     }
     if (realFailureBuckets.size > 0) {
@@ -1292,10 +1302,16 @@ async function backfillNativeDroppedFiles(
         `Native orchestrator dropped ${realCount} file(s) across ${realFailureBuckets.size} extension(s) in natively-supported languages — likely a Rust extractor bug. Backfilling via WASM:${formatDropExtensionSummary(realFailureBuckets)}`,
       );
     }
-    if (silentDropBuckets.size > 0) {
-      const silentCount = [...silentDropBuckets.values()].reduce((s, a) => s + a.length, 0);
+    if (emptyFileBuckets.size > 0) {
+      const emptyCount = [...emptyFileBuckets.values()].reduce((s, a) => s + a.length, 0);
       debug(
-        `Native orchestrator skipped ${silentCount} file(s) in natively-supported languages that also produced 0 symbols via WASM (likely gitignored or empty); backfilling file nodes:${formatDropExtensionSummary(silentDropBuckets)}`,
+        `Native orchestrator skipped ${emptyCount} file(s) in natively-supported languages that also produced 0 symbols via WASM (likely gitignored or empty); backfilling file nodes:${formatDropExtensionSummary(emptyFileBuckets)}`,
+      );
+    }
+    if (wasmSkipBuckets.size > 0) {
+      const skipCount = [...wasmSkipBuckets.values()].reduce((s, a) => s + a.length, 0);
+      debug(
+        `Native orchestrator skipped ${skipCount} file(s) in natively-supported languages that WASM also could not parse (unregistered extension or parse error); no file-node inserted:${formatDropExtensionSummary(wasmSkipBuckets)}`,
       );
     }
   }

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1230,10 +1230,29 @@ async function backfillNativeDroppedFiles(
 
   if (missingAbs.length === 0) return;
 
+  // Parse all missing files via WASM first so we can distinguish real native
+  // extractor failures (WASM finds symbols but native didn't) from files the
+  // Rust engine legitimately skipped (gitignored artifacts, empty declaration
+  // files, etc. where WASM also produces 0 symbols). Both categories are
+  // backfilled — only the former triggers a WARN (#1566).
+  const wasmResults = await parseFilesWasmForBackfill(missingAbs, ctx.rootDir);
+
+  // Build a set of rel-paths where WASM found at least one symbol, so we can
+  // tell real extractor failures apart from intentionally-skipped files.
+  const wasmFoundSymbols = new Set<string>();
+  for (const [relPath, symbols] of wasmResults) {
+    if ((symbols.definitions?.length ?? 0) > 0 || (symbols.exports?.length ?? 0) > 0) {
+      wasmFoundSymbols.add(relPath);
+    }
+  }
+
   // Classify drops so users see per-extension reasons instead of just a count
   // (#1011). `unsupported-by-native` is a legitimate parser limit (no Rust
   // extractor); `native-extractor-failure` indicates a real native bug since
-  // the language IS supported by the addon yet the file was dropped anyway.
+  // the language IS supported by the addon yet WASM found symbols the native
+  // engine should have extracted. Files where both engines produce 0 symbols
+  // are legitimately empty (e.g. gitignored napi-generated declaration stubs)
+  // and logged at debug level only.
   const { byReason, totals } = classifyNativeDrops(missingRel);
   if (totals['unsupported-by-native'] > 0) {
     const buckets = byReason['unsupported-by-native'];
@@ -1242,12 +1261,44 @@ async function backfillNativeDroppedFiles(
     );
   }
   if (totals['native-extractor-failure'] > 0) {
-    const buckets = byReason['native-extractor-failure'];
-    warn(
-      `Native orchestrator dropped ${totals['native-extractor-failure']} file(s) across ${buckets.size} extension(s) in natively-supported languages — likely a Rust extractor bug. Backfilling via WASM:${formatDropExtensionSummary(buckets)}`,
-    );
+    // Split into real failures (WASM found symbols) and no-op drops (0 symbols
+    // in both engines — likely gitignored or truly empty files the Rust engine
+    // intentionally skipped while the JS filesystem walk found them on disk).
+    const realFailurePaths = byReason['native-extractor-failure'];
+    const realFailureBuckets = new Map<string, string[]>();
+    const silentDropBuckets = new Map<string, string[]>();
+    for (const [ext, paths] of realFailurePaths) {
+      for (const relPath of paths) {
+        if (wasmFoundSymbols.has(relPath)) {
+          let list = realFailureBuckets.get(ext);
+          if (!list) {
+            list = [];
+            realFailureBuckets.set(ext, list);
+          }
+          list.push(relPath);
+        } else {
+          let list = silentDropBuckets.get(ext);
+          if (!list) {
+            list = [];
+            silentDropBuckets.set(ext, list);
+          }
+          list.push(relPath);
+        }
+      }
+    }
+    if (realFailureBuckets.size > 0) {
+      const realCount = [...realFailureBuckets.values()].reduce((s, a) => s + a.length, 0);
+      warn(
+        `Native orchestrator dropped ${realCount} file(s) across ${realFailureBuckets.size} extension(s) in natively-supported languages — likely a Rust extractor bug. Backfilling via WASM:${formatDropExtensionSummary(realFailureBuckets)}`,
+      );
+    }
+    if (silentDropBuckets.size > 0) {
+      const silentCount = [...silentDropBuckets.values()].reduce((s, a) => s + a.length, 0);
+      debug(
+        `Native orchestrator skipped ${silentCount} file(s) in natively-supported languages that also produced 0 symbols via WASM (likely gitignored or empty); backfilling file nodes:${formatDropExtensionSummary(silentDropBuckets)}`,
+      );
+    }
   }
-  const wasmResults = await parseFilesWasmForBackfill(missingAbs, ctx.rootDir);
 
   const rows: unknown[][] = [];
   const exportKeys: unknown[][] = [];


### PR DESCRIPTION
## Summary

- **Root cause**: On every full native build, `detectDroppedLanguageGap` compares the JS filesystem walk (which doesn't respect `.gitignore`) against the DB (populated by the Rust engine, which does respect `.gitignore`). Gitignored napi artifacts (`crates/codegraph-core/index.d.ts`, `crates/codegraph-core/index.js`) appear in the JS expected set but not in the DB, so they're classified as `native-extractor-failure` and trigger a WARN.
- **Fix**: Move the WASM parse before the log/warn step in `backfillNativeDroppedFiles`. After parsing, split `native-extractor-failure` files into two groups: (1) files where WASM also found 0 symbols — these are legitimately empty or gitignored, logged at `debug` only; (2) files where WASM found symbols — these are real extractor bugs, still logged as `warn`. Both groups are backfilled correctly.
- The existing `dropped-language-gap.test.ts` integration test continues to exercise the WARN path (via a simulated DB gap on a real JS fixture file that WASM does find symbols in), confirming real extractor failures still surface.

## Test plan

- [x] `npx vitest run tests/parsers/native-drop-classification.test.ts` — 17 tests pass
- [x] `npx vitest run tests/integration/dropped-language-gap.test.ts` — 2 tests pass (WARN still fires for real JS files with symbols)
- [x] `npm run lint` — biome passes clean

Closes #1566