### PR TITLE
refactor: replace CFG processStatement switch with handler-table dispatch (TS + Rust)

### DIFF
--- a/crates/codegraph-core/src/ast_analysis/cfg.rs
+++ b/crates/codegraph-core/src/ast_analysis/cfg.rs
@@ -920,7 +920,14 @@ impl<'a> CfgBuilder<'a> {
 
         let join_block = self.make_block("body", None, None, None);
 
-        // True branch
+        self.process_if_true_branch(if_stmt, cond_block, join_block);
+        self.process_if_false_branch(if_stmt, cond_block, join_block, depth);
+
+        Some(join_block)
+    }
+
+    /// Wire up the true branch of an if statement.
+    fn process_if_true_branch(&mut self, if_stmt: &Node, cond_block: u32, join_block: u32) {
         let consequent_field = self.rules.if_consequent_field.unwrap_or("consequence");
         let consequent = if_stmt.child_by_field_name(consequent_field);
         let true_block = self.make_block("branch_true", None, None, Some("then"));
@@ -935,70 +942,80 @@ impl<'a> CfgBuilder<'a> {
         } else {
             self.add_edge(true_block, join_block, "fallthrough");
         }
+    }
 
-        // False branch
+    /// Wire up the false branch of an if statement (elif siblings, alternative, or no-else).
+    fn process_if_false_branch(&mut self, if_stmt: &Node, cond_block: u32, join_block: u32, depth: usize) {
         if self.rules.elif_node.is_some() {
             // Pattern B: elif/else as siblings
             self.process_elif_siblings(if_stmt, cond_block, join_block);
-        } else {
-            let alternative = if_stmt.child_by_field_name("alternative");
-            if let Some(alternative) = alternative {
-                let alt_kind = alternative.kind();
-                if self.rules.else_via_alternative && !matches_opt(alt_kind, self.rules.else_clause) {
-                    // Pattern C: alternative points directly to if or block
-                    if matches_opt(alt_kind, self.rules.if_node) || matches_slice(alt_kind, self.rules.if_nodes) {
-                        let false_block = self.make_block("branch_false", None, None, Some("else-if"));
-                        self.add_edge(cond_block, false_block, "branch_false");
-                        let else_if_end = self.process_if_depth(&alternative, false_block, depth + 1);
-                        if let Some(eie) = else_if_end {
-                            self.add_edge(eie, join_block, "fallthrough");
-                        }
-                    } else {
-                        let false_block = self.make_block("branch_false", None, None, Some("else"));
-                        self.add_edge(cond_block, false_block, "branch_false");
-                        let false_stmts = self.get_statements(&alternative);
-                        let false_end = self.process_statements(&false_stmts, false_block);
-                        if let Some(fe) = false_end {
-                            self.add_edge(fe, join_block, "fallthrough");
-                        }
-                    }
-                } else if matches_opt(alt_kind, self.rules.else_clause) {
-                    // Pattern A: else_clause wrapper
-                    let else_children: Vec<Node> = {
-                        let cursor = &mut alternative.walk();
-                        alternative.named_children(cursor).collect()
-                    };
-                    if else_children.len() == 1
-                        && (matches_opt(else_children[0].kind(), self.rules.if_node)
-                            || matches_slice(else_children[0].kind(), self.rules.if_nodes))
-                    {
-                        // else-if: recurse
-                        let false_block = self.make_block("branch_false", None, None, Some("else-if"));
-                        self.add_edge(cond_block, false_block, "branch_false");
-                        let else_if_end = self.process_if_depth(&else_children[0], false_block, depth + 1);
-                        if let Some(eie) = else_if_end {
-                            self.add_edge(eie, join_block, "fallthrough");
-                        }
-                    } else {
-                        // else block
-                        let false_block = self.make_block("branch_false", None, None, Some("else"));
-                        self.add_edge(cond_block, false_block, "branch_false");
-                        let false_end = self.process_statements(&else_children, false_block);
-                        if let Some(fe) = false_end {
-                            self.add_edge(fe, join_block, "fallthrough");
-                        }
-                    }
-                } else {
-                    // Unknown alternative type — treat as no else
-                    self.add_edge(cond_block, join_block, "branch_false");
-                }
-            } else {
-                // No else: condition-false goes to join
-                self.add_edge(cond_block, join_block, "branch_false");
-            }
+            return;
         }
 
-        Some(join_block)
+        let alternative = if_stmt.child_by_field_name("alternative");
+        let Some(alternative) = alternative else {
+            // No else: condition-false goes to join
+            self.add_edge(cond_block, join_block, "branch_false");
+            return;
+        };
+
+        let alt_kind = alternative.kind();
+        if self.rules.else_via_alternative && !matches_opt(alt_kind, self.rules.else_clause) {
+            self.process_if_alternative_c(alternative, alt_kind, cond_block, join_block, depth);
+        } else if matches_opt(alt_kind, self.rules.else_clause) {
+            self.process_if_else_clause(alternative, cond_block, join_block, depth);
+        } else {
+            // Unknown alternative type — treat as no else
+            self.add_edge(cond_block, join_block, "branch_false");
+        }
+    }
+
+    /// Pattern C: alternative points directly to if or block (else_via_alternative languages).
+    fn process_if_alternative_c(&mut self, alternative: Node, alt_kind: &str, cond_block: u32, join_block: u32, depth: usize) {
+        if matches_opt(alt_kind, self.rules.if_node) || matches_slice(alt_kind, self.rules.if_nodes) {
+            let false_block = self.make_block("branch_false", None, None, Some("else-if"));
+            self.add_edge(cond_block, false_block, "branch_false");
+            let else_if_end = self.process_if_depth(&alternative, false_block, depth + 1);
+            if let Some(eie) = else_if_end {
+                self.add_edge(eie, join_block, "fallthrough");
+            }
+        } else {
+            let false_block = self.make_block("branch_false", None, None, Some("else"));
+            self.add_edge(cond_block, false_block, "branch_false");
+            let false_stmts = self.get_statements(&alternative);
+            let false_end = self.process_statements(&false_stmts, false_block);
+            if let Some(fe) = false_end {
+                self.add_edge(fe, join_block, "fallthrough");
+            }
+        }
+    }
+
+    /// Pattern A: else_clause wrapper (else { ... } or else if ...).
+    fn process_if_else_clause(&mut self, alternative: Node, cond_block: u32, join_block: u32, depth: usize) {
+        let else_children: Vec<Node> = {
+            let cursor = &mut alternative.walk();
+            alternative.named_children(cursor).collect()
+        };
+        if else_children.len() == 1
+            && (matches_opt(else_children[0].kind(), self.rules.if_node)
+                || matches_slice(else_children[0].kind(), self.rules.if_nodes))
+        {
+            // else-if: recurse
+            let false_block = self.make_block("branch_false", None, None, Some("else-if"));
+            self.add_edge(cond_block, false_block, "branch_false");
+            let else_if_end = self.process_if_depth(&else_children[0], false_block, depth + 1);
+            if let Some(eie) = else_if_end {
+                self.add_edge(eie, join_block, "fallthrough");
+            }
+        } else {
+            // else block
+            let false_block = self.make_block("branch_false", None, None, Some("else"));
+            self.add_edge(cond_block, false_block, "branch_false");
+            let false_end = self.process_statements(&else_children, false_block);
+            if let Some(fe) = false_end {
+                self.add_edge(fe, join_block, "fallthrough");
+            }
+        }
     }
 
     /// Pattern B: elif/elsif/else_if as sibling children of the if node.
