### PR TITLE
docs: prepare release notes for v3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.13.0](https://github.com/optave/ops-codegraph-tool/compare/v3.12.0...v3.13.0) (2026-06-16)
+
+**User-level global config, `codegraph config` scaffolding, and an `explain` alias land.** The headline feature is a new user-level configuration layer (`~/.config/codegraph/config.json` via XDG, or `~/.codegraph/config.json` fallback) with an interactive per-repo consent model — DEFAULTS → global (if consented) → project → env → secrets. `codegraph config` now shows a human-friendly key/value/source table by default (pass `--json` for machine output), and gains `--init` (scaffold a `.codegraphrc.json` with all sections pre-populated), `--edit` (open in `$EDITOR`), `--enable-global`, `--disable-global`, and `--list-global` flags. Global `--user-config [path]` and `--no-user-config` CLI flags are also new. The `explain` command lands as a discoverable alias for `audit`. TypeScript compiler-based type resolution now auto-enables for TS projects that have a `tsconfig.json`. A supply-chain incident is resolved — a malicious `tree-sitter-erlang` npm package is replaced with a clean source build. On engine accuracy, super-dispatch cross-file false edges are eliminated, CHA confidence is aligned between WASM and native, and a sweep of parity fixes improves call-graph correctness for Go, Python, C++, CUDA, Haskell, and Zig.
+
+### Features
+
+* **cli:** add `explain` as alias for `audit` — `codegraph explain <target>` is equivalent to `codegraph audit <target>`; makes the audit command easier to discover
+* **config:** `codegraph config` now shows a key/value/source table when `--json` is not passed — each key displays its current value and which layer it came from (`default`, `user`, `project`, `env`)
+* **config:** add `--init` and `--edit` scaffolding helpers — `codegraph config --init` scaffolds a `.codegraphrc.json` with all sections pre-populated; `codegraph config --edit` opens the project config file in `$EDITOR`
+* **config:** user-level (global) config with per-repo consent — new `~/.config/codegraph/config.json` (XDG) or `~/.codegraph/config.json` fallback; interactive per-repo consent model; `codegraph config --enable-global`, `--disable-global`, `--list-global` flags; global `--user-config [path]` and `--no-user-config` CLI flags; layered merge order: DEFAULTS → global (if consented) → project → env; `config_hash` invalidation triggers a full rebuild when build-relevant config changes; `loadConfigWithProvenance` returns per-key source map ([#1559](https://github.com/optave/ops-codegraph-tool/pull/1559))
+
+### Bug Fixes
+
+* **config:** auto-enable TypeScript compiler resolver for TS projects — `typescriptResolver` now defaults to `true`; silently skips when `typescript` is unavailable or no `tsconfig.json` is present, so JS-only projects and environments without TypeScript are unaffected ([#1461](https://github.com/optave/ops-codegraph-tool/pull/1461))
+* **config:** clarify consent prompt wording to reflect per-key inheritance semantics and improve question clarity
+* **cha:** eliminate super-dispatch cross-file false edges — `super.method()` calls no longer resolve to methods outside the class hierarchy; the native engine expands super-dispatch into CHA sibling overrides ([#1506](https://github.com/optave/ops-codegraph-tool/pull/1506), [#1514](https://github.com/optave/ops-codegraph-tool/pull/1514), [#1537](https://github.com/optave/ops-codegraph-tool/pull/1537), [#1544](https://github.com/optave/ops-codegraph-tool/pull/1544))
+* **native:** resolve this-dispatch in func-prop methods — `fn.method = function(){ this.other() }` now resolves `other` through the func-prop enclosing context ([#1512](https://github.com/optave/ops-codegraph-tool/pull/1512))
+* **native:** seed typeMap entries for let/var object-literal methods — object literal methods defined with `let`/`var` now register their receiver types for downstream resolution
+* **native:** prefer bare name over qualified in span-tie caller attribution — when two candidates share the same span, the bare-name symbol wins to avoid false qualified-name attribution
+* **native:** resolve Go factory and Python constructor receiver types — `NewFoo()` in Go and `Foo()` constructors in Python now seed the typeMap for downstream method-call resolution ([#1498](https://github.com/optave/ops-codegraph-tool/pull/1498))
+* **native:** align object-literal shorthand method node ordering with WASM — extraction order is now consistent between engines
+* **wasm:** align TypeScript CHA dispatch confidence (0.6 → 0.8) — WASM now matches the native engine's confidence for CHA-resolved edges ([#1505](https://github.com/optave/ops-codegraph-tool/pull/1505))
+* **wasm:** port missing node extractions to JS extractor (jelly-micro #1471) — several edge-type gaps in the WASM engine aligned with the native engine ([#1509](https://github.com/optave/ops-codegraph-tool/pull/1509))
+* **wasm:** emit receiver edges for declaration-typed locals (C++, CUDA) — typed local declarations in C++ and CUDA now produce receiver call edges ([#1497](https://github.com/optave/ops-codegraph-tool/pull/1497))
+* **parity:** port the JS points-to solver to native — WASM and native now run identical resolution logic for JavaScript/TypeScript points-to bindings; the four JS pts post-passes on the hybrid path are removed, leaving a single source of truth ([#1465](https://github.com/optave/ops-codegraph-tool/pull/1465))
+* **parity:** align Java interface dispatch across WASM, native, and hybrid engines — all three engines now agree on interface method resolution confidence and edge set ([#1503](https://github.com/optave/ops-codegraph-tool/pull/1503))
+* **parity:** align enclosing-caller attribution for variable bindings (Haskell, Zig) — multi-binding `let` patterns now attribute calls to the correct enclosing caller ([#1499](https://github.com/optave/ops-codegraph-tool/pull/1499))
+* **extractor:** strip brackets from computed string-key method names — `obj['method']()` no longer emits `['method']` as the method name
+* **receiver:** local function constructors block cross-file class receiver edges — prevents false cross-file receiver matches when a same-file function constructor is in scope
+* **resolver:** class-scope field annotation typeMap keys prevent cross-class collision — `private repo: Repository` in two classes no longer shares a typeMap key ([#1495](https://github.com/optave/ops-codegraph-tool/pull/1495))
+* **triage:** normalize JSON output to use `items` key at all levels — all triage JSON responses now use a consistent `items` array structure
+* **cli:** accept `--json` flag in batch command as no-op — batch command no longer errors when `--json` is passed ([#1563](https://github.com/optave/ops-codegraph-tool/pull/1563))
+* **parser:** downgrade WARN to debug for optional parsers with missing WASM grammar — language parse errors for optional grammars no longer pollute stderr with WARN messages
+* **native:** don't warn when a natively-supported file produces 0 symbols via WASM — gitignored Rust addon artifacts no longer trigger false-positive extractor failure warnings
+* **deps:** remove malicious `tree-sitter-erlang`, fix 3 moderate vulnerabilities — replaces the compromised npm package with a clean source build; also fixes 3 moderate-severity vulns ([#1478](https://github.com/optave/ops-codegraph-tool/pull/1478))
+* **hooks:** track Bash file modifications to prevent false-positive commit blocks ([#1483](https://github.com/optave/ops-codegraph-tool/pull/1483))
+* **perf:** scope `runPostNativeCha` to changed files on incremental builds — incremental rebuilds no longer run the full CHA post-pass on unchanged files ([#1490](https://github.com/optave/ops-codegraph-tool/pull/1490))
+* **perf:** pass `symbolsOnly` through `parseFilesWasmInline` — avoids unnecessary data extraction during symbol-only parse passes ([#1489](https://github.com/optave/ops-codegraph-tool/pull/1489))
+* **bench:** update Elixir, Julia, and Objective-C expected-edges to module-qualified names ([#1496](https://github.com/optave/ops-codegraph-tool/pull/1496))
+* **ci:** accept v-prefixed versions in `publish` `workflow_dispatch` input ([#1443](https://github.com/optave/ops-codegraph-tool/pull/1443))
+
+### Performance
+
+* **native:** replace O(n²) type-map dedup with O(n) write-then-dedup — large files with many type-map entries no longer degrade quadratically during the native post-pass
+
+### Refactors
+
+* **native:** mirror Rust crate module layout to the TypeScript `src/` tree — `crates/codegraph-core/src/` modules now follow the snake_case equivalent of their TypeScript counterparts ([#1463](https://github.com/optave/ops-codegraph-tool/pull/1463))
+* **extractors:** deduplicate C-family primitive types into a shared constant
+
+### Chores
+
+* **ci:** add per-PR perf canary for extractor/graph/native changes ([#1488](https://github.com/optave/ops-codegraph-tool/pull/1488))
+* **ci:** add dev-dependency audit step at critical severity ([#1479](https://github.com/optave/ops-codegraph-tool/pull/1479))
+* **deps-dev:** bump `@biomejs/biome` from 2.4.16 to 2.5.0 ([#1523](https://github.com/optave/ops-codegraph-tool/pull/1523))
+* **deps-dev:** bump `tree-sitter-gleam` ([#1522](https://github.com/optave/ops-codegraph-tool/pull/1522))
+* **deps-dev:** bump `@vitest/coverage-v8` from 4.1.7 to 4.1.8 ([#1521](https://github.com/optave/ops-codegraph-tool/pull/1521))
+* **deps:** bump `anthropics/claude-code-action` from 0.0.63 to 1.0.148 ([#1520](https://github.com/optave/ops-codegraph-tool/pull/1520))
+
 ## [3.12.0](https://github.com/optave/ops-codegraph-tool/compare/v3.11.2...v3.12.0) (2026-06-10)
 
 **Phase 8 Analysis Depth lands in full, plus a 30-technique JavaScript/TypeScript resolution sweep.** Sub-phases 8.1 through 8.6 are now complete, with 8.3 substantially complete (one stretch-goal item — full allocation-site abstraction with fixed-point iteration — deferred to a future release): TypeScript compiler API type resolution (`typescriptResolver` opt-in in `.codegraphrc.json`) upgrades confidence-0.7 heuristic edges to compiler-verified 1.0; inter-procedural return-type propagation resolves method chains and factory patterns up to 3 hops; field-based points-to analysis (Phases 8.3 through 8.3f) covers callbacks, event handlers, parameter flows, object property writes, and object destructuring rest parameters in both WASM and native engines; barrel re-export chain resolution traces symbols through `index.ts` re-exports to their actual declaration files; CHA+RTA dynamic dispatch resolves interface method calls to all instantiated concrete implementations; and Phase 8.6 adds a `byTechnique` breakdown to `codegraph stats --json` showing edges attributed to each resolver technique. Beyond the Phase 8 work, a parallel accuracy sweep adds resolution for prototype-based method calls, `Object.defineProperty` accessor this-dispatch, `super.method()` dispatch via class expressions and static blocks, `.call/.apply/.bind` receiver rebinding, `for-of`/`Set`/`Array.from` iteration callbacks, inline-array spread call edges, and constructor-assigned property types. C# call graphs improve with same-class bare static call resolution and `var`-typed local type inference. Six native engine parity issues in the incremental rebuild path are fixed. Caller coverage for real-world TypeScript projects is substantially higher after this release. Note: most resolver improvements appear under Bug Fixes below — they used `fix:` commit prefixes because they corrected missing edges in existing resolution logic rather than introducing entirely new CLI capabilities.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Composite commands for risk-driven workflows and multi-agent dispatch.
 codegraph audit <file-or-function>    # Combined structural summary + impact + health in one report
 codegraph audit <target> --quick      # Structural summary only (skip impact and health)
 codegraph audit src/queries.js -T     # Audit all functions in a file
+codegraph explain <target>            # Alias for audit — same output, easier to discover
 codegraph triage                      # Ranked audit priority queue (connectivity + hotspots + roles)
 codegraph triage -T --limit 20        # Top 20 riskiest functions, excluding tests
 codegraph triage --level file -T      # File-level hotspot analysis
@@ -455,6 +456,22 @@ codegraph registry remove <name>  # Unregister
 ```
 
 `codegraph build` auto-registers the project — no manual setup needed.
+
+### Configuration
+
+Inspect and manage `.codegraphrc.json` settings.
+
+```bash
+codegraph config                    # Show all config keys with values and sources
+codegraph config --json             # JSON output of the merged config
+codegraph config --init             # Scaffold a .codegraphrc.json with all sections pre-populated
+codegraph config --edit             # Open .codegraphrc.json in $EDITOR
+codegraph config --enable-global    # Opt this repo into user-level global config
+codegraph config --disable-global   # Opt this repo out of user-level global config
+codegraph config --list-global      # Show the contents of the global config file
+```
+
+A user-level config file at `~/.config/codegraph/config.json` (XDG) or `~/.codegraph/config.json` lets you set personal defaults once and apply them to opted-in repos. The merge order is: DEFAULTS → global (if consented) → project → env. Non-interactive contexts (CI, MCP) never apply the global config without explicit consent. See [docs/guides/configuration.md](docs/guides/configuration.md) for full details.
 
 ### Common Flags
 

--- a/README.md
+++ b/README.md
@@ -492,6 +492,8 @@ A user-level config file at `~/.config/codegraph/config.json` (XDG) or `~/.codeg
 | `--limit <n>` | Limit number of results |
 | `--offset <n>` | Skip first N results (pagination) |
 | `--rrf-k <n>` | RRF smoothing constant for multi-query search (default 60) |
+| `--user-config [path]` | Apply global user config for this run; optionally specify a custom path instead of the XDG default (`~/.config/codegraph/config.json`) |
+| `--no-user-config` | Skip global user config for this run (CI/non-interactive safe) |
 
 ## 🌐 Language Support
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,6 +1,6 @@
 # Codegraph Roadmap
 
-> **Current version:** 3.12.0 | **Status:** Active development | **Updated:** 2026-06-10
+> **Current version:** 3.13.0 | **Status:** Active development | **Updated:** 2026-06-16
 
 Codegraph is a strong local-first code graph CLI. This roadmap describes planned improvements across fourteen phases -- closing gaps with commercial code intelligence platforms while preserving codegraph's core strengths: fully local, open source, zero cloud dependency by default.
 
@@ -2311,6 +2311,8 @@ Commander supports shell completion but it's not implemented. Basic UX gap for a
 1. **CI `npm audit`** -- add `npm audit --omit=dev` step to CI pipeline; fail on critical/high vulnerabilities
    - ✅ npm audit CI step added (v3.9.1, [#834](https://github.com/optave/ops-codegraph-tool/pull/834))
    - ✅ WASM grammar validation — build-time integrity checks for tree-sitter grammar files (v3.9.1, [#834](https://github.com/optave/ops-codegraph-tool/pull/834))
+   - ✅ Dev-dependency audit at critical severity added to CI (v3.13.0, [#1479](https://github.com/optave/ops-codegraph-tool/pull/1479))
+   - ✅ Supply-chain incident resolved — malicious `tree-sitter-erlang` npm package replaced with clean source build; 3 moderate vulns fixed (v3.13.0, [#1478](https://github.com/optave/ops-codegraph-tool/pull/1478))
 2. **SBOM generation** -- produce CycloneDX or SPDX SBOM on each release via `@cyclonedx/cyclonedx-npm` or similar
    - 🔲 Not yet started
 3. **SLSA provenance** -- enable SLSA Level 2+ build provenance using `actions/attest-build-provenance` in the publish workflow; attach attestation to npm packages


### PR DESCRIPTION
## Summary

- Add CHANGELOG entry for v3.13.0 (all commits since v3.12.0)
- Update ROADMAP version header to 3.13.0 and add Phase 10.1 progress notes for CI audit step (#1479) and supply-chain remediation (#1478)
- Add `codegraph explain` alias to README Audit section
- Add `codegraph config` command section to README with `--init`, `--edit`, `--enable-global`, `--disable-global`, `--list-global` flags
- Repo "about": no changes needed — description and topics are current

## Version bump rationale

**Minor** (3.12.0 → 3.13.0). New user-facing CLI surface in this release:
- New `explain` command (alias for `audit`)
- New `codegraph config --init` and `--edit` scaffolding helpers
- User-level global config with per-repo consent (`--enable-global`, `--disable-global`, `--list-global`, `--user-config`, `--no-user-config`)
- Table output for `codegraph config` without `--json`

**After merging:** create a GitHub Release with tag `v3.13.0` to trigger the publish workflow, which handles version bumping, native binary builds, and npm publishing.

## Test plan
- [ ] CHANGELOG renders correctly on GitHub
- [ ] ROADMAP checklist items match actual codebase state
- [ ] README roadmap order matches ROADMAP.md
- [ ] Repo "about" description and topics are current