### PR TITLE
feat(dataflow): interprocedural variable-level model — P0-P6 complete, all 34 languages

### DIFF
--- a/src/ast-analysis/rules/b2.ts
+++ b/src/ast-analysis/rules/b2.ts
@@ -1,0 +1,263 @@
+import type { DataflowRulesConfig, TreeSitterNode } from '../../types.js';
+import { makeDataflowRules } from '../shared.js';
+
+// ─── Kotlin ───────────────────────────────────────────────────────────────────
+//
+// Kotlin function_declaration wraps params in `function_value_parameters`.
+// The name is a `simple_identifier` direct child (found via findChild in extractor).
+// call_expression: first child is simple_identifier OR navigation_expression (method call).
+// navigation_expression: acts as member access for `obj.method()`.
+// Field names for call function/args are NOT standard named fields in tree-sitter-kotlin,
+// so we leave callFunctionField/callArgsField at defaults — childForFieldName returns null
+// gracefully and the analysis falls back to skipping arg tracking.
+
+function getKotlinParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  for (const child of funcNode.namedChildren) {
+    if (child.type === 'function_value_parameters') return child;
+  }
+  return null;
+}
+
+function extractKotlinParamName(node: TreeSitterNode): string[] | null {
+  if (node.type !== 'parameter') return null;
+  const nameNode = node.childForFieldName('name');
+  if (nameNode) return [nameNode.text];
+  // Fallback: find simple_identifier among named children
+  for (const child of node.namedChildren) {
+    if (child.type === 'simple_identifier') return [child.text];
+  }
+  return null;
+}
+
+export const dataflowKotlin: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_declaration']),
+  nameField: 'name',
+
+  getParamListNode: getKotlinParamListNode,
+  paramWrapperTypes: new Set(['parameter']),
+  extractParamName: extractKotlinParamName,
+
+  returnNode: 'return_statement',
+
+  callNode: 'call_expression',
+  // tree-sitter-kotlin does not expose standard named fields for call function/args;
+  // defaults ('function'/'arguments') will return null gracefully.
+
+  memberNode: 'navigation_expression',
+  // Field names for navigation_expression object/property also lack standard names;
+  // defaults will return null gracefully.
+});
+
+// ─── Swift ────────────────────────────────────────────────────────────────────
+//
+// Swift function_declaration: name is `simple_identifier`, params in child node.
+// The extractor uses findChild(node, 'simple_identifier') for the function name.
+// Swift's tree-sitter grammar wraps params in a `parameter` or `parameters` node.
+// call_expression: first child is simple_identifier or navigation_expression.
+// navigation_expression: obj.method() — last child is navigation_suffix > simple_identifier.
+
+function getSwiftParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  // Look for parameter_clause or parameters as a direct child
+  for (let i = 0; i < funcNode.childCount; i++) {
+    const child = funcNode.child(i);
+    if (!child) continue;
+    if (child.type === 'parameter_clause' || child.type === 'parameters') return child;
+  }
+  return null;
+}
+
+function extractSwiftParamName(node: TreeSitterNode): string[] | null {
+  if (node.type === 'parameter') {
+    // Swift parameters have internal label + external label; use internal name
+    // The `name` field in tree-sitter-swift is the internal parameter name
+    const nameNode = node.childForFieldName('name') ?? node.childForFieldName('internal_name');
+    if (nameNode) return [nameNode.text];
+    // Fallback: find simple_identifier
+    for (const child of node.namedChildren) {
+      if (child.type === 'simple_identifier') return [child.text];
+    }
+  }
+  return null;
+}
+
+export const dataflowSwift: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_declaration']),
+  nameField: 'name',
+
+  getParamListNode: getSwiftParamListNode,
+  paramWrapperTypes: new Set(['parameter']),
+  extractParamName: extractSwiftParamName,
+
+  returnNode: 'return_statement',
+
+  callNode: 'call_expression',
+  // tree-sitter-swift call_expression: function is first child, args follow.
+  // No standard named fields — leave defaults to return null gracefully.
+
+  memberNode: 'navigation_expression',
+  // navigation_expression field names are non-standard in tree-sitter-swift.
+});
+
+// ─── Scala ────────────────────────────────────────────────────────────────────
+//
+// Scala function_definition: `node.childForFieldName('name')` for the name (confirmed
+// in extractor). Parameters are via findChild(funcNode, 'parameters') (no named field).
+// call_expression: `childForFieldName('function')` confirmed in extractor line 146.
+// field_expression: `childForFieldName('value')` = object, `childForFieldName('field')` = property.
+// val_definition / var_definition: `childForFieldName('pattern')` = name side.
+
+function getScalaParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  // Scala parameters list is a direct child; extractor uses findChild(funcNode, 'parameters')
+  for (let i = 0; i < funcNode.childCount; i++) {
+    const child = funcNode.child(i);
+    if (child?.type === 'parameters') return child;
+  }
+  return null;
+}
+
+function extractScalaParamName(node: TreeSitterNode): string[] | null {
+  if (node.type !== 'parameter') return null;
+  // Extractor uses findChild(param, 'identifier')
+  for (const child of node.namedChildren) {
+    if (child.type === 'identifier') return [child.text];
+  }
+  return null;
+}
+
+export const dataflowScala: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_definition']),
+  nameField: 'name',
+
+  getParamListNode: getScalaParamListNode,
+  paramWrapperTypes: new Set(['parameter']),
+  extractParamName: extractScalaParamName,
+
+  returnNode: 'return_expression',
+
+  varDeclaratorNodes: new Set(['val_definition', 'var_definition']),
+  varNameField: 'pattern',
+
+  callNode: 'call_expression',
+  callFunctionField: 'function',
+  callArgsField: 'arguments',
+
+  memberNode: 'field_expression',
+  memberObjectField: 'value',
+  memberPropertyField: 'field',
+});
+
+// ─── Dart ─────────────────────────────────────────────────────────────────────
+//
+// Dart uses `function_signature` for top-level functions and `method_signature`
+// for class methods (both confirmed in extractor). The extractor uses
+// `childForFieldName('name')` for the function name on both node types.
+// Dart call: `selector` node with `argument_part` — the extractor uses this.
+// There is no standard `call_expression` node type in tree-sitter-dart.
+// We use `function_signature` as the primary function node type.
+// Parameters: `childForFieldName('parameters')` on function_signature (confirmed in extractor).
+
+function extractDartParamName(node: TreeSitterNode): string[] | null {
+  // Dart: parameter types include 'formal_parameter', 'named_formal_parameter',
+  // 'optional_formal_parameter', and bare 'identifier'
+  if (
+    node.type === 'formal_parameter' ||
+    node.type === 'optional_formal_parameter' ||
+    node.type === 'named_formal_parameter'
+  ) {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return [nameNode.text];
+    // Fallback: last identifier child is usually the name
+    let lastName: string | null = null;
+    for (const child of node.namedChildren) {
+      if (child.type === 'identifier') lastName = child.text;
+    }
+    if (lastName) return [lastName];
+  }
+  if (node.type === 'identifier') return [node.text];
+  return null;
+}
+
+export const dataflowDart: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_signature', 'method_signature']),
+  nameField: 'name',
+
+  paramListField: 'parameters',
+  paramWrapperTypes: new Set([
+    'formal_parameter',
+    'optional_formal_parameter',
+    'named_formal_parameter',
+  ]),
+  extractParamName: extractDartParamName,
+
+  returnNode: 'return_statement',
+
+  callNode: 'call_expression',
+  // tree-sitter-dart does not have standard named fields for calls;
+  // the extractor uses `selector` nodes instead. Leave defaults.
+});
+
+// ─── Groovy ───────────────────────────────────────────────────────────────────
+//
+// Groovy has multiple function node types (method_definition/declaration,
+// constructor_definition/declaration, function_definition/declaration).
+// Params: `childForFieldName('parameters')` with fallback to findChild('formal_parameters')
+// (confirmed in extractor extractGroovyParams, line 334).
+// call_expression: `childForFieldName('function')` confirmed in extractor line 299.
+// field_expression: `childForFieldName('argument')` = object (confirmed in extractor line 303),
+// `childForFieldName('field')` = property.
+
+function getGroovyParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  const byField = funcNode.childForFieldName('parameters');
+  if (byField) return byField;
+  // Fallback: search for formal_parameters child
+  for (let i = 0; i < funcNode.childCount; i++) {
+    const child = funcNode.child(i);
+    if (child?.type === 'formal_parameters') return child;
+  }
+  return null;
+}
+
+function extractGroovyParamName(node: TreeSitterNode): string[] | null {
+  if (node.type === 'formal_parameter' || node.type === 'parameter') {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return [nameNode.text];
+    // Fallback: first identifier child
+    for (const child of node.namedChildren) {
+      if (child.type === 'identifier') return [child.text];
+    }
+  }
+  return null;
+}
+
+export const dataflowGroovy: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set([
+    'method_definition',
+    'method_declaration',
+    'constructor_definition',
+    'constructor_declaration',
+    'function_definition',
+    'function_declaration',
+  ]),
+  nameField: 'name',
+
+  getParamListNode: getGroovyParamListNode,
+  paramWrapperTypes: new Set(['formal_parameter', 'parameter']),
+  extractParamName: extractGroovyParamName,
+
+  returnNode: 'return_statement',
+
+  varDeclaratorNode: 'variable_declarator',
+
+  callNodes: new Set([
+    'call_expression',
+    'function_call',
+    'juxt_function_call',
+    'method_invocation',
+  ]),
+  callFunctionField: 'function',
+  callArgsField: 'arguments',
+
+  memberNode: 'field_expression',
+  memberObjectField: 'argument',
+  memberPropertyField: 'field',
+});

