### PR TITLE
feat(dynamic-calls): Phase 0 — detect and flag dynamic JS call sites

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1529,6 +1529,8 @@ fn build_and_insert_call_edges(
                     line: c.line,
                     dynamic: c.dynamic,
                     receiver: c.receiver.clone(),
+                    dynamic_kind: c.dynamic_kind.clone(),
+                    key_expr: c.key_expr.clone(),
                 })
                 .collect(),
             imported_names,

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -721,6 +721,10 @@ fn process_file<'a>(
     // Key: edge_key (same as seen_edges). Value: index into `edges` vec.
     let mut seen_edges: HashSet<u64> = HashSet::new();
     let mut pts_edge_map: HashMap<u64, usize> = HashMap::new();
+    // Separate dedup set for sink edges: (caller_id, file_node_id, dynamic_kind_byte).
+    // Using a distinct set avoids the bit-packing collision that would occur when
+    // caller_id >= 16 M (upper 8 bits of caller_id would overlap with the kind byte).
+    let mut seen_sink_edges: HashSet<(u32, u32, u8)> = HashSet::new();
 
     for call in &file_input.calls {
         if let Some(ref receiver) = call.receiver {
@@ -751,10 +755,9 @@ fn process_file<'a>(
         if targets.is_empty() {
             if let Some(ref dk) = call.dynamic_kind {
                 if dk == "eval" || dk == "computed-key" || dk == "unresolved-dynamic" {
-                    let sink_key = ((caller_id as u64) << 32) | (fc.file_node_id as u64)
-                        | ((dk.as_bytes()[0] as u64) << 56); // differentiate by kind
-                    if !seen_edges.contains(&sink_key) {
-                        seen_edges.insert(sink_key);
+                    let sink_key = (caller_id, fc.file_node_id, dk.as_bytes()[0]);
+                    if !seen_sink_edges.contains(&sink_key) {
+                        seen_sink_edges.insert(sink_key);
                         edges.push(ComputedEdge {
                             source_id: caller_id,
                             target_id: fc.file_node_id,
@@ -2301,7 +2304,7 @@ mod call_edge_tests {
                 // this() inside invoker
                 call("this", 2, None),
                 // invoker.call(handler, 10) — extractor emits dynamic call to invoker
-                CallInfo { name: "invoker".to_string(), line: 9, dynamic: Some(true), receiver: None },
+                CallInfo { name: "invoker".to_string(), line: 9, dynamic: Some(true), receiver: None, dynamic_kind: None, key_expr: None },
             ],
             vec![],
             vec![],
@@ -2384,7 +2387,7 @@ mod call_edge_tests {
             vec![def("f3", "function", 1, 3), def("main", "function", 8, 10)],
             vec![
                 // eerest.e4() inside f3
-                CallInfo { name: "e4".to_string(), line: 2, dynamic: None, receiver: Some("eerest".to_string()) },
+                CallInfo { name: "e4".to_string(), line: 2, dynamic: None, receiver: Some("eerest".to_string()), dynamic_kind: None, key_expr: None },
                 call("f3", 9, None),
             ],
             vec![],

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -36,6 +36,10 @@ pub struct CallInfo {
     pub line: u32,
     pub dynamic: Option<bool>,
     pub receiver: Option<String>,
+    #[napi(js_name = "dynamicKind")]
+    pub dynamic_kind: Option<String>,
+    #[napi(js_name = "keyExpr")]
+    pub key_expr: Option<String>,
 }
 
 #[napi(object)]
@@ -122,6 +126,8 @@ pub struct ComputedEdge {
     pub kind: String,
     pub confidence: f64,
     pub dynamic: u32,
+    #[napi(js_name = "dynamic_kind")]
+    pub dynamic_kind: Option<String>,
 }
 
 /// Internal struct for caller resolution (def line range → node ID).
@@ -398,6 +404,8 @@ fn emit_pts_alias_edges<'a>(
             line: alias_ctx.call_line,
             dynamic: Some(true),
             receiver: None,
+            dynamic_kind: None,
+            key_expr: None,
         };
         let mut alias_targets = resolve_call_targets(
             ctx, &alias_call, alias_ctx.rel_path, alias_imported_from, alias_ctx.type_map, alias_ctx.caller_name,
@@ -416,6 +424,7 @@ fn emit_pts_alias_edges<'a>(
                         kind: "calls".to_string(),
                         confidence: conf,
                         dynamic: alias_ctx.is_dynamic,
+                        dynamic_kind: None,
                     });
                 }
             }
@@ -735,6 +744,29 @@ fn process_file<'a>(
         }
 
         emit_receiver_edge(ctx, call, caller_id, fc.rel_path, &fc.type_map, &fc.imported_names, &mut seen_edges, edges);
+
+        // Sink edge: flag-only dynamic calls with no resolved target are emitted as
+        // a (caller → file_node) edge at confidence=0.0 with dynamic_kind set.
+        // This makes them queryable (`codegraph roles --dynamic`) instead of silent drops.
+        if targets.is_empty() {
+            if let Some(ref dk) = call.dynamic_kind {
+                if dk == "eval" || dk == "computed-key" || dk == "unresolved-dynamic" {
+                    let sink_key = ((caller_id as u64) << 32) | (fc.file_node_id as u64)
+                        | ((dk.as_bytes()[0] as u64) << 56); // differentiate by kind
+                    if !seen_edges.contains(&sink_key) {
+                        seen_edges.insert(sink_key);
+                        edges.push(ComputedEdge {
+                            source_id: caller_id,
+                            target_id: fc.file_node_id,
+                            kind: "calls".to_string(),
+                            confidence: 0.0,
+                            dynamic: 1,
+                            dynamic_kind: Some(dk.clone()),
+                        });
+                    }
+                }
+            }
+        }
     }
 
     emit_hierarchy_edges(ctx, file_input, fc.rel_path, edges);
@@ -848,6 +880,12 @@ fn resolve_call_targets<'a>(
     type_map: &HashMap<&str, (&str, f64)>,
     caller_name: &str,
 ) -> Vec<&'a NodeInfo> {
+    // Flagged dynamic calls use synthetic names like "<dynamic:eval>". Short-circuit
+    // so they never accidentally match a real symbol via name lookup.
+    if call.name.starts_with("<dynamic:") {
+        return vec![];
+    }
+
     // 1. Import-aware resolution
     if let Some(imp_file) = imported_from {
         let targets = ctx.nodes_by_name_and_file
@@ -1124,6 +1162,7 @@ fn emit_call_edges(
                 edges.push(ComputedEdge {
                     source_id: caller_id, target_id: t.id,
                     kind: "calls".to_string(), confidence, dynamic: is_dynamic,
+                    dynamic_kind: None,
                 });
             }
         }
@@ -1180,6 +1219,7 @@ fn emit_receiver_edge(
             edges.push(ComputedEdge {
                 source_id: caller_id, target_id: recv_target.id,
                 kind: "receiver".to_string(), confidence, dynamic: 0,
+                dynamic_kind: None,
             });
         }
     }
@@ -1205,6 +1245,7 @@ fn emit_hierarchy_edges(
                 edges.push(ComputedEdge {
                     source_id: source.id, target_id: t.id,
                     kind: "extends".to_string(), confidence: 1.0, dynamic: 0,
+                    dynamic_kind: None,
                 });
             }
         }
@@ -1216,6 +1257,7 @@ fn emit_hierarchy_edges(
                 edges.push(ComputedEdge {
                     source_id: source.id, target_id: t.id,
                     kind: "implements".to_string(), confidence: 1.0, dynamic: 0,
+                    dynamic_kind: None,
                 });
             }
         }
@@ -1459,6 +1501,7 @@ fn emit_type_only_symbol_edges(
                 kind: "imports-type".to_string(),
                 confidence: 1.0,
                 dynamic: 0,
+                dynamic_kind: None,
             });
         }
     }
@@ -1508,6 +1551,7 @@ fn emit_barrel_through_edges(
                 kind: barrel_kind.to_string(),
                 confidence: 0.9,
                 dynamic: 0,
+                dynamic_kind: None,
             });
         }
         resolved_sources.insert(actual_source);
