### PR TITLE
fix: wire config.build.engine into pipeline and connection

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { loadConfig } from '../infrastructure/config.js';
 import { debug, warn } from '../infrastructure/logger.js';
 import { getNative, isNativeAvailable } from '../infrastructure/native.js';
 import { DbError, toErrorMessage } from '../shared/errors.js';
@@ -379,9 +380,11 @@ export function openRepo(
     return { repo: opts.repo, close() {} };
   }
 
-  // Respect explicit engine selection: opts.engine > CODEGRAPH_ENGINE env > auto.
+  // Respect explicit engine selection: opts.engine > config.build.engine > auto.
+  // config.build.engine is already populated from CODEGRAPH_ENGINE env by applyEnvOverrides,
+  // so this covers both the env-var path and the .codegraphrc.json config-file path.
   // This ensures --engine wasm and benchmark workers bypass the native path.
-  const engine = opts.engine || process.env.CODEGRAPH_ENGINE || 'auto';
+  const engine = opts.engine ?? loadConfig().build.engine ?? 'auto';
 
   // Try native rusqlite path first (Phase 6.14)
   if (engine !== 'wasm' && isNativeAvailable()) {
@@ -425,7 +428,9 @@ export function openReadonlyWithNative(customPath?: string): {
   const db = openReadonlyOrFail(customPath);
 
   // Respect explicit engine selection, consistent with openRepo().
-  const engine = process.env.CODEGRAPH_ENGINE || 'auto';
+  // config.build.engine covers both CODEGRAPH_ENGINE env (via applyEnvOverrides)
+  // and the .codegraphrc.json config-file path.
+  const engine = loadConfig().build.engine ?? 'auto';
 
   let nativeDb: NativeDatabase | undefined;
   if (engine !== 'wasm' && isNativeAvailable()) {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -419,18 +419,25 @@ export function openRepo(
  * Returns the better-sqlite3 handle (for backwards compat) plus an optional
  * NativeDatabase for modules that can use batched Rust query methods.
  * Callers should use nativeDb when available and fall back to db.prepare().
+ *
+ * @param opts.engine - Per-call engine override: 'native' | 'wasm' | 'auto'.
+ *   When omitted, falls back to config.build.engine then 'auto', mirroring
+ *   the priority chain used by openRepo().
  */
-export function openReadonlyWithNative(customPath?: string): {
+export function openReadonlyWithNative(
+  customPath?: string,
+  opts: { engine?: 'native' | 'wasm' | 'auto' } = {},
+): {
   db: BetterSqlite3Database;
   nativeDb: NativeDatabase | undefined;
   close(): void;
 } {
   const db = openReadonlyOrFail(customPath);
 
-  // Respect explicit engine selection, consistent with openRepo().
+  // Respect explicit engine selection: opts.engine > config.build.engine > auto.
   // config.build.engine covers both CODEGRAPH_ENGINE env (via applyEnvOverrides)
-  // and the .codegraphrc.json config-file path.
-  const engine = loadConfig().build.engine ?? 'auto';
+  // and the .codegraphrc.json config-file path. Mirrors openRepo() priority chain.
+  const engine = opts.engine ?? loadConfig().build.engine ?? 'auto';
 
   let nativeDb: NativeDatabase | undefined;
   if (engine !== 'wasm' && isNativeAvailable()) {

--- a/src/domain/analysis/fn-impact.ts
+++ b/src/domain/analysis/fn-impact.ts
@@ -294,7 +294,7 @@ export function fnImpactData(
         maxDepth,
         includeImplementors,
       });
-      const direct = (levels[1]?.length ?? 0);
+      const direct = levels[1]?.length ?? 0;
       const transitive = totalDependents - direct;
       return {
         ...normalizeSymbol(node, repo, hc),

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -62,7 +62,9 @@ export {
 
 function initializeEngine(ctx: PipelineContext): void {
   ctx.engineOpts = {
-    engine: ctx.opts.engine || 'auto',
+    // Priority: CLI --engine flag > .codegraphrc.json build.engine > 'auto'.
+    // ctx.config is already populated by the time initializeEngine is called.
+    engine: ctx.opts.engine ?? ctx.config.build.engine ?? 'auto',
     dataflow: ctx.opts.dataflow !== false,
     ast: ctx.opts.ast !== false,
     // nativeDb and WAL callbacks are set later when NativeDatabase is opened
@@ -174,8 +176,13 @@ function setupPipeline(ctx: PipelineContext): void {
     ? path.resolve(ctx.opts.dbPath)
     : path.join(ctx.rootDir, '.codegraph', 'graph.db');
 
+  // Load config first so build.engine from .codegraphrc.json is available for
+  // the engine-pref fallback below (ctx.opts.engine > config.build.engine > 'auto').
+  ctx.config = loadConfig(ctx.rootDir, { userConfig: ctx.opts.userConfig });
+
   // Detect whether native engine is available.
-  const enginePref = ctx.opts.engine || 'auto';
+  // Priority: CLI --engine flag > .codegraphrc.json build.engine > 'auto'.
+  const enginePref = ctx.opts.engine ?? ctx.config.build.engine ?? 'auto';
   const native = enginePref !== 'wasm' ? loadNative() : null;
   ctx.nativeAvailable = !!native?.NativeDatabase;
 
@@ -188,8 +195,6 @@ function setupPipeline(ctx: PipelineContext): void {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   ctx.db = openDb(ctx.dbPath);
   initSchema(ctx.db);
-
-  ctx.config = loadConfig(ctx.rootDir, { userConfig: ctx.opts.userConfig });
   // Merge caller-supplied excludes on top of the file-config excludes so
   // programmatic callers (e.g. benchmark scripts) can extend exclusion
   // without mutating .codegraphrc.json. Native orchestrator picks this up


### PR DESCRIPTION
## Summary
- `openRepo()` and `openReadonlyWithNative()` in `connection.ts` previously read `process.env.CODEGRAPH_ENGINE` directly, silently ignoring any `engine` value set via `.codegraphrc.json`. They now read `loadConfig().build.engine`, which already incorporates both the env-var path (via `applyEnvOverrides`) and the config-file path.
- `initializeEngine()` and `setupPipeline()` in `pipeline.ts` used `ctx.opts.engine || 'auto'`, skipping `config.build.engine`. The priority chain is now `ctx.opts.engine ?? ctx.config.build.engine ?? 'auto'`. Config is loaded first in `setupPipeline()` so `build.engine` is available before the native-availability check.
- Fix a pre-existing Biome format warning in `fn-impact.ts` (unnecessary parentheses, carried in from the `fix/issue-1587` merge).

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Graph classifier and role unit tests pass (`npx vitest run tests/graph/classifiers tests/unit/roles.test.ts`)
- [x] All non-WASM tests pass (WASM grammar files are not available in the worktree — this is a known limitation, not a regression)

Closes #1596