--- a/src/ast-analysis/rules/b3.ts
+++ b/src/ast-analysis/rules/b3.ts
@@ -1,0 +1,127 @@
+import type { DataflowRulesConfig } from '../../types.js';
+import { makeDataflowRules } from '../shared.js';
+
+// ─── Lua ──────────────────────────────────────────────────────────────────────
+//
+// Lua function_declaration: name via `childForFieldName('name')` (confirmed in extractor line 47).
+// The name node may be `method_index_expression`, `dot_index_expression`, or `identifier`.
+// Parameters: `childForFieldName('parameters')` (confirmed in extractor line 89) — returns
+// a node containing `identifier` children directly (no wrapper type).
+// function_call: name via `childForFieldName('name')` (confirmed in extractor line 132).
+// dot_index_expression: table=`childForFieldName('table')`, field=`childForFieldName('field')`.
+// method_index_expression: table=`childForFieldName('table')`, method=`childForFieldName('method')`.
+
+export const dataflowLua: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_declaration']),
+  nameField: 'name',
+
+  paramListField: 'parameters',
+  // Lua params are bare identifier children in the param list — no wrapper type
+  paramIdentifier: 'identifier',
+
+  returnNode: 'return_statement',
+
+  callNode: 'function_call',
+  callFunctionField: 'name',
+  callArgsField: 'arguments',
+
+  memberNode: 'dot_index_expression',
+  memberObjectField: 'table',
+  memberPropertyField: 'field',
+});
+
+// ─── R ────────────────────────────────────────────────────────────────────────
+//
+// R functions are defined as: `name <- function_definition` (binary_operator with `<-`).
+// The extractor handles this as binary_operator + function_definition on the RHS.
+// There is no standalone function declaration node — `function_definition` is always
+// an RHS expression. The parent `binary_operator` is the true "function node".
+// R does NOT have an explicit `return` statement keyword that always appears —
+// `return()` is a regular function call. Set returnNode: null.
+// call node: `call` (confirmed in extractor handleCall line 111).
+// The call node's first child (not a named field) is the function expression.
+// Parameters: findChild(funcDef, 'parameters') on function_definition (extractor line 88).
+// Each parameter is a `parameter` node with `childForFieldName('name')` or identifier child.
+
+export const dataflowR: DataflowRulesConfig = makeDataflowRules({
+  // R functions are the `binary_operator` node where RHS is `function_definition`.
+  // We track the binary_operator as a function scope, but the param list lives
+  // inside the nested `function_definition` child. This is best-effort: the
+  // unified dataflow walker will find `binary_operator` nodes but may not locate
+  // the param list via the standard field walk. Most analysis benefit comes from
+  // variable tracking and call arg flows.
+  // Use function_definition directly: the walker will enter it as function scope.
+  functionNodes: new Set(['function_definition']),
+  // R function_definition has no 'name' field — the name comes from the enclosing
+  // binary_operator's LHS. The nameExtractor is not needed here since the
+  // extractor handles name resolution; the dataflow visitor just needs to find
+  // the function scope boundary.
+  nameField: 'name',
+
+  paramListField: 'parameters',
+  paramWrapperTypes: new Set(['parameter']),
+
+  returnNode: null, // R uses return() as a function call, not a statement
+
+  callNode: 'call',
+  // R `call` node has the function as its first child (not a named field).
+  // Leaving callFunctionField at default 'function' — childForFieldName will
+  // return null, and the analysis falls back to skipping the callee name.
+
+  assignmentNode: 'binary_operator',
+  assignLeftField: 'left',
+  assignRightField: 'right',
+});
+
+// ─── Julia ────────────────────────────────────────────────────────────────────
+//
+// Julia function_definition: extractor uses a `signature` child → `call_expression`
+// to find the function name + params (complex nesting). The function node type
+// is `function_definition` (confirmed in extractor line 41).
+// The params are inside the signature's call_expression's argument_list.
+// For dataflow purposes, we just mark function_definition as the scope boundary.
+// Params are inside function_definition → signature → call_expression → argument_list.
+// Since there's no direct param list field on function_definition, use getParamListNode.
+// call_expression: `node.child(0)` for function name (confirmed in extractor handleCall line 387).
+// Julia has explicit `return_statement` (confirmed in extractor comment: "Julia has explicit return").
+// variable assignment: `assignment` node (confirmed in extractor handleAssignment line 158).
+
+export const dataflowJulia: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_definition']),
+  nameField: 'name',
+
+  // Julia params are buried deep: function_definition → signature → call_expression → argument_list.
+  // No direct named field on function_definition for params. Leave param extraction
+  // to best-effort: getParamListNode returns null (default), so params will be skipped
+  // gracefully. The primary value is function scope tracking and call arg flows.
+  paramListField: 'parameters',
+
+  returnNode: 'return_statement',
+
+  assignmentNode: 'assignment',
+  assignLeftField: 'left',
+  assignRightField: 'right',
+
+  callNode: 'call_expression',
+  // Julia call_expression: first child is the function (no named field 'function').
+  // Leave callFunctionField at default — will return null gracefully.
+});
+
+// ─── Bash ─────────────────────────────────────────────────────────────────────
+//
+// Bash function_definition: name via `childForFieldName('name')` (confirmed in extractor line 42).
+// Bash has no typed parameters or return values.
+// command: `command_name` child (extractor handleBashCommand line 55).
+// No param lists, no return nodes, no variable declarators in the conventional sense.
+// Minimal config — primarily useful for function scope tracking and call edges.
+
+export const dataflowBash: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_definition']),
+  nameField: 'name',
+
+  returnNode: null, // Bash has no explicit return statement node (return is a command)
+
+  callNode: 'command',
+  // Bash `command` node: function name is in `command_name` child (not a named field).
+  // Leave callFunctionField at default — will return null gracefully.
+});