@@ -1542,6 +1586,7 @@ fn process_single_import(
         kind: edge_kind.to_string(),
         confidence: 1.0,
         dynamic: 0,
+        dynamic_kind: None,
     });
     emit_type_only_symbol_edges(edges, file_input, imp, resolved_path, ctx);
     emit_barrel_through_edges(edges, file_input, imp, resolved_path, edge_kind, ctx);
@@ -1861,7 +1906,14 @@ mod call_edge_tests {
     }
 
     fn call(name: &str, line: u32, receiver: Option<&str>) -> CallInfo {
-        CallInfo { name: name.to_string(), line, dynamic: None, receiver: receiver.map(|s| s.to_string()) }
+        CallInfo {
+            name: name.to_string(),
+            line,
+            dynamic: None,
+            receiver: receiver.map(|s| s.to_string()),
+            dynamic_kind: None,
+            key_expr: None,
+        }
     }
 
     fn type_map_entry(name: &str, type_name: &str, confidence: f64) -> TypeMapInput {

--- a/crates/codegraph-core/src/extractors/bash.rs
+++ b/crates/codegraph-core/src/extractors/bash.rs
@@ -64,6 +64,7 @@ fn match_bash_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
                             line: start_line(node),
                             dynamic: None,
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                 }

--- a/crates/codegraph-core/src/extractors/c.rs
+++ b/crates/codegraph-core/src/extractors/c.rs
@@ -301,6 +301,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                             line: start_line(node),
                             dynamic: None,
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                     "field_expression" => {
@@ -314,6 +315,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                             line: start_line(node),
                             dynamic: None,
                             receiver,
+                            ..Default::default()
                         });
                     }
                     _ => {
@@ -322,6 +324,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                             line: start_line(node),
                             dynamic: None,
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                 }

--- a/crates/codegraph-core/src/extractors/clojure.rs
+++ b/crates/codegraph-core/src/extractors/clojure.rs
@@ -114,6 +114,7 @@ fn handle_list_form(
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -231,6 +231,7 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "member_access_expression" => {
@@ -242,6 +243,7 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
                     line: start_line(node),
                     dynamic: None,
                     receiver,
+                    ..Default::default()
                 });
             }
         }
@@ -253,6 +255,7 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
         }
@@ -274,6 +277,7 @@ fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             line: start_line(node),
             dynamic: None,
             receiver: None,
+            ..Default::default()
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -286,6 +286,7 @@ fn handle_dart_constructor_call(node: &Node, source: &[u8], symbols: &mut FileSy
             line: start_line(node),
             dynamic: None,
             receiver: None,
+            ..Default::default()
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -40,6 +40,7 @@ fn match_elixir_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
         }
@@ -380,5 +381,6 @@ fn handle_dot_call(node: &Node, dot_node: &Node, source: &[u8], symbols: &mut Fi
         line: start_line(node),
         dynamic: None,
         receiver,
+        ..Default::default()
     });
 }

--- a/crates/codegraph-core/src/extractors/erlang.rs
+++ b/crates/codegraph-core/src/extractors/erlang.rs
@@ -320,6 +320,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "remote" => {
@@ -342,6 +343,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver: Some(receiver),
+                    ..Default::default()
                 });
             } else if atoms.len() == 1 {
                 symbols.calls.push(Call {
@@ -349,6 +351,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/fsharp.rs
+++ b/crates/codegraph-core/src/extractors/fsharp.rs
@@ -313,6 +313,7 @@ fn handle_application(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "long_identifier_or_op" => {
@@ -329,6 +330,7 @@ fn handle_application(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
         }
@@ -358,6 +360,7 @@ fn handle_dot_expression(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             line: start_line(node),
             dynamic: None,
             receiver: Some(receiver),
+            ..Default::default()
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/gleam.rs
+++ b/crates/codegraph-core/src/extractors/gleam.rs
@@ -262,6 +262,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "field_access" | "module_select" => {
@@ -287,6 +288,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver,
+                    ..Default::default()
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/go.rs
+++ b/crates/codegraph-core/src/extractors/go.rs
@@ -204,6 +204,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "selector_expression" => {
@@ -215,6 +216,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver,
+                    ..Default::default()
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/groovy.rs
+++ b/crates/codegraph-core/src/extractors/groovy.rs
@@ -319,6 +319,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             line: start_line(node),
             dynamic: None,
             receiver,
+            ..Default::default()
         });
         return;
     }
@@ -348,6 +349,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                         line: start_line(node),
                         dynamic: None,
                         receiver: obj.map(|n| node_text(&n, source).to_string()),
+                        ..Default::default()
                     });
                 }
             }
@@ -357,6 +359,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
         }
@@ -376,6 +379,7 @@ fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             line: start_line(node),
             dynamic: None,
             receiver: None,
+            ..Default::default()
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/haskell.rs
+++ b/crates/codegraph-core/src/extractors/haskell.rs
@@ -296,6 +296,7 @@ fn handle_haskell_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         _ => {}

--- a/crates/codegraph-core/src/extractors/helpers.rs
+++ b/crates/codegraph-core/src/extractors/helpers.rs
@@ -822,6 +822,7 @@ pub fn push_call(
         line: start_line(node),
         dynamic,
         receiver,
+        ..Default::default()
     });
 }
 

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -2116,6 +2116,7 @@ fn extract_callback_reference_calls(call_node: &Node, source: &[u8], calls: &mut
                     line: call_line,
                     dynamic: Some(true),
                     receiver: None,
+                    ..Default::default()
                 });
             }
             "member_expression" if member_expr_args_allowed => {
@@ -2127,6 +2128,7 @@ fn extract_callback_reference_calls(call_node: &Node, source: &[u8], calls: &mut
                         line: call_line,
                         dynamic: Some(true),
                         receiver,
+                        ..Default::default()
                     });
                 }
             }
@@ -2215,6 +2217,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
             line: start_line(call_node),
             dynamic: None,
             receiver: None,
+            ..Default::default()
         }),
         "member_expression" => {
             let obj = fn_node.child_by_field_name("object");
@@ -2230,6 +2233,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                             line: start_line(call_node),
                             dynamic: Some(true),
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                     if obj.kind() == "member_expression" {
@@ -2239,6 +2243,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                                 line: start_line(call_node),
                                 dynamic: Some(true),
                                 receiver: None,
+                                ..Default::default()
                             });
                         }
                     }
@@ -2254,6 +2259,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                         line: start_line(call_node),
                         dynamic: Some(true),
                         receiver,
+                        ..Default::default()
                     });
                 }
             }
@@ -2264,6 +2270,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                 line: start_line(call_node),
                 dynamic: None,
                 receiver,
+                ..Default::default()
             })
         }
         "subscript_expression" => {
@@ -2280,6 +2287,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                             line: start_line(call_node),
                             dynamic: Some(true),
                             receiver,
+                            ..Default::default()
                         });
                     }
                 }
@@ -2712,6 +2720,7 @@ fn collect_this_call_and_bindings(node: &Node, source: &[u8], symbols: &mut File
             line: start_line(node),
             dynamic: None,
             receiver: None,
+            ..Default::default()
         });
         return;
     }

--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -319,6 +319,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                             line: start_line(node),
                             dynamic: None,
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                     "navigation_expression" => {
@@ -348,6 +349,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                             line: start_line(node),
                             dynamic: None,
                             receiver,
+                            ..Default::default()
                         });
                     }
                     _ => {
@@ -356,6 +358,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                             line: start_line(node),
                             dynamic: None,
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                 }

--- a/crates/codegraph-core/src/extractors/lua.rs
+++ b/crates/codegraph-core/src/extractors/lua.rs
@@ -120,6 +120,7 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
                     line: start_line(node),
                     dynamic: None,
                     receiver: table.map(|t| node_text(&t, source).to_string()),
+                    ..Default::default()
                 });
             }
         }
@@ -132,6 +133,7 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
                     line: start_line(node),
                     dynamic: None,
                     receiver: table.map(|t| node_text(&t, source).to_string()),
+                    ..Default::default()
                 });
             }
         }
@@ -141,6 +143,7 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
     }