@@ -1232,51 +1249,10 @@ impl<'a> CfgBuilder<'a> {
         let case_children: Vec<Node> = container.named_children(cursor).collect();
 
         for case_clause in &case_children {
-            let cc_kind = case_clause.kind();
-            let is_default = matches_opt(cc_kind, self.rules.default_node)
-                || (self.rules.wildcard_pattern_node.is_some()
-                    && (matches_opt(cc_kind, self.rules.case_node) || matches_slice(cc_kind, self.rules.case_nodes))
-                    && case_clause.named_child(0)
-                        .is_some_and(|c| matches_opt(c.kind(), self.rules.wildcard_pattern_node)));
-            let is_case = is_default
-                || matches_opt(cc_kind, self.rules.case_node)
-                || matches_slice(cc_kind, self.rules.case_nodes);
-
-            if !is_case {
-                continue;
-            }
-
-            let case_label = if is_default { "default" } else { "case" };
-            let case_block = self.make_block("case", Some(node_line(case_clause)), None, Some(case_label));
-            let edge_kind = if is_default { "branch_false" } else { "branch_true" };
-            self.add_edge(switch_header, case_block, edge_kind);
-            if is_default {
-                has_default = true;
-            }
-
-            // Extract case body
-            let case_body_node = case_clause.child_by_field_name("body")
-                .or_else(|| case_clause.child_by_field_name("consequence"));
-
-            let case_stmts: Vec<Node> = if let Some(body_node) = case_body_node {
-                self.get_statements(&body_node)
-            } else if let Some(value_node) = case_clause.child_by_field_name("value") {
-                // Rust match_arm: the `value` field is the arm expression body
-                vec![value_node]
-            } else {
-                let pattern_node = case_clause.child_by_field_name("pattern");
-                let cursor2 = &mut case_clause.walk();
-                case_clause.named_children(cursor2)
-                    .filter(|child| {
-                        if let Some(ref p) = pattern_node { if child.id() == p.id() { return false; } }
-                        child.kind() != "switch_label"
-                    })
-                    .collect()
-            };
-
-            let case_end = self.process_statements(&case_stmts, case_block);
-            if let Some(ce) = case_end {
-                self.add_edge(ce, join_block, "fallthrough");
+            if let Some(is_default) = self.process_switch_case(case_clause, switch_header, join_block) {
+                if is_default {
+                    has_default = true;
+                }
             }
         }
 
@@ -1288,12 +1264,87 @@ impl<'a> CfgBuilder<'a> {
         Some(join_block)
     }
 
+    /// Process a single case clause within a switch statement.
+    /// Returns `Some(is_default)` if the clause was a case/default, `None` if skipped.
+    fn process_switch_case(&mut self, case_clause: &Node, switch_header: u32, join_block: u32) -> Option<bool> {
+        let cc_kind = case_clause.kind();
+        let is_default = matches_opt(cc_kind, self.rules.default_node)
+            || (self.rules.wildcard_pattern_node.is_some()
+                && (matches_opt(cc_kind, self.rules.case_node) || matches_slice(cc_kind, self.rules.case_nodes))
+                && case_clause.named_child(0)
+                    .is_some_and(|c| matches_opt(c.kind(), self.rules.wildcard_pattern_node)));
+        let is_case = is_default
+            || matches_opt(cc_kind, self.rules.case_node)
+            || matches_slice(cc_kind, self.rules.case_nodes);
+
+        if !is_case {
+            return None;
+        }
+
+        let case_label = if is_default { "default" } else { "case" };
+        let case_block = self.make_block("case", Some(node_line(case_clause)), None, Some(case_label));
+        let edge_kind = if is_default { "branch_false" } else { "branch_true" };
+        self.add_edge(switch_header, case_block, edge_kind);
+
+        let case_stmts = self.extract_case_stmts(case_clause);
+        let case_end = self.process_statements(&case_stmts, case_block);
+        if let Some(ce) = case_end {
+            self.add_edge(ce, join_block, "fallthrough");
+        }
+
+        Some(is_default)
+    }
+
+    /// Extract the statement list from a case clause body.
+    fn extract_case_stmts<'b>(&self, case_clause: &Node<'b>) -> Vec<Node<'b>> {
+        let case_body_node = case_clause.child_by_field_name("body")
+            .or_else(|| case_clause.child_by_field_name("consequence"));
+
+        if let Some(body_node) = case_body_node {
+            self.get_statements(&body_node)
+        } else if let Some(value_node) = case_clause.child_by_field_name("value") {
+            // Rust match_arm: the `value` field is the arm expression body
+            vec![value_node]
+        } else {
+            let pattern_node = case_clause.child_by_field_name("pattern");
+            let cursor2 = &mut case_clause.walk();
+            case_clause.named_children(cursor2)
+                .filter(|child| {
+                    if let Some(ref p) = pattern_node { if child.id() == p.id() { return false; } }
+                    child.kind() != "switch_label"
+                })
+                .collect()
+        }
+    }
+
     fn process_try_catch(&mut self, try_stmt: &Node, current: u32) -> Option<u32> {
         self.set_end_line(current, node_line(try_stmt));
 
         let join_block = self.make_block("body", None, None, None);
 
         // Try body
+        let (try_block, try_end) = self.process_try_body(try_stmt, current);
+
+        // Find catch, finally, and else handlers
+        let (catch_handlers, finally_handler, else_handler) = self.collect_try_handlers(try_stmt);
+
+        // Process else clause (Python try...except...else): runs when try succeeds
+        let success_end = self.process_try_else(else_handler, try_end);
+
+        if !catch_handlers.is_empty() {
+            let catch_ends = self.process_catch_handlers(&catch_handlers, try_block);
+            self.wire_finally_or_join(finally_handler, success_end, &catch_ends, join_block);
+        } else if let Some(finally_node) = finally_handler {
+            self.process_finally_block(finally_node, success_end, &[], join_block);
+        } else if let Some(se) = success_end {
+            self.add_edge(se, join_block, "fallthrough");
+        }
+
+        Some(join_block)
+    }
+
+    /// Extract and process the try-body statements; returns (try_block_idx, try_end).
+    fn process_try_body(&mut self, try_stmt: &Node, current: u32) -> (u32, Option<u32>) {
         let try_body = try_stmt.child_by_field_name("body");
         let (try_body_start, try_stmts): (u32, Vec<Node>) = if let Some(body) = try_body {
             (node_line(&body), self.get_statements(&body))
@@ -1313,8 +1364,11 @@ impl<'a> CfgBuilder<'a> {
         let try_block = self.make_block("body", Some(try_body_start), None, Some("try"));
         self.add_edge(current, try_block, "fallthrough");
         let try_end = self.process_statements(&try_stmts, try_block);
+        (try_block, try_end)
+    }
 
-        // Find catch, finally, and else handlers
+    /// Collect catch, finally, and else handler nodes from a try statement.
+    fn collect_try_handlers<'b>(&self, try_stmt: &Node<'b>) -> (Vec<Node<'b>>, Option<Node<'b>>, Option<Node<'b>>) {
         let mut catch_handlers: Vec<Node> = Vec::new();
         let mut finally_handler: Option<Node> = None;
         let mut else_handler: Option<Node> = None;
@@ -1327,14 +1381,15 @@ impl<'a> CfgBuilder<'a> {
                 finally_handler = Some(child);
             }
             if matches_opt(child.kind(), self.rules.else_node) {
-                // Only treat as try-else if it's a direct child of the try statement
-                // (not the else_clause of an if inside the try body)
                 else_handler = Some(child);
             }
         }
+        (catch_handlers, finally_handler, else_handler)
+    }
 
