### PR TITLE
fix(config): clarify consent prompt to reflect per-key inheritance semantics

### DIFF
--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -508,7 +508,7 @@ export async function promptForConsentIfNeeded(
   const answer = await new Promise<string>((resolve) => {
     rl.question(
       `\nA global codegraph config was found at ${globalPath}.\n` +
-        `Apply it to settings not explicitly configured in this repo (${path.resolve(rootDir)})? [y/N]\n` +
+        `Apply settings not explicitly configured in this repo to ${path.resolve(rootDir)}? [y/N]\n` +
         `(remembered per-repo; change later with \`codegraph config --enable-global|--disable-global\`)\n` +
         `> `,
       (ans) => {

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -508,7 +508,7 @@ export async function promptForConsentIfNeeded(
   const answer = await new Promise<string>((resolve) => {
     rl.question(
       `\nA global codegraph config was found at ${globalPath}.\n` +
-        `Apply it to this repository (${path.resolve(rootDir)})? [y/N]\n` +
+        `Apply it to settings not explicitly configured in this repo (${path.resolve(rootDir)})? [y/N]\n` +
         `(remembered per-repo; change later with \`codegraph config --enable-global|--disable-global\`)\n` +
         `> `,
       (ans) => {


### PR DESCRIPTION
## Summary

- Changes the global config consent prompt from _"Apply it to this repository"_ to _"Apply it to settings not explicitly configured in this repo"_
- Makes the replace-when-present, inherit-when-absent semantics self-documenting at consent time, without requiring users to read the docs

## Test plan

- [ ] Run `codegraph build` in a repo with a global config and no recorded consent — verify the new prompt wording appears
- [ ] Verify `y` and `n` responses still record consent correctly

Closes #1574