--- a/crates/codegraph-core/src/extractors/ocaml.rs
+++ b/crates/codegraph-core/src/extractors/ocaml.rs
@@ -326,6 +326,7 @@ fn handle_ocaml_application(node: &Node, source: &[u8], symbols: &mut FileSymbol
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "field_get_expression" => {
@@ -341,6 +342,7 @@ fn handle_ocaml_application(node: &Node, source: &[u8], symbols: &mut FileSymbol
                     receiver: record.and_then(|r| {
                         if r.id() != f.id() { Some(node_text(&r, source).to_string()) } else { None }
                     }),
+                    ..Default::default()
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/php.rs
+++ b/crates/codegraph-core/src/extractors/php.rs
@@ -238,6 +238,7 @@ fn handle_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "qualified_name" => {
@@ -248,6 +249,7 @@ fn handle_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         _ => {}
@@ -263,6 +265,7 @@ fn handle_member_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             line: start_line(node),
             dynamic: None,
             receiver,
+            ..Default::default()
         });
     }
 }
@@ -276,6 +279,7 @@ fn handle_scoped_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             line: start_line(node),
             dynamic: None,
             receiver,
+            ..Default::default()
         });
     }
 }
@@ -290,6 +294,7 @@ fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         line: start_line(node),
         dynamic: None,
         receiver: None,
+        ..Default::default()
     });
 }
 

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -131,6 +131,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             line: start_line(node),
             dynamic: None,
             receiver,
+            ..Default::default()
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/ruby.rs
+++ b/crates/codegraph-core/src/extractors/ruby.rs
@@ -152,6 +152,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             line: start_line(node),
             dynamic: None,
             receiver,
+            ..Default::default()
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -190,6 +190,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
         "field_expression" => {
@@ -201,6 +202,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver,
+                    ..Default::default()
                 });
             }
         }
@@ -213,6 +215,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver,
+                    ..Default::default()
                 });
             }
         }
@@ -227,6 +230,7 @@ fn handle_macro_invocation(node: &Node, source: &[u8], symbols: &mut FileSymbols
             line: start_line(node),
             dynamic: None,
             receiver: None,
+            ..Default::default()
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/scala.rs
+++ b/crates/codegraph-core/src/extractors/scala.rs
@@ -303,6 +303,7 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
             "field_expression" => {
@@ -318,6 +319,7 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                     line: start_line(node),
                     dynamic: None,
                     receiver,
+                    ..Default::default()
                 });
             }
             _ => {
@@ -326,6 +328,7 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                     line: start_line(node),
                     dynamic: None,
                     receiver: None,
+                    ..Default::default()
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/swift.rs
+++ b/crates/codegraph-core/src/extractors/swift.rs
@@ -295,6 +295,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                             line: start_line(node),
                             dynamic: None,
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                     "navigation_expression" => {
@@ -322,6 +323,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                             line: start_line(node),
                             dynamic: None,
                             receiver,
+                            ..Default::default()
                         });
                     }
                     _ => {
@@ -330,6 +332,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                             line: start_line(node),
                             dynamic: None,
                             receiver: None,
+                            ..Default::default()
                         });
                     }
                 }

--- a/crates/codegraph-core/src/extractors/verilog.rs
+++ b/crates/codegraph-core/src/extractors/verilog.rs
@@ -241,6 +241,7 @@ fn handle_module_instantiation(node: &Node, source: &[u8], symbols: &mut FileSym
         line: start_line(node),
         dynamic: None,
         receiver: None,
+        ..Default::default()
     });
 }
 

--- a/crates/codegraph-core/src/extractors/zig.rs
+++ b/crates/codegraph-core/src/extractors/zig.rs
@@ -188,6 +188,7 @@ fn handle_zig_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     line: start_line(node),
                     dynamic: None,
                     receiver: value.map(|v| node_text(&v, source).to_string()),
+                    ..Default::default()
                 });
             }
         }
@@ -197,6 +198,7 @@ fn handle_zig_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 line: start_line(node),
                 dynamic: None,
                 receiver: None,
+                ..Default::default()
             });
         }
     }
@@ -233,6 +235,7 @@ fn handle_zig_builtin(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         line: start_line(node),
         dynamic: None,
         receiver: None,
+        ..Default::default()
     });
 }
 

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -102,12 +102,16 @@ pub struct Definition {
 }
 
 #[napi(object)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Call {
     pub name: String,
     pub line: u32,
     pub dynamic: Option<bool>,
     pub receiver: Option<String>,
+    #[napi(js_name = "dynamicKind")]
+    pub dynamic_kind: Option<String>,
+    #[napi(js_name = "keyExpr")]
+    pub key_expr: Option<String>,
 }
 
 #[napi(object)]

--- a/src/cli/commands/roles.ts
+++ b/src/cli/commands/roles.ts
@@ -1,6 +1,6 @@
 import { collectFile } from '../../db/query-builder.js';
 import { VALID_ROLES } from '../../domain/queries.js';
