### PR TITLE
fix(ci): resolve Windows npm install timeout caused by SSH-locked git deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -118,7 +118,7 @@ jobs:
         shell: bash
         run: |
           git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -159,7 +159,7 @@ jobs:
         shell: bash
         run: |
           git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -245,7 +245,7 @@ jobs:
         shell: bash
         run: |
           git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -393,7 +393,7 @@ jobs:
         shell: bash
         run: |
           git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         timeout-minutes: 20
         shell: bash
         run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -115,6 +117,8 @@ jobs:
         timeout-minutes: 20
         shell: bash
         run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -154,6 +158,8 @@ jobs:
         timeout-minutes: 20
         shell: bash
         run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -238,6 +244,8 @@ jobs:
         timeout-minutes: 20
         shell: bash
         run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then
@@ -384,6 +392,8 @@ jobs:
         timeout-minutes: 20
         shell: bash
         run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
           for attempt in 1 2 3; do
             npm install && break
             if [ "$attempt" -lt 3 ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -7304,7 +7304,7 @@
     },
     "node_modules/tree-sitter-clojure": {
       "version": "0.0.13",
-      "resolved": "git+ssh://git@github.com/sogaiu/tree-sitter-clojure.git#e43eff80d17cf34852dcd92ca5e6986d23a7040f",
+      "resolved": "git+https://github.com/sogaiu/tree-sitter-clojure.git#e43eff80d17cf34852dcd92ca5e6986d23a7040f",
       "dev": true
     },
     "node_modules/tree-sitter-cpp": {
@@ -7425,7 +7425,7 @@
     },
     "node_modules/tree-sitter-gleam": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/gleam-lang/tree-sitter-gleam.git#c610c282ef73f830d80c1f0999dce8e83f024ef5",
+      "resolved": "git+https://github.com/gleam-lang/tree-sitter-gleam.git#c610c282ef73f830d80c1f0999dce8e83f024ef5",
       "integrity": "sha512-ZpX7xyHHP5uWbtG1agroI1IZNoCAgsdhZplm8CUAbhuqOZ7D82hToeeWO3JM+VUPC9D2GAA5Uv2VpNWTmTgtlQ==",
       "dev": true,
       "license": "Apache-2.0",


### PR DESCRIPTION
## Root cause

\`tree-sitter-gleam\` and \`tree-sitter-clojure\` were locked in \`package-lock.json\` as \`git+ssh://git@github.com/...\` URLs. The lockfile was generated on a machine with SSH configured for GitHub, so npm captured SSH as the resolved protocol.

Windows GitHub Actions runners have no SSH key for GitHub. When npm install hits these deps and the npm cache is cold, it tries to clone via SSH — which hangs indefinitely (no fast-fail, no fallback) and times out at the 20-minute CI limit. This is what killed every Windows job on PRs #1580 and #1581.

Main branch CI passes because its Windows runs have been completing sequentially (not cancelled mid-install), keeping the npm cache warm. PR branch runs are cancelled and restarted, so the cache never gets written and every run hits the cold-path hang.

## Fix

**\`package-lock.json\`** — rewrite both \`resolved\` URLs from \`git+ssh://\` to \`git+https://\`. The commit hash and integrity fields are unchanged; the content is identical, just fetched over HTTPS.

**\`.github/workflows/ci.yml\`** — add \`git config url.insteadOf\` before every \`npm install\` block as defense-in-depth. This ensures any future lockfile regeneration that captures SSH URLs does not silently re-introduce the problem.

## After merging

Rebase PRs #1580 and #1581 on main — their Windows CI jobs will pass immediately.