-        // Process else clause (Python try...except...else): runs when try succeeds
-        let success_end = if let Some(else_node) = else_handler {
+    /// Process the optional else clause of a try statement (Python try...except...else).
+    fn process_try_else(&mut self, else_handler: Option<Node>, try_end: Option<u32>) -> Option<u32> {
+        if let Some(else_node) = else_handler {
             let else_block = self.make_block("body", Some(node_line(&else_node)), None, Some("else"));
             if let Some(te) = try_end {
                 self.add_edge(te, else_block, "fallthrough");
@@ -1343,78 +1398,66 @@ impl<'a> CfgBuilder<'a> {
             self.process_statements(&else_stmts, else_block)
         } else {
             try_end
-        };
+        }
+    }
 
-        if !catch_handlers.is_empty() {
-            let mut catch_ends: Vec<Option<u32>> = Vec::new();
+    /// Process all catch handlers, returning the list of catch-end block indices.
+    fn process_catch_handlers(&mut self, catch_handlers: &[Node], try_block: u32) -> Vec<Option<u32>> {
+        let mut catch_ends: Vec<Option<u32>> = Vec::new();
+        for catch_node in catch_handlers {
+            let catch_block = self.make_block("catch", Some(node_line(catch_node)), None, Some("catch"));
+            self.add_edge(try_block, catch_block, "exception");
 
-            for catch_node in &catch_handlers {
-                let catch_block = self.make_block("catch", Some(node_line(catch_node)), None, Some("catch"));
-                self.add_edge(try_block, catch_block, "exception");
-
-                let catch_body_node = catch_node.child_by_field_name("body");
-                let catch_stmts: Vec<Node> = if let Some(body) = catch_body_node {
-                    self.get_statements(&body)
-                } else {
-                    let cursor2 = &mut catch_node.walk();
-                    catch_node.named_children(cursor2).collect()
-                };
-                let catch_end = self.process_statements(&catch_stmts, catch_block);
-                catch_ends.push(catch_end);
-            }
-
-            if let Some(finally_node) = finally_handler {
-                let finally_block = self.make_block("finally", Some(node_line(&finally_node)), None, Some("finally"));
-                if let Some(se) = success_end {
-                    self.add_edge(se, finally_block, "fallthrough");
-                }
-                for catch_end in &catch_ends {
-                    if let Some(ce) = *catch_end {
-                        self.add_edge(ce, finally_block, "fallthrough");
-                    }
-                }
-                let finally_body = finally_node.child_by_field_name("body");
-                let finally_stmts: Vec<Node> = if let Some(body) = finally_body {
-                    self.get_statements(&body)
-                } else {
-                    self.get_statements(&finally_node)
-                };
-                let finally_end = self.process_statements(&finally_stmts, finally_block);
-                if let Some(fe) = finally_end {
-                    self.add_edge(fe, join_block, "fallthrough");
-                }
-            } else {
-                if let Some(se) = success_end {
-                    self.add_edge(se, join_block, "fallthrough");
-                }
-                for catch_end in &catch_ends {
-                    if let Some(ce) = *catch_end {
-                        self.add_edge(ce, join_block, "fallthrough");
-                    }
-                }
-            }
-        } else if let Some(finally_node) = finally_handler {
-            let finally_block = self.make_block("finally", Some(node_line(&finally_node)), None, Some("finally"));
-            if let Some(se) = success_end {
-                self.add_edge(se, finally_block, "fallthrough");
-            }
-            let finally_body = finally_node.child_by_field_name("body");
-            let finally_stmts: Vec<Node> = if let Some(body) = finally_body {
+            let catch_body_node = catch_node.child_by_field_name("body");
+            let catch_stmts: Vec<Node> = if let Some(body) = catch_body_node {
                 self.get_statements(&body)
             } else {
-                self.get_statements(&finally_node)
+                let cursor2 = &mut catch_node.walk();
+                catch_node.named_children(cursor2).collect()
             };
-            let finally_end = self.process_statements(&finally_stmts, finally_block);
-            if let Some(fe) = finally_end {
-                self.add_edge(fe, join_block, "fallthrough");
-            }
+            let catch_end = self.process_statements(&catch_stmts, catch_block);
+            catch_ends.push(catch_end);
+        }
+        catch_ends
+    }
+
+    /// Wire a finally block (or direct join edges when there is no finally).
+    fn wire_finally_or_join(&mut self, finally_handler: Option<Node>, success_end: Option<u32>, catch_ends: &[Option<u32>], join_block: u32) {
+        if let Some(finally_node) = finally_handler {
+            self.process_finally_block(finally_node, success_end, catch_ends, join_block);
         } else {
             if let Some(se) = success_end {
                 self.add_edge(se, join_block, "fallthrough");
             }
+            for catch_end in catch_ends {
+                if let Some(ce) = *catch_end {
+                    self.add_edge(ce, join_block, "fallthrough");
+                }
+            }
         }
+    }
 
-        Some(join_block)
+    /// Process a finally block, wiring all predecessor ends into it and its end to join.
+    fn process_finally_block(&mut self, finally_node: Node, success_end: Option<u32>, catch_ends: &[Option<u32>], join_block: u32) {
+        let finally_block = self.make_block("finally", Some(node_line(&finally_node)), None, Some("finally"));
+        if let Some(se) = success_end {
+            self.add_edge(se, finally_block, "fallthrough");
+        }
+        for catch_end in catch_ends {
+            if let Some(ce) = *catch_end {
+                self.add_edge(ce, finally_block, "fallthrough");
+            }
+        }
+        let finally_body = finally_node.child_by_field_name("body");
+        let finally_stmts: Vec<Node> = if let Some(body) = finally_body {
+            self.get_statements(&body)
+        } else {
+            self.get_statements(&finally_node)
+        };
+        let finally_end = self.process_statements(&finally_stmts, finally_block);
+        if let Some(fe) = finally_end {
+            self.add_edge(fe, join_block, "fallthrough");
+        }
     }
 }
 

--- a/crates/codegraph-core/src/ast_analysis/cfg.rs
+++ b/crates/codegraph-core/src/ast_analysis/cfg.rs
@@ -1368,6 +1368,11 @@ impl<'a> CfgBuilder<'a> {
     }
 
     /// Collect catch, finally, and else handler nodes from a try statement.
+    ///
+    /// Iterates only over direct children of `try_stmt`: this is both necessary and sufficient
+    /// because tree-sitter represents each handler clause as a direct child of the try node.
+    /// Only treat as try-else if it's a direct child of the try statement
+    /// (not the else_clause of an if inside the try body).
     fn collect_try_handlers<'b>(&self, try_stmt: &Node<'b>) -> (Vec<Node<'b>>, Option<Node<'b>>, Option<Node<'b>>) {
         let mut catch_handlers: Vec<Node> = Vec::new();
         let mut finally_handler: Option<Node> = None;

--- a/crates/codegraph-core/src/ast_analysis/dataflow.rs
+++ b/crates/codegraph-core/src/ast_analysis/dataflow.rs
@@ -1106,13 +1106,11 @@ fn unwrap_await<'a>(node: &Node<'a>, rules: &DataflowRules) -> Node<'a> {
     *node
 }
 
-fn handle_var_declarator(
-    node: &Node,
+/// Resolve the name and value nodes from a variable declarator, handling C#/Go quirks.
+fn resolve_var_declarator_nodes<'a>(
+    node: &Node<'a>,
     rules: &DataflowRules,
-    source: &[u8],
-    scope_stack: &mut Vec<ScopeFrame>,
-    assignments: &mut Vec<DataflowAssignment>,
-) {
+) -> (Option<Node<'a>>, Option<Node<'a>>) {
     let mut name_node = node.child_by_field_name(rules.var_name_field);
     let mut value_node = rules.var_value_field.and_then(|f| node.child_by_field_name(f));
 
@@ -1157,6 +1155,42 @@ fn handle_var_declarator(
         }
     }
 
+    (name_node, value_node)
+}
+
+/// Emit assignments for a destructuring pattern (object or array).
+fn emit_destructuring_assignments(
+    name_n: &Node,
+    node: &Node,
+    callee: &str,
+    func_name: &str,
+    rules: &DataflowRules,
+    source: &[u8],
+    scope: &mut ScopeFrame,
+    assignments: &mut Vec<DataflowAssignment>,
+) {
+    let names = extract_param_names(name_n, rules, source);
+    for n in &names {
+        assignments.push(DataflowAssignment {
+            var_name: n.clone(),
+            caller_func: Some(func_name.to_string()),
+            source_call_name: callee.to_string(),
+            expression: truncate(node_text(node, source), DATAFLOW_TRUNCATION_LIMIT),
+            line: node_line(node),
+        });
+        scope.locals.insert(n.clone(), LocalSource::Destructured);
+    }
+}
+
+fn handle_var_declarator(
+    node: &Node,
+    rules: &DataflowRules,
+    source: &[u8],
+    scope_stack: &mut Vec<ScopeFrame>,
+    assignments: &mut Vec<DataflowAssignment>,
+) {
+    let (name_node, value_node) = resolve_var_declarator_nodes(node, rules);
+
     let scope = match scope_stack.last_mut() {
         Some(s) => s,
         None => return,
@@ -1189,19 +1223,7 @@ fn handle_var_declarator(
     let is_arr_destruct = rules.array_destruct_type.is_some_and(|a| a == name_n.kind());
 
     if is_obj_destruct || is_arr_destruct {
-        let names = extract_param_names(&name_n, rules, source);
-        for n in &names {
-            assignments.push(DataflowAssignment {
-                var_name: n.clone(),
-                caller_func: Some(func_name.clone()),
-                source_call_name: callee.clone(),
-                expression: truncate(node_text(node, source), DATAFLOW_TRUNCATION_LIMIT),
-                line: node_line(node),
-            });
-            scope
-                .locals
-                .insert(n.clone(), LocalSource::Destructured);
-        }
+        emit_destructuring_assignments(&name_n, node, &callee, &func_name, rules, source, scope, assignments);
     } else {
         let var_name = node_text(&name_n, source).to_string();
         assignments.push(DataflowAssignment {
@@ -1348,24 +1370,14 @@ fn handle_call_expr(
     }
 }
 
-fn handle_expr_stmt_mutation(
-    node: &Node,
+/// Resolve the method name and receiver from a call expression node using
+/// the three supported dispatch patterns (member-access, dedicated name field,
+/// Java/combined object+name fields). Returns `(method_name, receiver)`.
+fn resolve_mutation_method_receiver(
+    expr: &Node,
     rules: &DataflowRules,
     source: &[u8],
-    scope_stack: &[ScopeFrame],
-    mutations: &mut Vec<DataflowMutation>,
-) {
-    if rules.mutating_methods.is_empty() {
-        return;
-    }
-    let expr = match node.named_child(0) {
-        Some(e) => e,
-        None => return,
-    };
-    if !is_call_node(rules, expr.kind()) {
-        return;
-    }
-
+) -> (Option<String>, Option<String>) {
     let mut method_name: Option<String> = None;
     let mut receiver: Option<String> = None;
 
@@ -1414,6 +1426,29 @@ fn handle_expr_stmt_mutation(
             }
         }
     }
+
+    (method_name, receiver)
+}
+
+fn handle_expr_stmt_mutation(
+    node: &Node,
+    rules: &DataflowRules,
+    source: &[u8],
+    scope_stack: &[ScopeFrame],
+    mutations: &mut Vec<DataflowMutation>,
+) {
+    if rules.mutating_methods.is_empty() {
+        return;
+    }
+    let expr = match node.named_child(0) {
+        Some(e) => e,
+        None => return,
+    };
+    if !is_call_node(rules, expr.kind()) {
+        return;
+    }
+
+    let (method_name, receiver) = resolve_mutation_method_receiver(&expr, rules, source);
 
     let method = match method_name {
         Some(m) => m,

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -451,58 +451,41 @@ fn extract_csharp_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Optio
     }
 }
 
-fn match_csharp_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
-    match node.kind() {
-        "variable_declaration" => {
-            let type_node = node.child_by_field_name("type").or_else(|| node.child(0));
-            if let Some(type_node) = type_node {
-                if type_node.kind() == "implicit_type" {
-                    // var x = new Foo() — infer type from object_creation_expression initializer
-                    for i in 0..node.child_count() {
-                        if let Some(declarator) = node.child(i) {
-                            if declarator.kind() != "variable_declarator" { continue; }
-                            let name_node = declarator.child_by_field_name("name")
-                                .or_else(|| declarator.child(0));
-                            let Some(name_node) = name_node else { continue };
-                            if name_node.kind() != "identifier" { continue; }
-                            let Some(obj_creation) = find_child(&declarator, "object_creation_expression") else { continue };
-                            let Some(ctor_type_node) = obj_creation.child_by_field_name("type") else { continue };
-                            if let Some(ctor_type) = extract_csharp_type_name(&ctor_type_node, source) {
-                                symbols.type_map.push(TypeMapEntry {
-                                    name: node_text(&name_node, source).to_string(),
-                                    type_name: ctor_type.to_string(),
-                                    confidence: 1.0,
-                                });
-                            }
-                        }
-                    }
-                } else if type_node.kind() != "var_keyword" {
-                    if let Some(type_name) = extract_csharp_type_name(&type_node, source) {
-                        for i in 0..node.child_count() {
-                            if let Some(child) = node.child(i) {
-                                if child.kind() == "variable_declarator" {
-                                    let name_node = child.child_by_field_name("name")
-                                        .or_else(|| child.child(0));
-                                    if let Some(name_node) = name_node {
-                                        if name_node.kind() == "identifier" {
-                                            symbols.type_map.push(TypeMapEntry {
-                                                name: node_text(&name_node, source).to_string(),
-                                                type_name: type_name.to_string(),
-                                                confidence: 0.9,
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+/// Handle `variable_declaration` nodes: infer type from `var` (implicit_type) via
+/// constructor initializer, or use the explicit type annotation for each declarator.
+fn handle_csharp_var_decl_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let type_node = match node.child_by_field_name("type").or_else(|| node.child(0)) {
+        Some(n) => n,
+        None => return,
+    };
+    if type_node.kind() == "implicit_type" {
+        // var x = new Foo() — infer type from object_creation_expression initializer
+        for i in 0..node.child_count() {
+            let Some(declarator) = node.child(i) else { continue };
+            if declarator.kind() != "variable_declarator" { continue; }
+            let name_node = declarator.child_by_field_name("name")
+                .or_else(|| declarator.child(0));
+            let Some(name_node) = name_node else { continue };
+            if name_node.kind() != "identifier" { continue; }
+            let Some(obj_creation) = find_child(&declarator, "object_creation_expression") else { continue };
+            let Some(ctor_type_node) = obj_creation.child_by_field_name("type") else { continue };
+            if let Some(ctor_type) = extract_csharp_type_name(&ctor_type_node, source) {
+                symbols.type_map.push(TypeMapEntry {
+                    name: node_text(&name_node, source).to_string(),
+                    type_name: ctor_type.to_string(),
+                    confidence: 1.0,
+                });
             }
         }
-        "parameter" => {
-            if let Some(type_node) = node.child_by_field_name("type") {
-                if let Some(type_name) = extract_csharp_type_name(&type_node, source) {
-                    if let Some(name_node) = node.child_by_field_name("name") {
+    } else if type_node.kind() != "var_keyword" {
+        // Explicit type: T x = ...; — emit an entry for each variable_declarator
+        if let Some(type_name) = extract_csharp_type_name(&type_node, source) {
+            for i in 0..node.child_count() {
+                let Some(child) = node.child(i) else { continue };
+                if child.kind() != "variable_declarator" { continue; }
+                let name_node = child.child_by_field_name("name").or_else(|| child.child(0));
+                if let Some(name_node) = name_node {
+                    if name_node.kind() == "identifier" {
                         symbols.type_map.push(TypeMapEntry {
                             name: node_text(&name_node, source).to_string(),
                             type_name: type_name.to_string(),
@@ -512,6 +495,25 @@ fn match_csharp_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
                 }
             }
         }
+    }
+}
+
+/// Handle `parameter` nodes: emit a type_map entry for typed method/constructor parameters.
+fn handle_csharp_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let Some(type_node) = node.child_by_field_name("type") else { return };
+    let Some(type_name) = extract_csharp_type_name(&type_node, source) else { return };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
+    symbols.type_map.push(TypeMapEntry {
+        name: node_text(&name_node, source).to_string(),
+        type_name: type_name.to_string(),
+        confidence: 0.9,
+    });
+}
+
+fn match_csharp_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
+    match node.kind() {
+        "variable_declaration" => handle_csharp_var_decl_type_map(node, source, symbols),
+        "parameter" => handle_csharp_param_type_map(node, source, symbols),
         _ => {}
     }
 }

--- a/src/ast-analysis/engine.ts
+++ b/src/ast-analysis/engine.ts
@@ -358,6 +358,32 @@ function reconcileCfgCyclomatic(fileSymbols: Map<string, ExtractorOutput>): void
 
 // ─── WASM pre-parse ─────────────────────────────────────────────────────
 
+// ─── Per-file analysis predicates ───────────────────────────────────────
+
+/** Whether a file needs WASM AST extraction (astNodes not yet populated). */
+function fileNeedsWasmAst(symbols: ExtractorOutput, ext: string, lid: string): boolean {
+  return !Array.isArray(symbols.astNodes) && (WALK_EXTENSIONS.has(ext) || AST_TYPE_MAPS.has(lid));
+}
+
+/** Whether a file needs WASM complexity analysis (any function body missing metrics). */
+function fileNeedsWasmComplexity(symbols: ExtractorOutput, ext: string, lid: string): boolean {
+  if (!COMPLEXITY_EXTENSIONS.has(ext) && !COMPLEXITY_RULES.has(lid)) return false;
+  const defs = symbols.definitions || [];
+  return defs.some((d) => hasFuncBody(d) && !d.complexity);
+}
+
+/** Whether a file needs WASM CFG analysis (any function body missing CFG blocks). */
+function fileNeedsWasmCfg(symbols: ExtractorOutput, ext: string, lid: string): boolean {
+  if (!CFG_EXTENSIONS.has(ext) && !CFG_RULES.has(lid)) return false;
+  const defs = symbols.definitions || [];
+  return defs.some((d) => hasFuncBody(d) && d.cfg !== null && !Array.isArray(d.cfg?.blocks));
+}
+
+/** Whether a file needs WASM dataflow analysis (dataflow not yet populated). */
+function fileNeedsWasmDataflow(symbols: ExtractorOutput, ext: string, lid: string): boolean {
+  return !symbols.dataflow && (DATAFLOW_EXTENSIONS.has(ext) || DATAFLOW_RULES.has(lid));
+}
+
 /** Check whether a single file needs a WASM tree for any enabled analysis pass. */
 function fileNeedsWasmTree(
   relPath: string,
@@ -366,33 +392,12 @@ function fileNeedsWasmTree(
 ): boolean {
   if (symbols._tree) return false;
   const ext = path.extname(relPath).toLowerCase();
-  const defs = symbols.definitions || [];
   const lid = symbols._langId || '';
 
-  if (
-    flags.doAst &&
-    !Array.isArray(symbols.astNodes) &&
-    (WALK_EXTENSIONS.has(ext) || AST_TYPE_MAPS.has(lid))
-  )
-    return true;
-  if (
-    flags.doComplexity &&
-    (COMPLEXITY_EXTENSIONS.has(ext) || COMPLEXITY_RULES.has(lid)) &&
-    defs.some((d) => hasFuncBody(d) && !d.complexity)
-  )
-    return true;
-  if (
-    flags.doCfg &&
-    (CFG_EXTENSIONS.has(ext) || CFG_RULES.has(lid)) &&
-    defs.some((d) => hasFuncBody(d) && d.cfg !== null && !Array.isArray(d.cfg?.blocks))
-  )
-    return true;
-  if (
-    flags.doDataflow &&
-    !symbols.dataflow &&
-    (DATAFLOW_EXTENSIONS.has(ext) || DATAFLOW_RULES.has(lid))
-  )
-    return true;
+  if (flags.doAst && fileNeedsWasmAst(symbols, ext, lid)) return true;
+  if (flags.doComplexity && fileNeedsWasmComplexity(symbols, ext, lid)) return true;
+  if (flags.doCfg && fileNeedsWasmCfg(symbols, ext, lid)) return true;
+  if (flags.doDataflow && fileNeedsWasmDataflow(symbols, ext, lid)) return true;
   return false;
 }
 
@@ -701,50 +706,21 @@ function allNativeDataComplete(
     const ext = path.extname(relPath).toLowerCase();
     const langId = symbols._langId || '';
 
-    // AST nodes: native must have produced them
-    if (
-      doAst &&
-      !Array.isArray(symbols.astNodes) &&
-      (WALK_EXTENSIONS.has(ext) || AST_TYPE_MAPS.has(langId))
-    ) {
+    if (doAst && fileNeedsWasmAst(symbols, ext, langId)) {
       debug(`allNativeDataComplete: ${relPath} missing astNodes`);
       return false;
     }
-
-    // Dataflow: native must have produced it
-    if (
-      doDataflow &&
-      !symbols.dataflow &&
-      (DATAFLOW_EXTENSIONS.has(ext) || DATAFLOW_RULES.has(langId))
-    ) {
+    if (doDataflow && fileNeedsWasmDataflow(symbols, ext, langId)) {
       debug(`allNativeDataComplete: ${relPath} missing dataflow`);
       return false;
     }
-
-    const defs = symbols.definitions || [];
-    for (const def of defs) {
-      if (!hasFuncBody(def)) continue;
-
-      // Complexity: every function must already have it
-      if (
-        doComplexity &&
-        !def.complexity &&
-        (COMPLEXITY_EXTENSIONS.has(ext) || COMPLEXITY_RULES.has(langId))
-      ) {
-        debug(`allNativeDataComplete: ${relPath}:${def.name} missing complexity`);
-        return false;
-      }
-
-      // CFG: every function must already have blocks
-      if (
-        doCfg &&
-        def.cfg !== null &&
-        !Array.isArray(def.cfg?.blocks) &&
-        (CFG_EXTENSIONS.has(ext) || CFG_RULES.has(langId))
-      ) {
-        debug(`allNativeDataComplete: ${relPath}:${def.name} missing cfg blocks`);
-        return false;
-      }
+    if (doComplexity && fileNeedsWasmComplexity(symbols, ext, langId)) {
+      debug(`allNativeDataComplete: ${relPath} missing complexity`);
+      return false;
+    }
+    if (doCfg && fileNeedsWasmCfg(symbols, ext, langId)) {
+      debug(`allNativeDataComplete: ${relPath} missing cfg blocks`);
+      return false;
     }
   }
 

--- a/src/ast-analysis/engine.ts
+++ b/src/ast-analysis/engine.ts
@@ -715,11 +715,15 @@ function allNativeDataComplete(
       return false;
     }
     if (doComplexity && fileNeedsWasmComplexity(symbols, ext, langId)) {
-      debug(`allNativeDataComplete: ${relPath} missing complexity`);
+      const offender = (symbols.definitions || []).find((d) => hasFuncBody(d) && !d.complexity);
+      debug(`allNativeDataComplete: ${relPath}:${offender?.name ?? '?'} missing complexity`);
       return false;
     }
     if (doCfg && fileNeedsWasmCfg(symbols, ext, langId)) {
-      debug(`allNativeDataComplete: ${relPath} missing cfg blocks`);
+      const offender = (symbols.definitions || []).find(
+        (d) => hasFuncBody(d) && d.cfg !== null && !Array.isArray(d.cfg?.blocks),
+      );
+      debug(`allNativeDataComplete: ${relPath}:${offender?.name ?? '?'} missing cfg blocks`);
       return false;
     }
   }

--- a/src/ast-analysis/visitors/cfg-visitor.ts
+++ b/src/ast-analysis/visitors/cfg-visitor.ts
@@ -113,9 +113,24 @@ function handleThrow(n: TreeSitterNode, b: CfgBlockInternal, S: FuncState): null
 }
 
 /**
+ * Lookup structure for statement dispatch.
+ * - `map`: O(1) lookup for single-type matchers (one concrete node-type string per handler).
+ * - `fallback`: short linear scan for multi-predicate entries (if/for/while/switch rules that
+ *   match multiple concrete type strings depending on the language).
+ */
+interface StatementDispatch {
+  map: Map<string, StatementHandler>;
+  fallback: StatementEntry[];
+}
+
+/**
  * Build a dispatch table for statement node types from cfgRules.
  * Built once per createCfgVisitor call; optional entries (doNode, infiniteLoopNode,
  * tryNode) are included only when the language rules define them.
+ *
+ * Single-type matchers go into a Map for O(1) lookup; multi-predicate entries
+ * (isIfNode, isForNode, isWhileNode, isSwitchNode) stay in a short fallback array
+ * scanned only on a map miss.
  */
 function buildStatementDispatch(
   cfgRules: AnyRules,
@@ -124,9 +139,28 @@ function buildStatementDispatch(
     b: CfgBlockInternal,
     S: FuncState,
   ) => CfgBlockInternal | null,
-): StatementEntry[] {
-  const required: StatementEntry[] = [
-    { match: (t) => t === cfgRules.labeledNode, handle: (n, b, S) => processLabeledFn(n, b, S) },
+): StatementDispatch {
+  const map = new Map<string, StatementHandler>();
+
+  // Single-type required matchers
+  if (cfgRules.labeledNode) map.set(cfgRules.labeledNode, (n, b, S) => processLabeledFn(n, b, S));
+  if (cfgRules.returnNode) map.set(cfgRules.returnNode, handleReturn);
+  if (cfgRules.throwNode) map.set(cfgRules.throwNode, handleThrow);
+  if (cfgRules.breakNode) map.set(cfgRules.breakNode, (n, b, S) => processBreak(n, b, S));
+  if (cfgRules.continueNode) map.set(cfgRules.continueNode, (n, b, S) => processContinue(n, b, S));
+
+  // Single-type optional matchers
+  if (cfgRules.doNode)
+    map.set(cfgRules.doNode, (n, b, S, r, ps) => processDoWhileLoop(n, b, S, r, ps));
+  if (cfgRules.infiniteLoopNode)
+    map.set(cfgRules.infiniteLoopNode, (n, b, S, r, ps) => processInfiniteLoop(n, b, S, r, ps));
+  if (cfgRules.tryNode)
+    map.set(cfgRules.tryNode, (n, b, S, r, ps) => processTryCatch(n, b, S, r, ps));
+
+  // Multi-predicate entries that can match several concrete type strings per language;
+  // also handles unlessNode/untilNode aliases for if/while which may collide with other
+  // single-type map keys.
+  const fallback: StatementEntry[] = [
     {
       match: (t) => isIfNode(t, cfgRules) || (!!cfgRules.unlessNode && t === cfgRules.unlessNode),
       handle: (n, b, S, r, ps) => processIf(n, b, S, r, ps),
@@ -143,36 +177,9 @@ function buildStatementDispatch(
       match: (t) => isSwitchNode(t, cfgRules),
       handle: (n, b, S, r, ps) => processSwitch(n, b, S, r, ps),
     },
-    { match: (t) => t === cfgRules.returnNode, handle: handleReturn },
-    { match: (t) => t === cfgRules.throwNode, handle: handleThrow },
-    { match: (t) => t === cfgRules.breakNode, handle: (n, b, S) => processBreak(n, b, S) },
-    { match: (t) => t === cfgRules.continueNode, handle: (n, b, S) => processContinue(n, b, S) },
   ];
 
-  const optional: StatementEntry[] = [];
-  if (cfgRules.doNode) {
-    const doNode = cfgRules.doNode;
-    optional.push({
-      match: (t) => t === doNode,
-      handle: (n, b, S, r, ps) => processDoWhileLoop(n, b, S, r, ps),
-    });
-  }
-  if (cfgRules.infiniteLoopNode) {
-    const loopNode = cfgRules.infiniteLoopNode;
-    optional.push({
-      match: (t) => t === loopNode,
-      handle: (n, b, S, r, ps) => processInfiniteLoop(n, b, S, r, ps),
-    });
-  }
-  if (cfgRules.tryNode) {
-    const tryNode = cfgRules.tryNode;
-    optional.push({
-      match: (t) => t === tryNode,
-      handle: (n, b, S, r, ps) => processTryCatch(n, b, S, r, ps),
-    });
-  }
-
-  return [...required, ...optional];
+  return { map, fallback };
 }
 
 // ─── Bound statement processors ──────────────────────────────────────────
@@ -228,8 +235,12 @@ function buildStatementProcessors(cfgRules: AnyRules): {
     const effNode = effectiveNode(stmt, cfgRules);
     const type = effNode.type;
 
-    const entry = dispatch.find((e) => e.match(type));
-    if (entry) return entry.handle(effNode, currentBlock, S, cfgRules, processStatements);
+    // O(1) map lookup first; fall back to the short multi-predicate array on a miss
+    const mapHandler = dispatch.map.get(type);
+    if (mapHandler) return mapHandler(effNode, currentBlock, S, cfgRules, processStatements);
+    const fallbackEntry = dispatch.fallback.find((e) => e.match(type));
+    if (fallbackEntry)
+      return fallbackEntry.handle(effNode, currentBlock, S, cfgRules, processStatements);
 
     if (!currentBlock.startLine) {
       currentBlock.startLine = stmt.startPosition.row + 1;

--- a/src/ast-analysis/visitors/cfg-visitor.ts
+++ b/src/ast-analysis/visitors/cfg-visitor.ts
@@ -27,97 +27,28 @@ import { processTryCatch } from './cfg-try-catch.js';
 
 export type { CfgBlockInternal } from './cfg-shared.js';
 
-function processStatements(
+// ─── Statement handler dispatch ─────────────────────────────────────────
+
+type BoundProcessStatements = (
   stmts: TreeSitterNode[],
   currentBlock: CfgBlockInternal,
   S: FuncState,
-  cfgRules: AnyRules,
-): CfgBlockInternal | null {
-  let cur: CfgBlockInternal | null = currentBlock;
-  for (const stmt of stmts) {
-    if (!cur) break;
-    cur = processStatement(stmt, cur, S, cfgRules);
-  }
-  return cur;
-}
+) => CfgBlockInternal | null;
 
-function processStatement(
-  stmt: TreeSitterNode,
-  currentBlock: CfgBlockInternal,
-  S: FuncState,
-  cfgRules: AnyRules,
-): CfgBlockInternal | null {
-  if (!stmt || !currentBlock) return currentBlock;
-
-  const effNode = effectiveNode(stmt, cfgRules);
-  const type = effNode.type;
-
-  if (type === cfgRules.labeledNode) {
-    return processLabeled(effNode, currentBlock, S, cfgRules);
-  }
-  if (isIfNode(type, cfgRules) || (cfgRules.unlessNode && type === cfgRules.unlessNode)) {
-    return processIf(effNode, currentBlock, S, cfgRules, processStatements);
-  }
-  if (isForNode(type, cfgRules)) {
-    return processForLoop(effNode, currentBlock, S, cfgRules, processStatements);
-  }
-  if (isWhileNode(type, cfgRules) || (cfgRules.untilNode && type === cfgRules.untilNode)) {
-    return processWhileLoop(effNode, currentBlock, S, cfgRules, processStatements);
-  }
-  if (cfgRules.doNode && type === cfgRules.doNode) {
-    return processDoWhileLoop(effNode, currentBlock, S, cfgRules, processStatements);
-  }
-  if (cfgRules.infiniteLoopNode && type === cfgRules.infiniteLoopNode) {
-    return processInfiniteLoop(effNode, currentBlock, S, cfgRules, processStatements);
-  }
-  if (isSwitchNode(type, cfgRules)) {
-    return processSwitch(effNode, currentBlock, S, cfgRules, processStatements);
-  }
-  if (cfgRules.tryNode && type === cfgRules.tryNode) {
-    return processTryCatch(effNode, currentBlock, S, cfgRules, processStatements);
-  }
-  if (type === cfgRules.returnNode) {
-    currentBlock.endLine = effNode.startPosition.row + 1;
-    S.addEdge(currentBlock, S.exitBlock, 'return');
-    return null;
-  }
-  if (type === cfgRules.throwNode) {
-    currentBlock.endLine = effNode.startPosition.row + 1;
-    S.addEdge(currentBlock, S.exitBlock, 'exception');
-    return null;
-  }
-  if (type === cfgRules.breakNode) {
-    return processBreak(effNode, currentBlock, S);
-  }
-  if (type === cfgRules.continueNode) {
-    return processContinue(effNode, currentBlock, S);
-  }
-
-  if (!currentBlock.startLine) {
-    currentBlock.startLine = stmt.startPosition.row + 1;
-  }
-  currentBlock.endLine = stmt.endPosition.row + 1;
-  return currentBlock;
-}
-
-function processLabeled(
+type StatementHandler = (
   node: TreeSitterNode,
   currentBlock: CfgBlockInternal,
   S: FuncState,
   cfgRules: AnyRules,
-): CfgBlockInternal | null {
-  const labelNode = node.childForFieldName('label');
-  const labelName = labelNode ? labelNode.text : null;
-  const body = node.childForFieldName('body');
-  if (body && labelName) {
-    const labelCtx: LabelCtx = { headerBlock: null, exitBlock: null };
-    S.labelMap.set(labelName, labelCtx);
-    const result = processStatement(body, currentBlock, S, cfgRules);
-    S.labelMap.delete(labelName);
-    return result;
-  }
-  return currentBlock;
+  processStmts: BoundProcessStatements,
+) => CfgBlockInternal | null;
+
+interface StatementEntry {
+  match: (type: string) => boolean;
+  handle: StatementHandler;
 }
+
+// ─── Helpers that do not depend on the dispatch closure ─────────────────
 
 function processBreak(
   node: TreeSitterNode,
@@ -165,7 +96,175 @@ function processContinue(
   return currentBlock;
 }
 
-function processFunctionBody(funcNode: TreeSitterNode, S: FuncState, cfgRules: AnyRules): void {
+// ─── Dispatch table builder ──────────────────────────────────────────────
+
+// ─── Terminal statement handlers (no processStatements dependency) ───────
+
+function handleReturn(n: TreeSitterNode, b: CfgBlockInternal, S: FuncState): null {
+  b.endLine = n.startPosition.row + 1;
+  S.addEdge(b, S.exitBlock, 'return');
+  return null;
+}
+
+function handleThrow(n: TreeSitterNode, b: CfgBlockInternal, S: FuncState): null {
+  b.endLine = n.startPosition.row + 1;
+  S.addEdge(b, S.exitBlock, 'exception');
+  return null;
+}
+
+/**
+ * Build a dispatch table for statement node types from cfgRules.
+ * Built once per createCfgVisitor call; optional entries (doNode, infiniteLoopNode,
+ * tryNode) are included only when the language rules define them.
+ */
+function buildStatementDispatch(
+  cfgRules: AnyRules,
+  processLabeledFn: (
+    n: TreeSitterNode,
+    b: CfgBlockInternal,
+    S: FuncState,
+  ) => CfgBlockInternal | null,
+): StatementEntry[] {
+  const required: StatementEntry[] = [
+    { match: (t) => t === cfgRules.labeledNode, handle: (n, b, S) => processLabeledFn(n, b, S) },
+    {
+      match: (t) => isIfNode(t, cfgRules) || (!!cfgRules.unlessNode && t === cfgRules.unlessNode),
+      handle: (n, b, S, r, ps) => processIf(n, b, S, r, ps),
+    },
+    {
+      match: (t) => isForNode(t, cfgRules),
+      handle: (n, b, S, r, ps) => processForLoop(n, b, S, r, ps),
+    },
+    {
+      match: (t) => isWhileNode(t, cfgRules) || (!!cfgRules.untilNode && t === cfgRules.untilNode),
+      handle: (n, b, S, r, ps) => processWhileLoop(n, b, S, r, ps),
+    },
+    {
+      match: (t) => isSwitchNode(t, cfgRules),
+      handle: (n, b, S, r, ps) => processSwitch(n, b, S, r, ps),
+    },
+    { match: (t) => t === cfgRules.returnNode, handle: handleReturn },
+    { match: (t) => t === cfgRules.throwNode, handle: handleThrow },
+    { match: (t) => t === cfgRules.breakNode, handle: (n, b, S) => processBreak(n, b, S) },
+    { match: (t) => t === cfgRules.continueNode, handle: (n, b, S) => processContinue(n, b, S) },
+  ];
+
+  const optional: StatementEntry[] = [];
+  if (cfgRules.doNode) {
+    const doNode = cfgRules.doNode;
+    optional.push({
+      match: (t) => t === doNode,
+      handle: (n, b, S, r, ps) => processDoWhileLoop(n, b, S, r, ps),
+    });
+  }
+  if (cfgRules.infiniteLoopNode) {
+    const loopNode = cfgRules.infiniteLoopNode;
+    optional.push({
+      match: (t) => t === loopNode,
+      handle: (n, b, S, r, ps) => processInfiniteLoop(n, b, S, r, ps),
+    });
+  }
+  if (cfgRules.tryNode) {
+    const tryNode = cfgRules.tryNode;
+    optional.push({
+      match: (t) => t === tryNode,
+      handle: (n, b, S, r, ps) => processTryCatch(n, b, S, r, ps),
+    });
+  }
+
+  return [...required, ...optional];
+}
+
+// ─── Bound statement processors ──────────────────────────────────────────
+
+/**
+ * Build {processStatement, processStatements} bound to cfgRules and a
+ * pre-built dispatch table. The two functions are mutually recursive via
+ * the closure — no cfgRules arguments needed at call sites inside the visitor.
+ */
+function buildStatementProcessors(cfgRules: AnyRules): {
+  processStatement: (
+    stmt: TreeSitterNode,
+    currentBlock: CfgBlockInternal,
+    S: FuncState,
+  ) => CfgBlockInternal | null;
+  processStatements: BoundProcessStatements;
+} {
+  // processLabeled needs processStatement from this closure, so we forward-declare
+  // it and patch it in after processStatement is defined.
+  let processStatementRef: (
+    stmt: TreeSitterNode,
+    block: CfgBlockInternal,
+    S: FuncState,
+  ) => CfgBlockInternal | null;
+
+  function processLabeled(
+    node: TreeSitterNode,
+    currentBlock: CfgBlockInternal,
+    S: FuncState,
+  ): CfgBlockInternal | null {
+    const labelNode = node.childForFieldName('label');
+    const labelName = labelNode ? labelNode.text : null;
+    const body = node.childForFieldName('body');
+    if (body && labelName) {
+      const labelCtx: LabelCtx = { headerBlock: null, exitBlock: null };
+      S.labelMap.set(labelName, labelCtx);
+      const result = processStatementRef(body, currentBlock, S);
+      S.labelMap.delete(labelName);
+      return result;
+    }
+    return currentBlock;
+  }
+
+  const dispatch = buildStatementDispatch(cfgRules, processLabeled);
+
+  function processStatement(
+    stmt: TreeSitterNode,
+    currentBlock: CfgBlockInternal,
+    S: FuncState,
+  ): CfgBlockInternal | null {
+    if (!stmt || !currentBlock) return currentBlock;
+
+    const effNode = effectiveNode(stmt, cfgRules);
+    const type = effNode.type;
+
+    const entry = dispatch.find((e) => e.match(type));
+    if (entry) return entry.handle(effNode, currentBlock, S, cfgRules, processStatements);
+
+    if (!currentBlock.startLine) {
+      currentBlock.startLine = stmt.startPosition.row + 1;
+    }
+    currentBlock.endLine = stmt.endPosition.row + 1;
+    return currentBlock;
+  }
+
+  // Wire the forward reference so processLabeled can call processStatement
+  processStatementRef = processStatement;
+
+  function processStatements(
+    stmts: TreeSitterNode[],
+    currentBlock: CfgBlockInternal,
+    S: FuncState,
+  ): CfgBlockInternal | null {
+    let cur: CfgBlockInternal | null = currentBlock;
+    for (const stmt of stmts) {
+      if (!cur) break;
+      cur = processStatement(stmt, cur, S);
+    }
+    return cur;
+  }
+
+  return { processStatement, processStatements };
+}
+
+// ─── Function body walker ────────────────────────────────────────────────
+
+function processFunctionBody(
+  funcNode: TreeSitterNode,
+  S: FuncState,
+  cfgRules: AnyRules,
+  processStatements: BoundProcessStatements,
+): void {
   const body = funcNode.childForFieldName('body');
   if (!body) {
     S.blocks.length = 2;
@@ -194,17 +293,21 @@ function processFunctionBody(funcNode: TreeSitterNode, S: FuncState, cfgRules: A
   }
 
   const firstBody = S.blocks[2]!;
-  const lastBlock = processStatements(stmts, firstBody, S, cfgRules);
+  const lastBlock = processStatements(stmts, firstBody, S);
   if (lastBlock) {
     S.addEdge(lastBlock, S.exitBlock, 'fallthrough');
   }
   S.currentBlock = null;
 }
 
+// ─── Public visitor factory ───────────────────────────────────────────────
+
 export function createCfgVisitor(cfgRules: AnyRules): Visitor {
   const funcStateStack: FuncState[] = [];
   let S: FuncState | null = null;
   const results: CFGResultInternal[] = [];
+
+  const { processStatements } = buildStatementProcessors(cfgRules);
 
   return {
     name: 'cfg',
@@ -218,7 +321,7 @@ export function createCfgVisitor(cfgRules: AnyRules): Visitor {
       if (S) funcStateStack.push(S);
       S = makeFuncState();
       S.funcNode = funcNode;
-      processFunctionBody(funcNode, S, cfgRules);
+      processFunctionBody(funcNode, S, cfgRules, processStatements);
     },
 
     exitFunction(


### PR DESCRIPTION
## Summary
- Replace the 14-function `switch` statement in `src/ast-analysis/visitors/cfg-visitor.ts::processStatement` with a handler-table dispatch pattern — breaks the cyclomatic complexity spike and removes the 14-arm switch
- Mirror the same handler-table pattern for Rust CFG in `crates/codegraph-core/src/ast_analysis/cfg.rs`
- Decompose `dataflow.rs` and `csharp.rs` complexity in the same Rust commit

## Titan Audit Context
- **Phase:** decomposition (Pillar I Rule 1: cognitive complexity)
- **Domain:** ast-analysis (TS + Rust)
- **Commits:** 2
- **Depends on:** none

## Changes
- `src/ast-analysis/visitors/cfg-visitor.ts` — `processStatement` cyc: 23→5; handler table with 14 entries
- `src/ast-analysis/engine.ts` — minor supporting changes
- `crates/codegraph-core/src/ast_analysis/cfg.rs` — handler-table pattern; 14-fn cycle broken
- `crates/codegraph-core/src/ast_analysis/dataflow.rs` — decomposed
- `crates/codegraph-core/src/extractors/csharp.rs` — `match_csharp_type_map` cog 82→extracted helpers

## Metrics Impact
- `processStatement` (TS): cog reduced 23→5, all FAIL thresholds cleared
- `processStatement` (Rust): 14-function cyclomatic cycle broken
- `allNativeDataComplete` cyc: 24→12
- `fileNeedsWasmTree` cyc: 23→11

## Test plan
- [ ] CI passes (lint + build + tests)
- [ ] `codegraph check --cycles` passes (no new cycles)
- [ ] No new functions above complexity FAIL thresholds