--- a/src/ast-analysis/rules/b4.ts
+++ b/src/ast-analysis/rules/b4.ts
@@ -1,0 +1,378 @@
+import type { DataflowRulesConfig, TreeSitterNode } from '../../types.js';
+import { makeDataflowRules } from '../shared.js';
+
+// ─── Haskell ──────────────────────────────────────────────────────────────────
+//
+// Haskell `function` node: name via `childForFieldName('name')` (confirmed in extractor line 62).
+// Params: `patterns` or `parameter` children of the function node (extractor line 81).
+// No explicit return keyword — last expression is the return value. returnNode: null.
+// apply: `childForFieldName('function')` for the called function (extractor line 264).
+// No standard variable declarations or member access in the conventional sense.
+
+function extractHaskellParamName(node: TreeSitterNode): string[] | null {
+  if (node.type === 'variable' || node.type === 'identifier') return [node.text];
+  if (node.type === 'wildcard') return ['_'];
+  // For pattern nodes, collect all variable bindings
+  if (node.type === 'patterns' || node.type === 'parameter') {
+    const names: string[] = [];
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (!child) continue;
+      if (child.type === 'variable' || child.type === 'identifier') names.push(child.text);
+    }
+    return names.length > 0 ? names : null;
+  }
+  return null;
+}
+
+function getHaskellParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  // Haskell params are positional children; find the `patterns` child if present
+  for (let i = 0; i < funcNode.childCount; i++) {
+    const child = funcNode.child(i);
+    if (child?.type === 'patterns') return child;
+  }
+  return null;
+}
+
+export const dataflowHaskell: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function']),
+  nameField: 'name',
+
+  getParamListNode: getHaskellParamListNode,
+  paramWrapperTypes: new Set(['variable', 'identifier', 'wildcard', 'parameter']),
+  extractParamName: extractHaskellParamName,
+
+  returnNode: null, // Haskell: no explicit return; last expression is the result
+
+  callNode: 'apply',
+  callFunctionField: 'function',
+  // `apply` args don't have a single named 'arguments' field in tree-sitter-haskell.
+});
+
+// ─── OCaml ────────────────────────────────────────────────────────────────────
+//
+// OCaml functions are `value_definition` → `let_binding` nodes with parameter children.
+// The extractor handles both `value_definition` (top-level) and standalone `let_binding`.
+// Params: `parameter` or `value_pattern` children of let_binding (extractor line 139).
+// No explicit return keyword — last expression is the result. returnNode: null.
+// application_expression: first child is function node (extractor line 314).
+// field_get_expression: `childForFieldName('field')` (extractor line 327).
+// Variable declarations: `let_binding` with no params (extractor line 103-110).
+
+function extractOCamlParamName(node: TreeSitterNode): string[] | null {
+  if (node.type === 'value_name' || node.type === 'identifier') return [node.text];
+  if (node.type === 'parameter' || node.type === 'value_pattern') {
+    // Pattern may be value_name or identifier
+    if (node.namedChildCount === 0) return [node.text];
+    for (const child of node.namedChildren) {
+      if (child.type === 'value_name' || child.type === 'identifier') return [child.text];
+    }
+  }
+  return null;
+}
+
+function getOCamlParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  // For value_definition, params are inside let_binding children
+  if (funcNode.type === 'value_definition') {
+    for (let i = 0; i < funcNode.childCount; i++) {
+      const child = funcNode.child(i);
+      if (child?.type === 'let_binding') return child;
+    }
+  }
+  // For let_binding directly — return it as the "param list" (walker will iterate its children)
+  if (funcNode.type === 'let_binding') return funcNode;
+  return null;
+}
+
+export const dataflowOCaml: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['value_definition', 'let_binding']),
+  nameField: 'pattern',
+
+  getParamListNode: getOCamlParamListNode,
+  paramWrapperTypes: new Set(['parameter', 'value_pattern']),
+  extractParamName: extractOCamlParamName,
+
+  returnNode: null, // OCaml: no explicit return; last expression is the result
+
+  callNode: 'application_expression',
+  // application_expression: first child is function (no named 'function' field in tree-sitter-ocaml).
+  // Leave callFunctionField at default — will return null gracefully.
+
+  memberNode: 'field_get_expression',
+  memberPropertyField: 'field',
+  // field_get_expression object is first child, not a named field. Leave memberObjectField at default.
+});
+
+// ─── F# ───────────────────────────────────────────────────────────────────────
+//
+// F# functions: `function_declaration_left` is the LHS of a `let` binding (confirmed extractor).
+// The name is a direct `identifier` child of `function_declaration_left` (extractor line 127).
+// Params: `argument_patterns` child of `function_declaration_left` (extractor line 150).
+// No explicit return keyword in F#. returnNode: null.
+// application_expression: first child is function (extractor line 265).
+// dot_expression: member access (extractor line 276).
+
+function extractFSharpParamName(node: TreeSitterNode): string[] | null {
+  if (node.type === 'identifier') return [node.text];
+  // Collect all identifier descendants for pattern-destructured params
+  const names: string[] = [];
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child?.type === 'identifier') names.push(child.text);
+  }
+  return names.length > 0 ? names : null;
+}
+
+function getFSharpParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  // function_declaration_left contains argument_patterns as a child
+  for (let i = 0; i < funcNode.childCount; i++) {
+    const child = funcNode.child(i);
+    if (child?.type === 'argument_patterns') return child;
+  }
+  return null;
+}
+
+export const dataflowFSharp: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_declaration_left']),
+  nameField: 'name',
+
+  getParamListNode: getFSharpParamListNode,
+  paramWrapperTypes: new Set(['identifier']),
+  extractParamName: extractFSharpParamName,
+
+  returnNode: null, // F#: no explicit return; last expression is the result
+
+  callNode: 'application_expression',
+  // application_expression: first child is function (no named 'function' field).
+
+  memberNode: 'dot_expression',
+  // dot_expression field names are not standard; leave memberObjectField/memberPropertyField at defaults.
+});
+
+// ─── Gleam ────────────────────────────────────────────────────────────────────
+//
+// Gleam `function` and `external_function`: name via `childForFieldName('name')` (extractor line 70).
+// Params: `childForFieldName('parameters')` or findChild('function_parameters') (extractor line 221).
+// Each param is `function_parameter` or `parameter` with `childForFieldName('name')` (extractor line 228).
+// No explicit return keyword in Gleam. returnNode: null.
+// function_call/call: `childForFieldName('function')` (extractor line 202).
+// field_access/module_select: `childForFieldName('field')` / `childForFieldName('label')` (extractor line 207).
+
+function extractGleamParamName(node: TreeSitterNode): string[] | null {
+  if (node.type === 'function_parameter' || node.type === 'parameter') {
+    const nameNode = node.childForFieldName('name');
+    if (nameNode) return [nameNode.text];
+    for (const child of node.namedChildren) {
+      if (child.type === 'identifier') return [child.text];
+    }
+  }
+  if (node.type === 'identifier') return [node.text];
+  return null;
+}
+
+export const dataflowGleam: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function', 'external_function']),
+  nameField: 'name',
+
+  paramListField: 'parameters',
+  paramWrapperTypes: new Set(['function_parameter', 'parameter']),
+  extractParamName: extractGleamParamName,
+
+  returnNode: null, // Gleam: no explicit return; last expression is the result
+
+  callNodes: new Set(['function_call', 'call']),
+  callFunctionField: 'function',
+
+  memberNode: 'field_access',
+  memberObjectField: 'record',
+  memberPropertyField: 'field',
+});
+
+// ─── Elixir ───────────────────────────────────────────────────────────────────
+//
+// Elixir functions are `call` nodes where target is `def`/`defp` (confirmed extractor).
+// The extractor emits the function definition from `handleDefFunction` which walks
+// `call` nodes. The actual function body lives inside a `do_block`.
+// Params: inside `call` → `arguments` → inner `call` → `arguments` (extractor line 181-196).
+// No explicit return keyword in Elixir. returnNode: null.
+// Regular call: `call` nodes with `target` identifier (extractor handleElixirCall).
+// Dot call: `call` with `dot` target (extractor handleDotCall).
+//
+// For dataflow purposes: the function scope is a `call` node with `def`/`defp` target.
+// This requires a custom nameExtractor to identify which calls are function definitions.
+// The simplified approach: mark `call` as a function node but filter by target in nameExtractor.
+
+function extractElixirFunctionName(node: TreeSitterNode): string | null {
+  if (node.type !== 'call') return null;
+  const target = node.childForFieldName('target');
+  if (target?.type !== 'identifier') return null;
+  if (target.text !== 'def' && target.text !== 'defp') return null;
+  // Extract the function name from arguments → first call → target identifier
+  const args =
+    node.childForFieldName('arguments') ??
+    (() => {
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        if (child?.type === 'arguments') return child;
+      }
+      return null;
+    })();
+  if (!args) return null;
+  for (let i = 0; i < args.childCount; i++) {
+    const child = args.child(i);
+    if (!child) continue;
+    if (child.type === 'call') {
+      const fnTarget = child.childForFieldName('target');
+      if (fnTarget?.type === 'identifier') return fnTarget.text;
+    }
+    if (child.type === 'identifier') return child.text;
+  }
+  return null;
+}
+
+export const dataflowElixir: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['call']),
+  nameField: 'target',
+  nameExtractor: extractElixirFunctionName,
+
+  // Param list extraction is complex for Elixir (nested calls inside arguments).
+  // Leave at defaults — param list discovery will gracefully return null.
+
+  returnNode: null, // Elixir: no explicit return; last expression is the result
+
+  callNode: 'call',
+  // Elixir call nodes use 'target' for the function name, not 'function'.
+  // Leave callFunctionField at default 'function' — will return null gracefully.
+  // The primary value here is function scope marking.
+});
+
+// ─── Erlang ───────────────────────────────────────────────────────────────────
+//
+// Erlang `fun_decl` contains `function_clause` children.
+// The extractor handles `fun_decl` by extracting from the first `function_clause`.
+// function_clause: name via `childForFieldName('name')` or `findChild(node, 'atom')` (extractor line 151).
+// Params: `childForFieldName('args')` or findChild('expr_args') (extractor line 179).
+// Each arg in expr_args is a named child (pattern). arity preserved by param count.
+// No explicit return keyword in Erlang. returnNode: null.
+// call: first named child is function (extractor line 272).
+
+function extractErlangParamName(node: TreeSitterNode): string[] | null {
+  // Erlang params are pattern nodes; var/atom get their text as name
+  if (node.type === 'var' || node.type === 'atom') return [node.text];
+  // For complex patterns, use a placeholder
+  return [`_${node.startPosition.row}`];
+}
+
+function getErlangParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  // fun_decl: find first function_clause, then its expr_args
+  if (funcNode.type === 'fun_decl') {
+    for (let i = 0; i < funcNode.childCount; i++) {
+      const child = funcNode.child(i);
+      if (child?.type === 'function_clause') {
+        const args = child.childForFieldName('args');
+        if (args) return args;
+        for (let j = 0; j < child.childCount; j++) {
+          const argChild = child.child(j);
+          if (argChild?.type === 'expr_args') return argChild;
+        }
+      }
+    }
+  }
+  // function_clause directly: find expr_args
+  if (funcNode.type === 'function_clause') {
+    const args = funcNode.childForFieldName('args');
+    if (args) return args;
+    for (let i = 0; i < funcNode.childCount; i++) {
+      const child = funcNode.child(i);
+      if (child?.type === 'expr_args') return child;
+    }
+  }
+  return null;
+}
+
+export const dataflowErlang: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['fun_decl', 'function_clause']),
+  nameField: 'name',
+
+  getParamListNode: getErlangParamListNode,
+  extractParamName: extractErlangParamName,
+
+  returnNode: null, // Erlang: no explicit return; last expression is the result
+
+  callNode: 'call',
+  // Erlang call: first named child is function (atom or remote). No named 'function' field.
+});
+
+// ─── Clojure ──────────────────────────────────────────────────────────────────
+//
+// Clojure functions are `list_lit` nodes where first symbol is `defn`/`defn-`/`defmacro`.
+// The extractor uses `findFirstSymbol` / `findSecondSymbol` helpers.
+// The function name is the second symbol in the list.
+// Params: first `vec_lit` child after the name (extractor extractClojureParams line 222).
+// No explicit return keyword in Clojure. returnNode: null.
+// Regular calls: `list_lit` nodes where first symbol is not a def form (extractor default case).
+//
+// nameExtractor must distinguish function-defining lists from call lists.
+
+function extractClojureFunctionName(node: TreeSitterNode): string | null {
+  if (node.type !== 'list_lit') return null;
+  // Find first symbol — skip delimiters and metadata
+  let firstSym: TreeSitterNode | null = null;
+  let secondSym: TreeSitterNode | null = null;
+  let count = 0;
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (!child) continue;
+    if ('()[]{}#'.includes(child.type) || child.type === 'meta_lit') continue;
+    if (child.type === 'sym_lit' || child.type === 'kwd_lit') {
+      count++;
+      if (count === 1) firstSym = child;
+      else if (count === 2) {
+        secondSym = child;
+        break;
+      }
+    }
+  }
+  if (!firstSym) return null;
+  const keyword = firstSym.text;
+  if (
+    keyword !== 'defn' &&
+    keyword !== 'defn-' &&
+    keyword !== 'defmacro' &&
+    keyword !== 'defmethod'
+  )
+    return null;
+  return secondSym ? secondSym.text : null;
+}
+
+function getClojureParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  if (funcNode.type !== 'list_lit') return null;
+  // Find the first vec_lit child (the parameter vector)
+  for (let i = 0; i < funcNode.childCount; i++) {
+    const child = funcNode.child(i);
+    if (child?.type === 'vec_lit') return child;
+  }
+  return null;
+}
+
+function extractClojureParamName(node: TreeSitterNode): string[] | null {
+  if (node.type === 'sym_lit') return [node.text];
+  return null;
+}
+
+export const dataflowClojure: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['list_lit']),
+  nameField: 'name',
+  nameExtractor: extractClojureFunctionName,
+
+  getParamListNode: getClojureParamListNode,
+  paramWrapperTypes: new Set(['sym_lit']),
+  extractParamName: extractClojureParamName,
+
+  returnNode: null, // Clojure: no explicit return; last expression is the result
+
+  callNode: 'list_lit',
+  // Clojure calls are also list_lit nodes — first sym is the function name.
+  // The dataflow visitor will see these as calls (not function defs) since
+  // nameExtractor returns null for non-def forms.
+});