-import { roles } from '../../presentation/queries-cli.js';
+import { dynamicCalls, roles } from '../../presentation/queries-cli.js';
 import type { CommandDefinition } from '../types.js';
 
 export const command: CommandDefinition = {
@@ -17,6 +17,7 @@ export const command: CommandDefinition = {
     ['-n, --limit <number>', 'Max results to return'],
     ['--offset <number>', 'Skip N results (default: 0)'],
     ['--ndjson', 'Newline-delimited JSON output'],
+    ['--dynamic', 'Show flagged dynamic call sites instead of symbol roles'],
   ],
   validate(_args, opts) {
     if (opts.role && !(VALID_ROLES as readonly string[]).includes(opts.role)) {
@@ -24,6 +25,10 @@ export const command: CommandDefinition = {
     }
   },
   execute(_args, opts, ctx) {
+    if (opts.dynamic) {
+      dynamicCalls(opts.db, ctx.resolveQueryOpts(opts));
+      return;
+    }
     roles(opts.db, {
       role: opts.role,
       file: opts.file,

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -328,7 +328,7 @@ export const MIGRATIONS: Migration[] = [
     version: 20,
     up: `
       ALTER TABLE edges ADD COLUMN dynamic_kind TEXT;
-      CREATE INDEX IF NOT EXISTS idx_edges_dynamic_kind ON edges(dynamic_kind);
+      CREATE INDEX IF NOT EXISTS idx_edges_dynamic_kind ON edges(dynamic_kind) WHERE dynamic_kind IS NOT NULL;
     `,
   },
 ];

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -324,6 +324,13 @@ export const MIGRATIONS: Migration[] = [
     // dataflow_vertices and dataflow_summary on the next `codegraph build`.
     up: `SELECT 1`,
   },
+  {
+    version: 20,
+    up: `
+      ALTER TABLE edges ADD COLUMN dynamic_kind TEXT;
+      CREATE INDEX IF NOT EXISTS idx_edges_dynamic_kind ON edges(dynamic_kind);
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {

--- a/src/domain/analysis/roles.ts
+++ b/src/domain/analysis/roles.ts
@@ -6,6 +6,29 @@ import { normalizeSymbol } from '../../shared/normalize.js';
 import { paginateResult } from '../../shared/paginate.js';
 import type { NodeRow } from '../../types.js';
 
+export interface DynamicCallCount {
+  dynamic_kind: string;
+  count: number;
+}
+
+/** Return a count of flagged dynamic call sink edges, grouped by kind. */
+export function dynamicCallsData(customDbPath: string): DynamicCallCount[] {
+  const db = openReadonlyOrFail(customDbPath);
+  try {
+    return db
+      .prepare(
+        `SELECT dynamic_kind, COUNT(*) AS count
+         FROM edges
+         WHERE dynamic_kind IS NOT NULL
+         GROUP BY dynamic_kind
+         ORDER BY count DESC`,
+      )
+      .all() as DynamicCallCount[];
+  } finally {
+    db.close();
+  }
+}
+
 export function rolesData(
   customDbPath: string,
   opts: {

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -193,6 +193,12 @@ export function resolveCallTargets(
   typeMap: Map<string, unknown>,
   callerName?: string | null,
 ): { targets: Array<{ id: number; file: string }>; importedFrom: string | undefined } {
+  // Flagged dynamic calls use synthetic names like '<dynamic:eval>'. Short-circuit
+  // so they never accidentally match a real symbol via lookup.byName.
+  if (call.name.startsWith('<dynamic:')) {
+    return { targets: [], importedFrom: undefined };
+  }
+
   const importedFrom = importedNames.get(call.name);
   let targets: ReadonlyArray<{ id: number; file: string }> | undefined;
 

--- a/src/domain/graph/builder/context.ts
+++ b/src/domain/graph/builder/context.ts
@@ -91,6 +91,7 @@ export class PipelineContext {
     confidence: number;
     dynamic: number;
     technique: string | null;
+    dynamicKind: string | null;
   }> = [];
 
   // ── Misc state ─────────────────────────────────────────────────────

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -320,9 +320,9 @@ function getEdgeStmt(db: BetterSqlite3Database, chunkSize: number): SqliteStatem
   }
   let stmt = cache.get(chunkSize);
   if (!stmt) {
-    const ph = '(?,?,?,?,?,?)';
+    const ph = '(?,?,?,?,?,?,?)';
     stmt = db.prepare(
-      'INSERT INTO edges (source_id,target_id,kind,confidence,dynamic,technique) VALUES ' +
+      'INSERT INTO edges (source_id,target_id,kind,confidence,dynamic,technique,dynamic_kind) VALUES ' +
         Array.from({ length: chunkSize }, () => ph).join(','),
     );
     cache.set(chunkSize, stmt);
@@ -351,7 +351,7 @@ export function batchInsertNodes(db: BetterSqlite3Database, rows: unknown[][]): 
 
 /**
  * Batch-insert edge rows via multi-value INSERT statements.
- * Each row: [source_id, target_id, kind, confidence, dynamic, technique]
+ * Each row: [source_id, target_id, kind, confidence, dynamic, technique, dynamic_kind]
  */
 export function batchInsertEdges(db: BetterSqlite3Database, rows: unknown[][]): void {
   if (!rows.length) return;
@@ -362,7 +362,7 @@ export function batchInsertEdges(db: BetterSqlite3Database, rows: unknown[][]): 
     const vals: unknown[] = [];
     for (let j = i; j < end; j++) {
       const r = rows[j] as unknown[];
-      vals.push(r[0], r[1], r[2], r[3], r[4], r[5] ?? null);
+      vals.push(r[0], r[1], r[2], r[3], r[4], r[5] ?? null, r[6] ?? null);
     }
     stmt.run(...vals);
   }

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1646,11 +1646,13 @@ function applyEdgeTechniquesAfterNativeInsert(
       ).run(...chunk);
     }
     // Back-fill dynamic_kind for flagged sink edges emitted by the native engine.
+    // Include dynamic_kind in the WHERE clause so two sink edges from the same caller
+    // to the same file node with different kinds don't clobber each other.
     if (dynamicKindRows.length > 0) {
       const stmt = db.prepare(
-        "UPDATE edges SET dynamic_kind = ? WHERE kind = 'calls' AND source_id = ? AND target_id = ? AND dynamic_kind IS NULL",
+        "UPDATE edges SET dynamic_kind = ? WHERE kind = 'calls' AND source_id = ? AND target_id = ? AND (dynamic_kind IS NULL OR dynamic_kind = ?)",
       );
-      for (const r of dynamicKindRows) stmt.run(r[6], r[0], r[1]);
+      for (const r of dynamicKindRows) stmt.run(r[6], r[0], r[1], r[6]);
     }
   });
   tx();

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -18,6 +18,7 @@ import type {
   Call,
   ClassRelation,
   Definition,
+  DynamicKind,
   ExtractorOutput,
   FnRefBinding,
   ForOfBinding,
@@ -56,7 +57,8 @@ import { getResolved, isBarrelFile, resolveBarrelExportCached } from './resolve-
 
 // ── Local types ──────────────────────────────────────────────────────────
 
-type EdgeRowTuple = [number, number, string, number, number, string | null];
+type EdgeRowTuple = [number, number, string, number, number, string | null, string | null];
+//                   src    tgt    kind   conf   dyn   technique             dynamic_kind
 
 interface NodeIdStmt {
   get(name: string, kind: string, file: string, line: number): { id: number } | undefined;
@@ -105,6 +107,7 @@ interface NativeEdge {
   kind: string;
   confidence: number;
   dynamic: number;
+  dynamic_kind?: string | null;
 }
 
 // ── Node lookup setup ───────────────────────────────────────────────────
@@ -163,7 +166,7 @@ function emitTypeOnlySymbolEdges(
     }
     const candidates = ctx.nodesByNameAndFile.get(`${cleanName}|${targetFile}`);
     if (candidates && candidates.length > 0) {
-      allEdgeRows.push([fileNodeId, candidates[0]!.id, 'imports-type', 1.0, 0, null]);
+      allEdgeRows.push([fileNodeId, candidates[0]!.id, 'imports-type', 1.0, 0, null, null]);
     }
   }
 }
@@ -185,7 +188,7 @@ function emitEdgesForImport(
   if (!targetRow) return;
 
   const edgeKind = importEdgeKind(imp);
-  allEdgeRows.push([fileNodeId, targetRow.id, edgeKind, 1.0, 0, null]);
+  allEdgeRows.push([fileNodeId, targetRow.id, edgeKind, 1.0, 0, null, null]);
 
   if (imp.typeOnly) {
     emitTypeOnlySymbolEdges(ctx, imp, resolvedPath, fileNodeId, allEdgeRows);
@@ -240,7 +243,7 @@ function buildBarrelEdges(
             : edgeKind === 'dynamic-imports'
               ? 'dynamic-imports'
               : 'imports';
-        edgeRows.push([fileNodeId, actualRow.id, kind, 0.9, 0, null]);
+        edgeRows.push([fileNodeId, actualRow.id, kind, 0.9, 0, null, null]);
       }
     }
   }
@@ -423,7 +426,7 @@ function buildImportEdgesNative(
   ) as NativeEdge[];
 
   for (const e of nativeEdges) {
-    allEdgeRows.push([e.sourceId, e.targetId, e.kind, e.confidence, e.dynamic, null]);
+    allEdgeRows.push([e.sourceId, e.targetId, e.kind, e.confidence, e.dynamic, null, null]);
   }
 }
 
@@ -577,6 +580,7 @@ function buildCallEdgesNative(
       e.confidence,
       e.dynamic,
       e.kind === 'calls' ? 'ts-native' : null,
+      e.dynamic_kind ?? null,
     ]);
   }
 }
@@ -661,7 +665,7 @@ function buildDefinePropertyPostPass(
           const conf = computeConfidence(relPath, t.file, null);
           if (conf > 0) {
             seenByPair.add(edgeKey);
-            allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'ts-native']);
+            allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'ts-native', null]);
           }
         }
       }
@@ -751,7 +755,7 @@ function buildChaPostPass(
             // Tag super-dispatch edges distinctly so runChaPostPass can exclude them
             // from further CHA expansion (super calls are not virtual dispatch).
             const technique = call.receiver === 'super' ? 'super-dispatch' : 'cha';
-            allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, technique]);
+            allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, technique, null]);
           }
         }
       }
@@ -1161,7 +1165,7 @@ function emitDirectCallEdgesForCall(
       seenCallEdges.add(edgeKey);
     } else {
       seenCallEdges.add(edgeKey);
-      allEdgeRows.push([caller.id, t.id, 'calls', confidence, isDynamic, 'ts-native']);
+      allEdgeRows.push([caller.id, t.id, 'calls', confidence, isDynamic, 'ts-native', null]);
     }
   }
 }
@@ -1255,7 +1259,7 @@ function emitPtsNoReceiverEdges(
           computeConfidence(relPath, t.file, aliasFrom ?? null) - PROPAGATION_HOP_PENALTY;
         if (conf > 0) {
           ptsEdgeRows.set(edgeKey, allEdgeRows.length);
-          allEdgeRows.push([caller.id, t.id, 'calls', conf, isDynamic, 'points-to']);
+          allEdgeRows.push([caller.id, t.id, 'calls', conf, isDynamic, 'points-to', null]);
         }
       }
     }
@@ -1309,7 +1313,7 @@ function emitPtsReceiverEdges(
           computeConfidence(relPath, t.file, aliasFrom ?? null) - PROPAGATION_HOP_PENALTY;
         if (conf > 0) {
           ptsEdgeRows.set(edgeKey, allEdgeRows.length);
-          allEdgeRows.push([caller.id, t.id, 'calls', conf, isDynamic, 'points-to']);
+          allEdgeRows.push([caller.id, t.id, 'calls', conf, isDynamic, 'points-to', null]);
         }
       }
     }
@@ -1370,11 +1374,22 @@ function emitChaCallEdgesForCall(
         : computeConfidence(relPath, t.file, null) - CHA_DISPATCH_PENALTY;
       if (conf > 0) {
         seenCallEdges.add(edgeKey);
-        allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'cha']);
+        allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'cha', null]);
       }
     }
   }
 }
+
+/**
+ * Dynamic kinds that can never be resolved statically — emit a sink edge to the
+ * file node instead of silently dropping the call site.  confidence=0.0 keeps
+ * these below DEFAULT_MIN_CONFIDENCE so they never appear in normal query results.
+ */
+const FLAG_ONLY_KINDS: ReadonlySet<DynamicKind> = new Set([
+  'eval',
+  'computed-key',
+  'unresolved-dynamic',
+]);
 
 /**
  * Build call edges for all calls in a single file (WASM/JS engine path).
@@ -1387,6 +1402,7 @@ function emitChaCallEdgesForCall(
  *   4. `emitPtsReceiverEdges`    — Phase 8.3f pts fallback for rest-param receiver calls
  *   5. Inline `resolveReceiverEdge` — emit `receiver` edge for external receivers
  *   6. `emitChaCallEdgesForCall` — Phase 8.5 CHA + RTA dispatch expansion
+ *   7. Sink edge for flag-only dynamic kinds (eval, computed-key, unresolved-dynamic)
  */
 function buildFileCallEdges(
   relPath: string,
@@ -1503,7 +1519,15 @@ function buildFileCallEdges(
         importedNames,
       );
       if (recv) {
-        allEdgeRows.push([recv.callerId, recv.receiverId, 'receiver', recv.confidence, 0, null]);
+        allEdgeRows.push([
+          recv.callerId,
+          recv.receiverId,
+          'receiver',
+          recv.confidence,
+          0,
+          null,
+          null,
+        ]);
       }
     }
 
@@ -1520,6 +1544,18 @@ function buildFileCallEdges(
         ptsEdgeRows,
         allEdgeRows,
       );
+    }
+
+    // Step 7: Flag-only dynamic kinds with no resolved target → sink edge to the
+    // file node.  confidence=0.0 keeps it below DEFAULT_MIN_CONFIDENCE so it never
+    // appears in normal query results, but is queryable via `codegraph roles --dynamic`.
+    if (targets.length === 0 && call.dynamicKind && FLAG_ONLY_KINDS.has(call.dynamicKind)) {
+      // Key per (caller, file, kind) so each kind gets at most one sink edge per caller.
+      const sinkKey = `${caller.id}:${fileNodeRow.id}:${call.dynamicKind}`;
+      if (!seenCallEdges.has(sinkKey)) {
+        seenCallEdges.add(sinkKey);
+        allEdgeRows.push([caller.id, fileNodeRow.id, 'calls', 0.0, 1, null, call.dynamicKind]);
+      }
     }
   }
 }
@@ -1546,7 +1582,7 @@ function buildClassHierarchyEdges(
       );
       if (sourceRow) {
         for (const t of targetRows) {
-          allEdgeRows.push([sourceRow.id, t.id, 'extends', 1.0, 0, null]);
+          allEdgeRows.push([sourceRow.id, t.id, 'extends', 1.0, 0, null, null]);
         }
       }
     }
@@ -1560,7 +1596,7 @@ function buildClassHierarchyEdges(
       );
       if (sourceRow) {
         for (const t of targetRows) {
-          allEdgeRows.push([sourceRow.id, t.id, 'implements', 1.0, 0, null]);
+          allEdgeRows.push([sourceRow.id, t.id, 'implements', 1.0, 0, null, null]);
         }
       }
     }
@@ -1592,6 +1628,9 @@ function applyEdgeTechniquesAfterNativeInsert(
   // Chunk to stay within SQLite's SQLITE_LIMIT_VARIABLE_NUMBER (999 on older builds).
   const CHUNK_SIZE = 500;
 
+  // Rows that carry an explicit dynamic_kind (sink edges for flagged dynamic calls).
+  const dynamicKindRows = callRows.filter((r) => r[6] != null);
+
   const tx = db.transaction(() => {
     if (taggedRows.length > 0) {
       const stmt = db.prepare(
@@ -1605,6 +1644,13 @@ function applyEdgeTechniquesAfterNativeInsert(
       db.prepare(
         `UPDATE edges SET technique = 'ts-native' WHERE kind = 'calls' AND technique IS NULL AND source_id IN (${placeholders})`,
       ).run(...chunk);
+    }
+    // Back-fill dynamic_kind for flagged sink edges emitted by the native engine.
+    if (dynamicKindRows.length > 0) {
+      const stmt = db.prepare(
+        "UPDATE edges SET dynamic_kind = ? WHERE kind = 'calls' AND source_id = ? AND target_id = ? AND dynamic_kind IS NULL",
+      );
+      for (const r of dynamicKindRows) stmt.run(r[6], r[0], r[1]);
     }
   });
   tx();
@@ -1643,6 +1689,7 @@ function reconnectReverseDepEdges(ctx: PipelineContext): void {
         saved.confidence,
         saved.dynamic,
         saved.technique,
+        saved.dynamicKind ?? null,
       ]);
     } else {
       // Target was removed or renamed in the changed file — edge is stale

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -413,7 +413,7 @@ function purgeAndAddReverseDeps(
         const saveEdgesStmt = db.prepare(`
           SELECT e.source_id, n_tgt.name AS tgt_name, n_tgt.kind AS tgt_kind,
                  n_tgt.file AS tgt_file, n_tgt.line AS tgt_line,
-                 e.kind AS edge_kind, e.confidence, e.dynamic, e.technique,
+                 e.kind AS edge_kind, e.confidence, e.dynamic, e.technique, e.dynamic_kind,
                  n_src.file AS src_file
           FROM edges e
           JOIN nodes n_src ON e.source_id = n_src.id
@@ -431,6 +431,7 @@ function purgeAndAddReverseDeps(
             confidence: number;
             dynamic: number;
             technique: string | null;
+            dynamic_kind: string | null;
             src_file: string;
           }>) {
             // Skip edges whose source is also being purged — buildEdges will
@@ -446,6 +447,7 @@ function purgeAndAddReverseDeps(
               confidence: row.confidence,
               dynamic: row.dynamic,
               technique: row.technique,
+              dynamicKind: row.dynamic_kind,
             });
           }
         }

--- a/src/domain/queries.ts
+++ b/src/domain/queries.ts
@@ -39,7 +39,7 @@ export {
   moduleMapData,
   statsData,
 } from './analysis/module-map.js';
-export { rolesData } from './analysis/roles.js';
+export { dynamicCallsData, rolesData } from './analysis/roles.js';
 // ── Analysis modules ─────────────────────────────────────────────────────
 export {
   childrenData,

--- a/src/extractors/helpers.ts
+++ b/src/extractors/helpers.ts
@@ -1,5 +1,6 @@
 import type {
   Call,
+  DynamicKind,
   ExtractorOutput,
   Import,
   SubDeclaration,
@@ -270,18 +271,20 @@ export function extractModifierVisibility(
 
 /**
  * Append a `Call` to the extractor output. `line` defaults to the start line of
- * `node`; pass `extra` for `receiver` / `dynamic` flags.
+ * `node`; pass `extra` for `receiver` / `dynamic` / `dynamicKind` / `keyExpr` fields.
  */
 export function pushCall(
   ctx: ExtractorOutput,
   node: TreeSitterNode,
   name: string,
-  extra: { receiver?: string; dynamic?: boolean } = {},
+  extra: { receiver?: string; dynamic?: boolean; dynamicKind?: DynamicKind; keyExpr?: string } = {},
 ): void {
   if (!name) return;
   const call: Call = { name, line: nodeStartLine(node) };
   if (extra.receiver !== undefined) call.receiver = extra.receiver;
   if (extra.dynamic !== undefined) call.dynamic = extra.dynamic;
+  if (extra.dynamicKind !== undefined) call.dynamicKind = extra.dynamicKind;
+  if (extra.keyExpr !== undefined) call.keyExpr = extra.keyExpr;
   ctx.calls.push(call);
 }
 

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -312,10 +312,9 @@ function dispatchQueryMatch(
   } else if (c.exp_node) {
     handleExportCapture(c, exps, imports);
   } else if (c.callfn_node) {
-    calls.push({
-      name: c.callfn_name!.text,
-      line: nodeStartLine(c.callfn_node),
-    });
+    // Route through extractCallInfo so special identifier calls (eval) get classified.
+    const callfnInfo = extractCallInfo(c.callfn_name!, c.callfn_node);
+    if (callfnInfo) calls.push(callfnInfo);
     calls.push(...extractCallbackReferenceCalls(c.callfn_node));
   } else if (c.callmem_node) {
     const callInfo = extractCallInfo(c.callmem_fn!, c.callmem_node);
@@ -328,10 +327,20 @@ function dispatchQueryMatch(
     if (callInfo) calls.push(callInfo);
     calls.push(...extractCallbackReferenceCalls(c.callsub_node));
   } else if (c.newfn_node) {
-    calls.push({
-      name: c.newfn_name!.text,
-      line: nodeStartLine(c.newfn_node),
-    });
+    if (c.newfn_name!.text === 'Function') {
+      // new Function(body) — dynamic code execution; classify as eval kind
+      calls.push({
+        name: '<dynamic:eval>',
+        line: nodeStartLine(c.newfn_node),
+        dynamic: true,
+        dynamicKind: 'eval',
+      });
+    } else {
+      calls.push({
+        name: c.newfn_name!.text,
+        line: nodeStartLine(c.newfn_node),
+      });
+    }
   } else if (c.newmem_node) {
     const callInfo = extractCallInfo(c.newmem_fn!, c.newmem_node);
     if (callInfo) calls.push(callInfo);

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -6,6 +6,7 @@ import type {
   CallAssignment,
   ClassRelation,
   Definition,
+  DynamicKind,
   Export,
   ExtractorOutput,
   FnRefBinding,
@@ -1261,7 +1262,17 @@ function handleNewExpr(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const ctor = node.childForFieldName('constructor') || node.child(1);
   if (!ctor) return;
   if (ctor.type === 'identifier') {
-    ctx.calls.push({ name: ctor.text, line: nodeStartLine(node) });
+    if (ctor.text === 'Function') {
+      // new Function(body) — dynamic code execution; undecidable static target
+      ctx.calls.push({
+        name: '<dynamic:eval>',
+        line: nodeStartLine(node),
+        dynamic: true,
+        dynamicKind: 'eval' as DynamicKind,
+      });
+    } else {
+      ctx.calls.push({ name: ctor.text, line: nodeStartLine(node) });
+    }
   } else if (ctor.type === 'member_expression') {
     const callInfo = extractCallInfo(ctor, node);
     if (callInfo) ctx.calls.push(callInfo);
@@ -2839,6 +2850,28 @@ function extractReceiverName(objNode: TreeSitterNode | null): string | undefined
 function extractCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode): Call | null {
   const fnType = fn.type;
   if (fnType === 'identifier') {
+    if (fn.text === 'eval') {
+      // eval(code) — dynamic code execution; capture first arg if it's a string literal
+      const args = callNode.childForFieldName('arguments') || findChild(callNode, 'arguments');
+      let keyExpr: string | undefined;
+      if (args) {
+        for (let i = 0; i < args.childCount; i++) {
+          const child = args.child(i);
+          if (!child) continue;
+          const t = child.type;
+          if (t === '(' || t === ')' || t === ',') continue;
+          if (t === 'string' || t === 'template_string') keyExpr = child.text;
+          break;
+        }
+      }
+      return {
+        name: '<dynamic:eval>',
+        line: nodeStartLine(callNode),
+        dynamic: true,
+        dynamicKind: 'eval',
+        keyExpr,
+      };
+    }
     return { name: fn.text, line: nodeStartLine(callNode) };
   }
   if (fnType === 'member_expression') {
@@ -2859,22 +2892,30 @@ function extractMemberExprCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode)
   const callLine = nodeStartLine(callNode);
   const propText = prop.text;
 
-  // .call()/.apply()/.bind() — dynamic invocation
+  // .call()/.apply()/.bind() — this-rebinding; target is statically known
   if (propText === 'call' || propText === 'apply' || propText === 'bind') {
-    if (obj && obj.type === 'identifier') return { name: obj.text, line: callLine, dynamic: true };
+    if (obj && obj.type === 'identifier')
+      return { name: obj.text, line: callLine, dynamic: true, dynamicKind: 'reflection' };
     if (obj && obj.type === 'member_expression') {
       const innerProp = obj.childForFieldName('property');
-      if (innerProp) return { name: innerProp.text, line: callLine, dynamic: true };
+      if (innerProp)
+        return { name: innerProp.text, line: callLine, dynamic: true, dynamicKind: 'reflection' };
     }
   }
 
-  // Computed property: obj["method"]()
+  // Computed string property: obj["method"]() — target is a literal; resolvable
   const propType = prop.type;
   if (propType === 'string' || propType === 'string_fragment') {
     const methodName = propText.replace(/['"]/g, '');
     if (methodName) {
       const receiver = extractReceiverName(obj);
-      return { name: methodName, line: callLine, dynamic: true, receiver };
+      return {
+        name: methodName,
+        line: callLine,
+        dynamic: true,
+        dynamicKind: 'computed-literal',
+        receiver,
+      };
     }
   }
 
@@ -2882,7 +2923,7 @@ function extractMemberExprCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode)
   return { name: propText, line: callLine, receiver };
 }
 
-/** Extract call info from a subscript_expression function node (obj["method"]()). */
+/** Extract call info from a subscript_expression function node (obj[key]()). */
 function extractSubscriptCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode): Call | null {
   const obj = fn.childForFieldName('object');
   const index = fn.childForFieldName('index');
@@ -2897,11 +2938,32 @@ function extractSubscriptCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode):
         name: methodName,
         line: nodeStartLine(callNode),
         dynamic: true,
+        dynamicKind: 'computed-literal',
         receiver,
       };
     }
   }
-  return null;
+
+  // obj[variable]() — key is a variable; may be resolvable via pts (RES-1), else flagged
+  if (indexType === 'identifier') {
+    const receiver = extractReceiverName(obj);
+    return {
+      name: '<dynamic:computed-key>',
+      line: nodeStartLine(callNode),
+      dynamic: true,
+      dynamicKind: 'computed-key',
+      keyExpr: index.text,
+      receiver,
+    };
+  }
+
+  // Any other index expression (binary, call, template with ${}…) — not statically resolvable
+  return {
+    name: '<dynamic:unresolved>',
+    line: nodeStartLine(callNode),
+    dynamic: true,
+    dynamicKind: 'unresolved-dynamic',
+  };
 }
 
 /**

--- a/src/presentation/queries-cli.ts
+++ b/src/presentation/queries-cli.ts
@@ -12,6 +12,7 @@ export {
   children,
   context,
   diffImpact,
+  dynamicCalls,
   explain,
   fileDeps,
   fileExports,

--- a/src/presentation/queries-cli/index.ts
+++ b/src/presentation/queries-cli/index.ts
@@ -9,5 +9,5 @@ export {
   queryName,
   where,
 } from './inspect.js';
-export { moduleMap, roles, stats } from './overview.js';
+export { dynamicCalls, moduleMap, roles, stats } from './overview.js';
 export { symbolPath } from './path.js';

--- a/src/presentation/queries-cli/overview.ts
+++ b/src/presentation/queries-cli/overview.ts
@@ -1,5 +1,11 @@
 import path from 'node:path';
-import { kindIcon, moduleMapData, rolesData, statsData } from '../../domain/queries.js';
+import {
+  dynamicCallsData,
+  kindIcon,
+  moduleMapData,
+  rolesData,
+  statsData,
+} from '../../domain/queries.js';
 import { debug } from '../../infrastructure/logger.js';
 import { outputResult } from '../../infrastructure/result-formatter.js';
 import { toErrorMessage } from '../../shared/errors.js';
@@ -315,6 +321,34 @@ function printRoleGroup(role: string, symbols: RoleSymbol[]): void {
     console.log(`  ... and ${symbols.length - 30} more`);
   }
   console.log();
+}
+
+export function dynamicCalls(customDbPath: string, opts: OutputOpts = {}): void {
+  const rows = dynamicCallsData(customDbPath);
+  if (opts.json || opts.ndjson) {
+    outputResult(
+      { dynamic_calls: rows } as unknown as Record<string, unknown>,
+      'dynamic_calls',
+      opts,
+    );
+    return;
+  }
+  if (rows.length === 0) {
+    console.log(
+      'No flagged dynamic calls found. Run "codegraph build" first, or add JavaScript files with eval/computed-key patterns.',
+    );
+    return;
+  }
+  console.log('\nFlagged dynamic calls (confidence=0.0 sink edges):\n');
+  const total = rows.reduce((s, r) => s + r.count, 0);
+  for (const { dynamic_kind, count } of rows) {
+    const bar = '█'.repeat(Math.min(30, Math.round((count / total) * 30)));
+    console.log(`  ${dynamic_kind.padEnd(20)} ${String(count).padStart(5)}  ${bar}`);
+  }
+  console.log(`\n  Total flagged: ${total}\n`);
+  console.log(
+    '  Kinds: eval — undecidable; computed-key — obj[var](); unresolved-dynamic — other\n',
+  );
 }
 
 export function roles(customDbPath: string, opts: OutputOpts = {}): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,6 +186,7 @@ export interface EdgeRow {
   kind: EdgeKind;
   confidence: number | null;
   dynamic: 0 | 1;
+  dynamic_kind?: string | null;
 }
 
 /** Callee/caller node shape (from findCallees / findCallers). */
@@ -475,12 +476,27 @@ export interface LOCMetrics {
   commentLines: number;
 }
 
+/**
+ * Taxonomy for dynamic/computed call sites — distinguishes resolvable kinds
+ * (computed-literal, reflection) from flag-only kinds (eval, computed-key,
+ * unresolved-dynamic) that cannot be resolved statically.
+ */
+export type DynamicKind =
+  | 'computed-literal' // obj["foo"]()    — resolvable; already emitted as normal edge
+  | 'computed-key' // obj[k]()        — potentially resolvable via pts; else flagged
+  | 'reflection' // .call/.apply/.bind — usually resolved; flagged if target unknown
+  | 'eval' // eval() / new Function() — undecidable; always flagged
+  | 'unresolved-dynamic'; // any other detected dynamic pattern; flagged
+
 /** A function/method call detected by an extractor. */
 export interface Call {
   name: string;
   line: number;
   receiver?: string;
   dynamic?: boolean;
+  dynamicKind?: DynamicKind;
+  /** Raw key/arg text — used for diagnostics and future RES-1 const-string resolution. */
+  keyExpr?: string;
 }
 
 /** An import statement detected by an extractor. */

--- a/tests/benchmarks/resolution/fixtures/dynamic-javascript/dispatch.js
+++ b/tests/benchmarks/resolution/fixtures/dynamic-javascript/dispatch.js
@@ -1,0 +1,21 @@
+// Fixture: computed property dispatch patterns
+// Resolvable: obj["method"]() — computed-literal kind
+// Flagged:    obj[key]()      — computed-key kind (sink edge, not in expected-edges)
+
+export function greet(name) {
+  return `Hello, ${name}`;
+}
+
+export function farewell(name) {
+  return `Goodbye, ${name}`;
+}
+
+export function runComputedLiteral(obj) {
+  // obj["greet"]() — computed-literal: resolvable to greet()
+  return obj['greet']('world');
+}
+
+export function runComputedKey(handlers, key) {
+  // handlers[key]() — computed-key: flagged as sink edge
+  return handlers[key]('world');
+}

--- a/tests/benchmarks/resolution/fixtures/dynamic-javascript/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/dynamic-javascript/expected-edges.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../expected-edges.schema.json",
+  "language": "javascript",
+  "description": "Dynamic call resolution fixture: computed-literal and reflection patterns. Flagged kinds (eval, computed-key) emit sink edges and are excluded from expected-edges.",
+  "edges": [
+    {
+      "source": { "name": "runCall", "file": "reflection.js" },
+      "target": { "name": "greet", "file": "reflection.js" },
+      "kind": "calls",
+      "mode": "dynamic",
+      "notes": "greet.call(ctx, 'world') — reflection kind, resolves to greet()"
+    },
+    {
+      "source": { "name": "runApply", "file": "reflection.js" },
+      "target": { "name": "greet", "file": "reflection.js" },
+      "kind": "calls",
+      "mode": "dynamic",
+      "notes": "greet.apply(ctx, ['world']) — reflection kind, resolves to greet()"
+    },
+    {
+      "source": { "name": "runInvokerCall", "file": "reflection.js" },
+      "target": { "name": "invoker", "file": "reflection.js" },
+      "kind": "calls",
+      "mode": "dynamic",
+      "notes": "invoker.call(handler, 10) — reflection kind, resolves to invoker()"
+    },
+    {
+      "source": { "name": "runComputedLiteral", "file": "dispatch.js" },
+      "target": { "name": "greet", "file": "dispatch.js" },
+      "kind": "calls",
+      "mode": "dynamic",
+      "notes": "obj[\"greet\"](\"world\") — computed-literal kind, resolves to greet()"
+    }
+  ]
+}

--- a/tests/benchmarks/resolution/fixtures/dynamic-javascript/reflection.js
+++ b/tests/benchmarks/resolution/fixtures/dynamic-javascript/reflection.js
@@ -1,0 +1,25 @@
+// Fixture: .call/.apply/.bind reflection patterns
+// Resolved as: reflection kind, dynamic=true
+
+export function greet(name) {
+  return `Hello, ${name}`;
+}
+
+export function invoker(ctx, arg) {
+  return `${ctx}: ${arg}`;
+}
+
+export function runCall(ctx) {
+  // greet.call(ctx, "world") — reflection: resolves to greet()
+  return greet.call(ctx, 'world');
+}
+
+export function runApply(ctx) {
+  // greet.apply(ctx, ["world"]) — reflection: resolves to greet()
+  return greet.apply(ctx, ['world']);
+}
+
+export function runInvokerCall(handler, ctx) {
+  // invoker.call(handler, 10) — reflection: resolves to invoker()
+  return invoker.call(handler, 10);
+}

--- a/tests/benchmarks/resolution/fixtures/dynamic-javascript/unsafe.js
+++ b/tests/benchmarks/resolution/fixtures/dynamic-javascript/unsafe.js
@@ -1,0 +1,13 @@
+// Fixture: eval/new Function patterns — flagged, not in expected-edges
+// These emit sink edges (confidence=0.0) visible via `codegraph roles --dynamic`
+
+export function runEval(code) {
+  // eval(code) — flagged as eval kind
+  return eval(code);
+}
+
+export function runNewFunction(body) {
+  // new Function(body) — flagged as eval kind
+  const fn = new Function(body);
+  return fn();
+}

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -136,6 +136,9 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   //   too broad for the main JS fixture. Patterns split per file to prevent intra-fixture FPs.
   //   Currently resolves all 13 expected edges (100% recall, 100% precision).
   'pts-javascript': { precision: 1.0, recall: 0.9 },
+  // dynamic-javascript: Phase 0 dynamic-call fixture — reflection (.call/.apply) + computed-literal.
+  //   Flagged kinds (eval, computed-key) emit sink edges (confidence=0.0) excluded from metrics.
+  'dynamic-javascript': { precision: 1.0, recall: 0.75 },
   // TS 0.72: Phase 8.3e adds this.method() same-class resolution (Shape.describe → Shape.area),
   //   lifting recall from 69.4% to 72.2%.  Remaining gap (interface-dispatch, CHA) is tracked
   //   in Phase 8.5 (TSC enrichment) and Phase 8.7 (CHA on JS/TS).
@@ -246,8 +249,31 @@ function extractResolvedEdges(fixtureDir: string) {
       JOIN nodes tgt ON e.target_id = tgt.id
       WHERE e.kind = 'calls'
         AND src.kind IN ('function', 'method')
+        AND (e.confidence IS NULL OR e.confidence > 0)
     `)
       .all();
+  } finally {
+    db.close();
+  }
+}
+
+/** Count flagged dynamic call sink edges (confidence=0, dynamic_kind IS NOT NULL) per kind. */
+function extractFlaggedDynamicCalls(fixtureDir: string): Record<string, number> {
+  const dbPath = path.join(fixtureDir, '.codegraph', 'graph.db');
+  const db = openReadonlyOrFail(dbPath);
+  try {
+    const rows = db
+      .prepare(`
+      SELECT dynamic_kind, COUNT(*) AS count
+      FROM edges
+      WHERE confidence = 0 AND dynamic_kind IS NOT NULL
+      GROUP BY dynamic_kind
+      ORDER BY count DESC
+    `)
+      .all() as { dynamic_kind: string; count: number }[];
+    return Object.fromEntries(rows.map((r) => [r.dynamic_kind, r.count]));
+  } catch {
+    return {}; // Column may not exist in older DBs
   } finally {
     db.close();
   }
@@ -556,6 +582,16 @@ describe('Call Resolution Precision/Recall', () => {
           const expectedEdges: ExpectedEdge[] = manifest.edges;
 
           metrics = computeMetrics(resolvedEdges, expectedEdges);
+
+          // Log flagged dynamic call sink edges (confidence=0) for visibility.
+          const flagged = extractFlaggedDynamicCalls(fixtureDir);
+          if (Object.keys(flagged).length > 0) {
+            const total = Object.values(flagged).reduce((s, c) => s + c, 0);
+            const breakdown = Object.entries(flagged)
+              .map(([k, v]) => `${k}:${v}`)
+              .join(' ');
+            console.log(`  [${lang}] flagged dynamic calls: ${total} (${breakdown})`);
+          }
         }
         allResults[lang] = metrics;
       }, 60_000);

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -249,7 +249,7 @@ function extractResolvedEdges(fixtureDir: string) {
       JOIN nodes tgt ON e.target_id = tgt.id
       WHERE e.kind = 'calls'
         AND src.kind IN ('function', 'method')
-        AND (e.confidence IS NULL OR e.confidence > 0)
+        AND (e.confidence IS NULL OR e.confidence > 0 OR e.dynamic_kind IS NULL)
     `)
       .all();
   } finally {

--- a/tests/engines/dynamic-call-ffi.test.ts
+++ b/tests/engines/dynamic-call-ffi.test.ts
@@ -84,6 +84,16 @@ describe('dynamic call classification — dynamicKind and keyExpr fields', () =>
     expect(c?.dynamicKind).toBe('reflection');
   });
 
+  it('tags obj[a + b]() as unresolved-dynamic kind', () => {
+    const out = parseJS(`
+      function test(handlers, a, b) { handlers[a + b]('arg'); }
+    `);
+    const c = out.calls.find((c) => c.name === '<dynamic:unresolved>');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBe('unresolved-dynamic');
+    expect(c?.dynamic).toBe(true);
+  });
+
   it('does not set dynamicKind on normal function calls', () => {
     const out = parseJS(`
       function test() { greet('world'); }

--- a/tests/engines/dynamic-call-ffi.test.ts
+++ b/tests/engines/dynamic-call-ffi.test.ts
@@ -1,0 +1,96 @@
+/**
+ * FFI field round-trip test for dynamic call classification.
+ *
+ * Verifies that dynamicKind and keyExpr fields are correctly set by the
+ * JS/WASM extractor and survive the ExtractorOutput → Call pipeline.
+ * Guards against silent drops at the Worker thread serialization seam
+ * (wasm-worker-protocol.ts passes calls wholesale, so this mainly tests extractor logic).
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createParsers, extractSymbols, getParser } from '../../src/domain/parser.js';
+
+let parsers: Awaited<ReturnType<typeof createParsers>>;
+
+describe('dynamic call classification — dynamicKind and keyExpr fields', () => {
+  beforeAll(async () => {
+    parsers = await createParsers();
+  }, 30_000);
+
+  function parseJS(code: string) {
+    const parser = getParser(parsers, 'test.js');
+    if (!parser) throw new Error('JS parser not available');
+    const tree = parser.parse(code);
+    return extractSymbols(tree, 'test.js');
+  }
+
+  it('tags eval() as eval kind with keyExpr captured for string literal', () => {
+    const out = parseJS(`
+      function test() { eval("console.log('hi')"); }
+    `);
+    const c = out.calls.find((c) => c.name === '<dynamic:eval>');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBe('eval');
+    expect(c?.dynamic).toBe(true);
+    expect(c?.keyExpr).toContain('console.log');
+  });
+
+  it('tags new Function() as eval kind', () => {
+    const out = parseJS(`
+      function test() { const fn = new Function('return 42'); }
+    `);
+    const c = out.calls.find((c) => c.name === '<dynamic:eval>');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBe('eval');
+  });
+
+  it("tags obj['method']() as computed-literal kind", () => {
+    const out = parseJS(`
+      function test(obj) { obj['greet']('world'); }
+    `);
+    const c = out.calls.find((c) => c.name === 'greet');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBe('computed-literal');
+    expect(c?.dynamic).toBe(true);
+  });
+
+  it('tags obj[key]() as computed-key kind with keyExpr', () => {
+    const out = parseJS(`
+      function test(handlers, key) { handlers[key]('arg'); }
+    `);
+    const c = out.calls.find((c) => c.name === '<dynamic:computed-key>');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBe('computed-key');
+    expect(c?.keyExpr).toBe('key');
+    expect(c?.dynamic).toBe(true);
+  });
+
+  it('tags fn.call(ctx) as reflection kind', () => {
+    const out = parseJS(`
+      function test(ctx) { greet.call(ctx, 'world'); }
+    `);
+    const c = out.calls.find((c) => c.name === 'greet');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBe('reflection');
+    expect(c?.dynamic).toBe(true);
+  });
+
+  it('tags fn.apply(ctx, args) as reflection kind', () => {
+    const out = parseJS(`
+      function test(ctx) { greet.apply(ctx, ['world']); }
+    `);
+    const c = out.calls.find((c) => c.name === 'greet');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBe('reflection');
+  });
+
+  it('does not set dynamicKind on normal function calls', () => {
+    const out = parseJS(`
+      function test() { greet('world'); }
+    `);
+    const c = out.calls.find((c) => c.name === 'greet');
+    expect(c).toBeDefined();
+    expect(c?.dynamicKind).toBeUndefined();
+    expect(c?.dynamic).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **`DynamicKind` taxonomy** (`computed-literal`, `computed-key`, `reflection`, `eval`, `unresolved-dynamic`) classifies JS dynamic calls at extraction time instead of silently dropping them
- **Sink edges** (confidence=0.0, `dynamic_kind` set) emitted for flag-only kinds (`eval`, `computed-key`, `unresolved-dynamic`) → visible via `codegraph roles --dynamic`, never pollute normal queries
- **Rust mirror** fully updated: `CallInfo`/`ComputedEdge` structs, short-circuit in `resolve_call_targets`, sink-edge emission in `process_file`, `..Default::default()` on all 25 extractor `Call` literals
- **DB migration v20**: `edges.dynamic_kind TEXT` column + index

## What changes

| Component | Change |
|-----------|--------|
| `src/types.ts` | `DynamicKind` type + `Call.dynamicKind`/`keyExpr` + `EdgeRow.dynamic_kind` |
| `src/extractors/javascript.ts` | Classify `eval`, `new Function`, `obj[k]()`, `.call/.apply/.bind`, `obj["lit"]()` |
| `src/domain/graph/builder/call-resolver.ts` | Short-circuit `<dynamic:*>` names |
| `src/domain/graph/builder/stages/build-edges.ts` | 7-element `EdgeRowTuple`, sink-edge step 7, `dynamic_kind` back-fill |
| `src/cli/commands/roles.ts` | `--dynamic` flag → `codegraph roles --dynamic` |
| `crates/codegraph-core/` | Mirror all TS changes in Rust |

## Test plan

- [x] `npx vitest run tests/engines/dynamic-call-ffi.test.ts` → 7/7 pass (eval, new Function, computed-key, computed-literal, reflection, normal calls)
- [x] `npx vitest run tests/parsers/javascript.test.ts` → 141/141 pass
- [x] Resolution benchmark `dynamic-javascript` fixture → 100% precision, 100% recall, 1 flagged sink edge (computed-key)
- [x] `npm run lint` → clean
- [x] `cargo check` → clean

## Deferred to follow-up PRs

- Phase 1–6: per-language-family detection (JS/TS idioms, JVM, Python, Scripting, Go/C, long tail)
- RES-1/RES-2: const-string-key propagation, dispatch-table resolution
- Docs/Parity PR: `README.md:919` rewrite, recall floor updates

## Related

- Closes #1628 (pre-existing WASM technique mismatch in issue-1292 test, filed as out-of-scope)
- Foundation for the dynamic call resolution roadmap in `DYNAMIC_CALL_RESOLUTION_PLAN.md`