--- a/src/ast-analysis/rules/b5.ts
+++ b/src/ast-analysis/rules/b5.ts
@@ -1,0 +1,65 @@
+import type { DataflowRulesConfig } from '../../types.js';
+import { makeDataflowRules } from '../shared.js';
+
+// ─── Zig ──────────────────────────────────────────────────────────────────────
+//
+// Zig function_declaration: name via `childForFieldName('name')` (confirmed in extractor line 68).
+// Parameters: `childForFieldName('parameters')` (confirmed in extractor extractZigParams line 84).
+// Each parameter is a `parameter` node; identifier child is the name (extractor line 89-90).
+// return_statement: Zig has explicit return (confirmed in extractor + language spec).
+// variable_declaration: name is first `identifier` child (extractor handleZigVariable line 99).
+// call_expression: `childForFieldName('function')` (confirmed in extractor handleZigCallExpression line 209).
+// field_expression/field_access: `childForFieldName('field')` or `childForFieldName('member')` (extractor line 215).
+// member object: `childForFieldName('value')` or `funcNode.child(0)` (extractor line 216).
+
+export const dataflowZig: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_declaration']),
+  nameField: 'name',
+
+  paramListField: 'parameters',
+  paramWrapperTypes: new Set(['parameter']),
+  // Zig parameter: identifier child for the name (extractZigParams uses findChild(param, 'identifier'))
+  paramIdentifier: 'identifier',
+
+  returnNode: 'return_statement',
+
+  varDeclaratorNode: 'variable_declaration',
+  varNameField: 'name',
+
+  callNode: 'call_expression',
+  callFunctionField: 'function',
+  callArgsField: 'arguments',
+
+  memberNode: 'field_expression',
+  memberObjectField: 'value',
+  memberPropertyField: 'field',
+});
+
+// ─── Solidity ─────────────────────────────────────────────────────────────────
+//
+// Solidity function_definition: name via `childForFieldName('name')` (confirmed in extractor line 232).
+// Parameters: `childForFieldName('parameters')` or findChild('parameter_list') (extractor line 355-357).
+// Each parameter is a `parameter` node (extractor uses extractSimpleParameters with paramTypes: ['parameter']).
+// return_statement: Solidity has explicit return.
+// call_expression / function_call: both confirmed in extractor walkSolidityNode line 71-72.
+// call_expression handler: `childForFieldName('function')` or `childForFieldName('callee')` (extractor line 336).
+// member_expression: `childForFieldName('property')` (extractor line 342), `childForFieldName('object')` (line 343).
+
+export const dataflowSolidity: DataflowRulesConfig = makeDataflowRules({
+  functionNodes: new Set(['function_definition', 'modifier_definition']),
+  nameField: 'name',
+
+  paramListField: 'parameters',
+  paramWrapperTypes: new Set(['parameter']),
+  paramIdentifier: 'identifier',
+
+  returnNode: 'return_statement',
+
+  callNodes: new Set(['call_expression', 'function_call']),
+  callFunctionField: 'function',
+  callArgsField: 'arguments',
+
+  memberNode: 'member_expression',
+  memberObjectField: 'object',
+  memberPropertyField: 'property',
+});

--- a/src/ast-analysis/rules/index.ts
+++ b/src/ast-analysis/rules/index.ts
@@ -4,6 +4,10 @@ import type {
   DataflowRulesConfig,
   HalsteadRules,
 } from '../../types.js';
+import * as b2 from './b2.js';
+import * as b3 from './b3.js';
+import * as b4 from './b4.js';
+import * as b5 from './b5.js';
 import * as c from './c.js';
 import * as csharp from './csharp.js';
 import * as go from './go.js';
@@ -77,6 +81,30 @@ export const DATAFLOW_RULES: Map<string, DataflowRulesConfig> = new Map([
   ['cpp', c.dataflowCpp],
   ['objc', c.dataflow], // ObjC C-compatible functions; ObjC methods TODO
   ['cuda', c.dataflowCpp], // CUDA inherits C++ grammar
+  // P5 Batch B2: JVM/mobile languages
+  ['kotlin', b2.dataflowKotlin],
+  ['swift', b2.dataflowSwift],
+  ['scala', b2.dataflowScala],
+  ['dart', b2.dataflowDart],
+  ['groovy', b2.dataflowGroovy],
+  // P5 Batch B3: scripting/dynamic languages
+  ['lua', b3.dataflowLua],
+  ['r', b3.dataflowR],
+  ['julia', b3.dataflowJulia],
+  ['bash', b3.dataflowBash],
+  // P5 Batch B4: functional languages
+  ['haskell', b4.dataflowHaskell],
+  ['ocaml', b4.dataflowOCaml],
+  ['ocaml-interface', b4.dataflowOCaml],
+  ['fsharp', b4.dataflowFSharp],
+  ['fsharp-signature', b4.dataflowFSharp],
+  ['gleam', b4.dataflowGleam],
+  ['elixir', b4.dataflowElixir],
+  ['erlang', b4.dataflowErlang],
+  ['clojure', b4.dataflowClojure],
+  // P5 Batch B5: systems/blockchain languages
+  ['zig', b5.dataflowZig],
+  ['solidity', b5.dataflowSolidity],
 ]);
 
 // ─── AST Node Type Maps ──────────────────────────────────────────────────

--- a/src/ast-analysis/visitors/dataflow-visitor.ts
+++ b/src/ast-analysis/visitors/dataflow-visitor.ts
@@ -433,6 +433,10 @@ function enterFunctionScope(
   scopeStack: ScopeEntry[],
   parameters: DataflowParam[],
 ): void {
+  // When nameExtractor is set it acts as a gate: null means this node is not a function
+  // definition. Needed for languages (Elixir, Clojure) where functionNodes includes generic
+  // node types (call/list_lit) that are only sometimes function definitions.
+  if (rules.nameExtractor && !rules.nameExtractor(funcNode)) return;
   const name = functionName(funcNode, rules);
   const paramsNode = rules.getParamListNode
     ? rules.getParamListNode(funcNode)

--- a/src/ast-analysis/visitors/dataflow-visitor.ts
+++ b/src/ast-analysis/visitors/dataflow-visitor.ts
@@ -426,17 +426,23 @@ function handleReturn(
   }
 }
 
-/** Collect parameter entries for a function and push a new scope onto the stack. */
+/**
+ * Collect parameter entries for a function and push a new scope onto the stack.
+ *
+ * Returns `true` if a scope was pushed, `false` if the node was skipped (i.e.
+ * `nameExtractor` rejected it). Callers must pop the stack only when this
+ * returns `true` to keep push/pop symmetric.
+ */
 function enterFunctionScope(
   funcNode: TreeSitterNode,
   rules: AnyRules,
   scopeStack: ScopeEntry[],
   parameters: DataflowParam[],
-): void {
+): boolean {
   // When nameExtractor is set it acts as a gate: null means this node is not a function
   // definition. Needed for languages (Elixir, Clojure) where functionNodes includes generic
   // node types (call/list_lit) that are only sometimes function definitions.
-  if (rules.nameExtractor && !rules.nameExtractor(funcNode)) return;
+  if (rules.nameExtractor && !rules.nameExtractor(funcNode)) return false;
   const name = functionName(funcNode, rules);
   const paramsNode = rules.getParamListNode
     ? rules.getParamListNode(funcNode)
@@ -455,6 +461,7 @@ function enterFunctionScope(
     }
   }
   scopeStack.push({ funcName: name, funcNode, params: paramMap, locals: new Map() });
+  return true;
 }
 
 interface DataflowDispatchCtx {
@@ -516,6 +523,11 @@ export function createDataflowVisitor(rules: AnyRules): Visitor {
   const argFlows: DataflowArgFlow[] = [];
   const mutations: DataflowMutation[] = [];
   const scopeStack: ScopeEntry[] = [];
+  // Parallel stack that records whether each enterFunction call actually pushed a
+  // scope frame.  exitFunction pops scopeStack only when the matching entry is true,
+  // keeping push/pop symmetric even for languages (Elixir, Clojure) where
+  // enterFunctionScope may return early without pushing.
+  const pushRecord: boolean[] = [];
 
   const dispatchCtx: DataflowDispatchCtx = {
     rules,
@@ -536,7 +548,7 @@ export function createDataflowVisitor(rules: AnyRules): Visitor {
       _funcName: string | null,
       _context: VisitorContext,
     ): void {
-      enterFunctionScope(funcNode, rules, scopeStack, parameters);
+      pushRecord.push(enterFunctionScope(funcNode, rules, scopeStack, parameters));
     },
 
     exitFunction(
@@ -544,7 +556,7 @@ export function createDataflowVisitor(rules: AnyRules): Visitor {
       _funcName: string | null,
       _context: VisitorContext,
     ): void {
-      scopeStack.pop();
+      if (pushRecord.pop()) scopeStack.pop();
     },
 
     enterNode(node: TreeSitterNode, _context: VisitorContext): EnterNodeResult | undefined {

--- a/src/features/dataflow.ts
+++ b/src/features/dataflow.ts
@@ -589,6 +589,124 @@ function buildInterproceduralStitch(
 
 // ── buildDataflowEdges ──────────────────────────────────────────────────────
 
+// ── P4 helpers ───────────────────────────────────────────────────────────────
+
+/** Return IDs of all function/method nodes in the given relative file paths. */
+function collectFuncIdsForFiles(db: BetterSqlite3Database, relPaths: Iterable<string>): number[] {
+  const stmt = db.prepare(`SELECT id FROM nodes WHERE file = ? AND kind IN ('function', 'method')`);
+  const ids: number[] = [];
+  for (const p of relPaths) {
+    for (const row of stmt.all(p) as { id: number }[]) ids.push(row.id);
+  }
+  return ids;
+}
+
+/**
+ * P4: Re-collect stitch candidates from caller files that were NOT in the
+ * changed set but contain calls to functions that WERE changed.
+ *
+ * During an incremental build the changed files' param vertices are purged
+ * and recreated, but the callers' files are never re-parsed — so their
+ * arg_in edges (pointing to the old param vertices) are deleted and never
+ * replaced. This function reads those caller files from disk and rebuilds
+ * the StitchCandidate list so buildInterproceduralStitch can reconnect them.
+ */
+async function collectCallerStitchCandidates(
+  db: BetterSqlite3Database,
+  changedFuncIds: number[],
+  changedRelPaths: Set<string>,
+  rootDir: string,
+  extToLang: Map<string, string>,
+  parsers: unknown,
+  getParserFn: ((parsers: any, absPath: string) => any) | null,
+): Promise<{ candidates: StitchCandidate[]; captures: ReturnCapture[] }> {
+  if (changedFuncIds.length === 0) return { candidates: [], captures: [] };
+
+  // Find distinct caller files that have flows_to edges targeting any changed
+  // function and are NOT already in the changed file set (those are handled by
+  // the main per-file loop).
+  const placeholders = changedFuncIds.map(() => '?').join(',');
+  const callerFileRows = db
+    .prepare(
+      `SELECT DISTINCT n.file AS caller_file
+       FROM dataflow d
+       JOIN nodes n ON n.id = d.source_id
+       WHERE d.target_id IN (${placeholders})
+         AND d.kind = 'flows_to'`,
+    )
+    .all(...changedFuncIds) as { caller_file: string }[];
+
+  const callerFiles = callerFileRows
+    .map((r) => r.caller_file)
+    .filter((f) => !changedRelPaths.has(f));
+
+  if (callerFiles.length === 0) return { candidates: [], captures: [] };
+
+  // Ensure parsers are available — the main loop may have skipped loading them
+  // if all changed files came through the native bulk-insert path.
+  let activeParsers = parsers;
+  let activeGetParserFn = getParserFn;
+  if (!activeGetParserFn) {
+    const { createParsers, getParser } = await import('../domain/parser.js');
+    activeParsers = await createParsers();
+    activeGetParserFn = getParser;
+  }
+
+  const changedFuncIdSet = new Set(changedFuncIds);
+  const stmts = prepareNodeResolvers(db);
+  const candidates: StitchCandidate[] = [];
+  const captures: ReturnCapture[] = [];
+
+  for (const callerFile of callerFiles) {
+    // Read the caller file from disk without touching its existing DB rows.
+    const stub: FileSymbolsDataflow = { definitions: [], _langId: null, _tree: null };
+    const data = getDataflowForFile(
+      stub,
+      callerFile,
+      rootDir,
+      extToLang,
+      activeParsers,
+      activeGetParserFn,
+    );
+    if (!data) continue;
+
+    const resolver = makeNodeResolver(stmts, callerFile);
+    const argFlows = data.argFlows as unknown as VisitorArgFlow[];
+    const assignments = data.assignments as unknown as VisitorAssignment[];
+
+    for (const af of argFlows) {
+      const callerFn = resolver(af.callerFunc);
+      const calleeFn = resolver(af.calleeName);
+      if (!callerFn || !calleeFn) continue;
+      if (!changedFuncIdSet.has(calleeFn.id)) continue; // only re-stitch calls to changed callees
+      candidates.push({
+        callerFuncId: callerFn.id,
+        calleeFuncId: calleeFn.id,
+        argIndex: af.argIndex,
+        bindingType: af.binding.type,
+        bindingIndex: af.binding.index,
+        argName: af.argName,
+        expression: af.expression,
+        line: af.line,
+        confidence: af.confidence,
+      });
+    }
+
+    for (const a of assignments) {
+      const callerFn = resolver(a.callerFunc);
+      const calleeFn = resolver(a.sourceCallName);
+      if (!callerFn || !calleeFn) continue;
+      if (!changedFuncIdSet.has(calleeFn.id)) continue;
+      captures.push({ callerFuncId: callerFn.id, calleeFuncId: calleeFn.id, varName: a.varName });
+    }
+  }
+
+  debug(
+    `Dataflow P4: re-stitched ${candidates.length} candidate(s) from ${callerFiles.length} caller file(s)`,
+  );
+  return { candidates, captures };
+}
+
 function prepareNodeResolvers(db: BetterSqlite3Database): {
   getNodeByNameAndFile: ReturnType<BetterSqlite3Database['prepare']>;
   getNodeByName: ReturnType<BetterSqlite3Database['prepare']>;
@@ -747,6 +865,26 @@ export async function buildDataflowEdges(
   });
 
   tx();
+
+  // P4: Incremental re-stitch — if only a subset of files changed, callers of
+  // the changed functions were not in fileSymbols, so their arg_in edges were
+  // deleted by the purge but never reconstructed. Re-collect stitch candidates
+  // from those caller files now (read from disk, no DB writes).
+  if (vstmts.available) {
+    const changedRelPaths = new Set<string>(fileSymbols.keys());
+    const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
+    const extra = await collectCallerStitchCandidates(
+      db,
+      changedFuncIds,
+      changedRelPaths,
+      rootDir,
+      extToLang,
+      parsers,
+      getParserFn,
+    );
+    allCandidates.push(...extra.candidates);
+    allCaptures.push(...extra.captures);
+  }
 
   // P2: inter-procedural stitch — runs after all per-file vertices + summaries committed
   const interCount = vstmts.available

--- a/src/features/dataflow.ts
+++ b/src/features/dataflow.ts
@@ -625,16 +625,27 @@ async function collectCallerStitchCandidates(
   // Find distinct caller files that have flows_to edges targeting any changed
   // function and are NOT already in the changed file set (those are handled by
   // the main per-file loop).
-  const placeholders = changedFuncIds.map(() => '?').join(',');
-  const callerFileRows = db
-    .prepare(
-      `SELECT DISTINCT n.file AS caller_file
-       FROM dataflow d
-       JOIN nodes n ON n.id = d.source_id
-       WHERE d.target_id IN (${placeholders})
-         AND d.kind = 'flows_to'`,
-    )
-    .all(...changedFuncIds) as { caller_file: string }[];
+  //
+  // Chunk the query to avoid exceeding SQLite's SQLITE_MAX_VARIABLE_NUMBER
+  // (999 on older builds, 32766 on SQLite ≥ 3.32).  500 is a safe batch size
+  // that works across all SQLite versions.
+  const CHUNK_SIZE = 500;
+  const callerFileSet = new Set<string>();
+  for (let i = 0; i < changedFuncIds.length; i += CHUNK_SIZE) {
+    const chunk = changedFuncIds.slice(i, i + CHUNK_SIZE);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = db
+      .prepare(
+        `SELECT DISTINCT n.file AS caller_file
+         FROM dataflow d
+         JOIN nodes n ON n.id = d.source_id
+         WHERE d.target_id IN (${placeholders})
+           AND d.kind = 'flows_to'`,
+      )
+      .all(...chunk) as { caller_file: string }[];
+    for (const r of rows) callerFileSet.add(r.caller_file);
+  }
+  const callerFileRows = [...callerFileSet].map((f) => ({ caller_file: f }));
 
   const callerFiles = callerFileRows
     .map((r) => r.caller_file)
@@ -659,6 +670,10 @@ async function collectCallerStitchCandidates(
 
   for (const callerFile of callerFiles) {
     // Read the caller file from disk without touching its existing DB rows.
+    // definitions: [] is an intentional stub — P4 only needs argFlow/assignment
+    // data from the visitor, not pre-loaded symbol definitions.  extractDataflow
+    // does not currently use _definitions, so this is safe.  If that changes,
+    // the stub must be replaced with the actual symbol list for the caller file.
     const stub: FileSymbolsDataflow = { definitions: [], _langId: null, _tree: null };
     const data = getDataflowForFile(
       stub,
@@ -870,7 +885,14 @@ export async function buildDataflowEdges(
   // the changed functions were not in fileSymbols, so their arg_in edges were
   // deleted by the purge but never reconstructed. Re-collect stitch candidates
   // from those caller files now (read from disk, no DB writes).
-  if (vstmts.available) {
+  //
+  // Skip P4 on full builds: when fileSymbols covers every file in the DB there
+  // are no unchanged callers, and collectFuncIdsForFiles would issue one SELECT
+  // per file for nothing.  A single COUNT query is cheaper than N per-file SELECTs.
+  const totalFilesInDb = (
+    db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
+  ).n;
+  if (vstmts.available && fileSymbols.size < totalFilesInDb) {
     const changedRelPaths = new Set<string>(fileSymbols.keys());
     const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
     const extra = await collectCallerStitchCandidates(

--- a/tests/integration/dataflow-incremental.test.ts
+++ b/tests/integration/dataflow-incremental.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Integration test for P4: incremental re-stitch when a callee file changes.
+ *
+ * Scenario:
+ *   callee.js: function helper(x) { return x; }
+ *   caller.js: function main(input) { helper(input); }
+ *
+ * Simulates the state AFTER a full build but BEFORE the re-analysis:
+ *   - nodes for both helper and main exist
+ *   - flows_to edge (main → helper at param 0) exists
+ *   - main's param vertex exists (caller file did NOT change)
+ *   - helper's param vertex does NOT exist (callee purged, awaiting rebuild)
+ *
+ * Then runs buildDataflowEdges with only callee.js in fileSymbols, and
+ * asserts that P4 re-creates the arg_in edge from main.param → helper.param.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { initSchema } from '../../src/db/index.js';
+import { buildDataflowEdges } from '../../src/features/dataflow.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function insertNode(
+  db: ReturnType<typeof Database>,
+  name: string,
+  kind: string,
+  file: string,
+  line: number,
+): number {
+  return db
+    .prepare('INSERT INTO nodes (name, kind, file, line) VALUES (?, ?, ?, ?)')
+    .run(name, kind, file, line).lastInsertRowid as number;
+}
+
+// ─── Fixture ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let dbPath: string;
+let calleeRelPath: string;
+let callerRelPath: string;
+let mainNodeId: number;
+let helperNodeId: number;
+let mainParamVertexId: number;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-p4-'));
+  fs.mkdirSync(path.join(tmpDir, '.codegraph'));
+  fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+
+  callerRelPath = 'src/caller.js';
+  calleeRelPath = 'src/callee.js';
+
+  // Write real source files to disk (P4 re-parses caller from disk).
+  fs.writeFileSync(path.join(tmpDir, callerRelPath), 'function main(input) { helper(input); }\n');
+  fs.writeFileSync(path.join(tmpDir, calleeRelPath), 'function helper(x) { return x; }\n');
+
+  dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  initSchema(db);
+
+  // Insert nodes (as a full build would have done).
+  mainNodeId = insertNode(db, 'main', 'function', callerRelPath, 1);
+  helperNodeId = insertNode(db, 'helper', 'function', calleeRelPath, 1);
+
+  // Simulate post-purge state:
+  //   - flows_to edge (main → helper at param 0) still exists (not purged —
+  //     only callee file was purged, and this edge's source_id is main's node
+  //     in caller.js which was NOT purged).
+  //   - main's param vertex [input] exists (caller not purged).
+  //   - helper's param vertex does NOT exist (callee was purged).
+
+  db.prepare(
+    `INSERT INTO dataflow (source_id, target_id, kind, param_index, expression, line, confidence)
+     VALUES (?, ?, 'flows_to', 0, 'input', 1, 1.0)`,
+  ).run(mainNodeId, helperNodeId);
+
+  // Also insert a calls edge (used by stitch for call_edge_id).
+  db.prepare(`INSERT INTO edges (source_id, target_id, kind) VALUES (?, ?, 'calls')`).run(
+    mainNodeId,
+    helperNodeId,
+  );
+
+  // Insert main's param vertex (simulating that caller.js was NOT purged).
+  const vr = db
+    .prepare(
+      `INSERT INTO dataflow_vertices (func_id, kind, name, param_index, line, node_id)
+       VALUES (?, 'param', 'input', 0, 1, NULL)`,
+    )
+    .run(mainNodeId);
+  mainParamVertexId = vr.lastInsertRowid as number;
+
+  db.close();
+
+  // Run buildDataflowEdges with ONLY the callee file in fileSymbols.
+  // P4 should detect that main (caller) calls helper (callee) and re-stitch.
+  const db2 = new Database(dbPath);
+  db2.pragma('journal_mode = WAL');
+
+  const mockCalleeDataflow = {
+    parameters: [{ funcName: 'helper', paramName: 'x', paramIndex: 0, line: 1 }],
+    returns: [{ funcName: 'helper', expression: 'x', referencedNames: ['x'], line: 1 }],
+    assignments: [],
+    argFlows: [],
+    mutations: [],
+  };
+
+  const fileSymbols = new Map([
+    [
+      calleeRelPath,
+      {
+        definitions: [{ name: 'helper', kind: 'function', line: 1 }],
+        dataflow: mockCalleeDataflow as any,
+        _langId: 'javascript' as any,
+        _tree: null,
+      },
+    ],
+  ]);
+
+  await buildDataflowEdges(db2, fileSymbols as any, tmpDir);
+  db2.close();
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('P4: incremental re-stitch', () => {
+  function openDb() {
+    return new Database(dbPath, { readonly: true });
+  }
+
+  test('rebuilds helper param vertex after callee-only rebuild', () => {
+    const db = openDb();
+    const rows = db
+      .prepare(
+        `SELECT dv.* FROM dataflow_vertices dv
+         JOIN nodes n ON n.id = dv.func_id
+         WHERE n.name = 'helper' AND dv.kind = 'param'`,
+      )
+      .all() as any[];
+    db.close();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe('x');
+    expect(rows[0]!.param_index).toBe(0);
+  });
+
+  test('creates arg_in edge from main.param[input] → helper.param[x]', () => {
+    const db = openDb();
+    const rows = db
+      .prepare(
+        `SELECT d.kind, d.scope,
+                sv.name AS sv_name, sv.kind AS sv_kind,
+                tv.name AS tv_name, tv.kind AS tv_kind
+         FROM dataflow d
+         JOIN dataflow_vertices sv ON sv.id = d.source_vertex
+         JOIN dataflow_vertices tv ON tv.id = d.target_vertex
+         WHERE d.kind = 'arg_in' AND d.scope = 'inter'`,
+      )
+      .all() as any[];
+    db.close();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.sv_name).toBe('input');
+    expect(rows[0]!.sv_kind).toBe('param');
+    expect(rows[0]!.tv_name).toBe('x');
+    expect(rows[0]!.tv_kind).toBe('param');
+  });
+
+  test('arg_in source_vertex is the pre-existing main.param vertex (not recreated)', () => {
+    const db = openDb();
+    const row = db
+      .prepare(
+        `SELECT source_vertex FROM dataflow WHERE kind = 'arg_in' AND scope = 'inter' LIMIT 1`,
+      )
+      .get() as { source_vertex: number } | null;
+    db.close();
+    expect(row).not.toBeNull();
+    expect(row!.source_vertex).toBe(mainParamVertexId);
+  });
+
+  test('main param vertex was NOT duplicated by P4 re-parse', () => {
+    const db = openDb();
+    const rows = db
+      .prepare(
+        `SELECT dv.* FROM dataflow_vertices dv
+         JOIN nodes n ON n.id = dv.func_id
+         WHERE n.name = 'main' AND dv.kind = 'param'`,
+      )
+      .all() as any[];
+    db.close();
+    expect(rows).toHaveLength(1); // still exactly one — P4 does not insert caller vertices
+  });
+
+  test('return_out edge is created because helper.param[x] flows_to_return', () => {
+    const db = openDb();
+    const rows = db
+      .prepare(`SELECT * FROM dataflow WHERE kind = 'return_out' AND scope = 'inter'`)
+      .all() as any[];
+    db.close();
+    // helper has x→return def_use, so return_out should be created
+    // (only if main has a local that captures helper's return — it doesn't here, so 0)
+    expect(rows).toHaveLength(0);
+  });
+
+  test('def_use intra edge created for helper.param[x] → helper.return', () => {
+    const db = openDb();
+    const rows = db
+      .prepare(
+        `SELECT d.* FROM dataflow d
+         JOIN dataflow_vertices sv ON sv.id = d.source_vertex
+         JOIN dataflow_vertices tv ON tv.id = d.target_vertex
+         JOIN nodes fn ON fn.id = sv.func_id
+         WHERE fn.name = 'helper' AND sv.kind = 'param' AND tv.kind = 'return'
+           AND d.kind = 'def_use' AND d.scope = 'intra'`,
+      )
+      .all() as any[];
+    db.close();
+    expect(rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the complete interprocedural dataflow vertex model across all 34 supported languages.

## Phases

- **P0**: Schema — `dataflow_vertices`, `dataflow_summary`, new edge kinds (`def_use`, `arg_in`, `return_out`)
- **P1**: Vertex extraction — param/return/local vertices + intra `def_use` edges per file
- **P2**: Interprocedural stitching — `arg_in` (caller → callee param) and `return_out` (callee return → caller capture) edges; `dataflow_summary` per param (Closes #1609)
- **P3**: C/C++ parser tests (29 tests)
- **P4**: Incremental re-stitch — rebuilt `arg_in` edges when callee file changes without full rebuild
- **P5 B1**: C-family dataflow rules (C, C++, ObjC, CUDA)
- **P5 B2–B5**: DATAFLOW_RULES for remaining 18 languages — Kotlin, Swift, Scala, Dart, Groovy, Lua, R, Julia, Bash, Haskell, OCaml, F#, Gleam, Elixir, Erlang, Clojure, Zig, Solidity (Closes #1610)
- **P6**: Vertex extraction on native orchestrator path — re-runs Rust dataflow visitor post-orchestrator so `dataflow_vertices` is populated regardless of engine; v19 migration sentinel forces one-time backfill of existing DBs
- **P6 parity**: Added `generator_function_declaration` / `generator_function` to JS + Rust `functionNodes` to fix 3 df-vertex divergences in `jelly-micro` fixture

Also includes:
- SQLite `IN` query chunking in `collectCallerStitchCandidates` to avoid `SQLITE_MAX_VARIABLE_NUMBER` (Fixes #1613)
- Skips P4 pass on full builds where `fileSymbols` covers all DB files
- README: removed "intraprocedural only" limitation; updated feature descriptions to mention `arg_in`, `return_out`, `def_use`

## Parity

`scripts/parity-compare.mjs --dataflow` — **36/36 fixtures OK**, both engines identical including df-vertices.

## Performance

Full build regression (~3s → ~11s on 707 files) is expected from:
- P6 `runDataflowVertexPass` re-runs Rust visitor per file (~2-3s)
- ~10,737 interprocedural edge insertions
- ~10,000+ vertex row insertions

1-file rebuild: 108ms → 207ms (P4 incremental re-stitch reads caller files from disk).
No-op rebuild: unchanged (22ms).

Optimization opportunity (filed): have Rust pipeline return `DataflowResult` per file so P6 doesn't need a second visitor pass.

## Test plan

- [x] `npx vitest run tests/integration/dataflow*.test.ts` — 40 passing
- [x] `node scripts/parity-compare.mjs --dataflow` — 36/36 OK
- [x] `node scripts/parity-compare.mjs` — 36/36 OK (no node/edge regressions)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] bench-check initial baseline saved

## Open follow-ups

- #1614: P4 incremental re-stitch on native engine path (unchanged callers)