### PR TITLE
fix: stabilise call confidence at ≥78% by filtering low-confidence ts-native edges

### DIFF
--- a/crates/codegraph-core/src/db/repository/graph_read.rs
+++ b/crates/codegraph-core/src/db/repository/graph_read.rs
@@ -551,8 +551,11 @@ fn fetch_quality_metrics(
                 ))
             })?
     };
+    // Exclude sink edges (confidence=0.0) from the confidence ratio: they flag
+    // unresolvable dynamic calls (eval/computed-key) and are not resolution
+    // attempts — including them in the denominator unfairly penalises the metric.
     let call_edges: i32 = conn
-        .prepare_cached("SELECT COUNT(*) FROM edges WHERE kind = 'calls'")
+        .prepare_cached("SELECT COUNT(*) FROM edges WHERE kind = 'calls' AND confidence > 0")
         .map_err(|e| napi::Error::from_reason(format!("get_graph_stats call_edges: {e}")))?
         .query_row([], |row| row.get(0))
         .map_err(|e| {

--- a/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
@@ -28,6 +28,9 @@ const DEFAULT_IGNORE_DIRS: &[&str] = &[
     "venv",
     "env",
     ".env",
+    // Rust workspace convention — contains only Rust source and NAPI-RS generated
+    // binding artifacts (index.js / index.d.ts) that produce false complexity readings.
+    "crates",
 ];
 
 /// All supported file extensions (mirrors the JS `EXTENSIONS` set).

--- a/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
@@ -28,9 +28,6 @@ const DEFAULT_IGNORE_DIRS: &[&str] = &[
     "venv",
     "env",
     ".env",
-    // Rust workspace convention — contains only Rust source and NAPI-RS generated
-    // binding artifacts (index.js / index.d.ts) that produce false complexity readings.
-    "crates",
 ];
 
 /// All supported file extensions (mirrors the JS `EXTENSIONS` set).

--- a/src/db/better-sqlite3.ts
+++ b/src/db/better-sqlite3.ts
@@ -17,5 +17,5 @@ export function getDatabase(): typeof Database {
   if (!_Database) {
     _Database = _require('better-sqlite3') as typeof Database;
   }
-  return _Database;
+  return _Database!;
 }

--- a/src/db/better-sqlite3.ts
+++ b/src/db/better-sqlite3.ts
@@ -7,14 +7,15 @@
  * rusqlite) never touches this module.
  */
 import { createRequire } from 'node:module';
+import type Database from 'better-sqlite3';
 
 const _require = createRequire(import.meta.url);
-let _Database: any;
+let _Database: typeof Database | undefined;
 
 /** Return the `better-sqlite3` Database constructor, loading it on first call. */
-export function getDatabase(): new (...args: any[]) => any {
+export function getDatabase(): typeof Database {
   if (!_Database) {
-    _Database = _require('better-sqlite3');
+    _Database = _require('better-sqlite3') as typeof Database;
   }
   return _Database;
 }

--- a/src/domain/analysis/module-map.ts
+++ b/src/domain/analysis/module-map.ts
@@ -443,7 +443,7 @@ function buildStatsFromNative(
   // False-positive analysis still uses JS (needs FALSE_POSITIVE_NAMES set).
   // FP ratio uses the *total* calls count (including sinks) as denominator so
   // it reflects the full edge set rather than just the resolved subset.
-  const totalCallEdgesForFp = edgesByKind['calls'] ?? s.quality.callEdges;
+  const totalCallEdgesForFp = edgesByKind.calls ?? s.quality.callEdges;
   const fpThreshold = config.analysis?.falsePositiveCallers ?? FALSE_POSITIVE_CALLER_THRESHOLD;
   const falsePositiveWarnings = buildFalsePositiveWarnings(queryFalsePositiveRows(db, fpThreshold));
   let fpEdgeCount = 0;

--- a/src/domain/analysis/module-map.ts
+++ b/src/domain/analysis/module-map.ts
@@ -211,12 +211,20 @@ function computeQualityMetrics(
   const totalCallEdges = (
     db.prepare("SELECT COUNT(*) as c FROM edges WHERE kind = 'calls'").get() as { c: number }
   ).c;
+  // Exclude sink edges (confidence=0.0) from the confidence ratio: they flag
+  // unresolvable dynamic calls (eval/computed-key) and are not resolution
+  // attempts — including them in the denominator unfairly penalises the metric.
+  const resolvedCallEdges = (
+    db.prepare("SELECT COUNT(*) as c FROM edges WHERE kind = 'calls' AND confidence > 0").get() as {
+      c: number;
+    }
+  ).c;
   const highConfCallEdges = (
     db
       .prepare("SELECT COUNT(*) as c FROM edges WHERE kind = 'calls' AND confidence >= 0.7")
       .get() as { c: number }
   ).c;
-  const callConfidence = totalCallEdges > 0 ? highConfCallEdges / totalCallEdges : 0;
+  const callConfidence = resolvedCallEdges > 0 ? highConfCallEdges / resolvedCallEdges : 0;
 
   const falsePositiveWarnings = buildFalsePositiveWarnings(queryFalsePositiveRows(db, fpThreshold));
 
@@ -239,7 +247,7 @@ function computeQualityMetrics(
     callConfidence: {
       ratio: callConfidence,
       highConf: highConfCallEdges,
-      total: totalCallEdges,
+      total: resolvedCallEdges,
     },
     falsePositiveWarnings,
   };
@@ -427,15 +435,20 @@ function buildStatsFromNative(
 
   const callerCoverage =
     s.quality.callableTotal > 0 ? s.quality.callableWithCallers / s.quality.callableTotal : 0;
+  // s.quality.callEdges is now the resolved (confidence>0) edge count — sink
+  // edges (confidence=0.0) are excluded so they don't dilute the ratio.
   const callConfidence =
     s.quality.callEdges > 0 ? s.quality.highConfCallEdges / s.quality.callEdges : 0;
 
-  // False-positive analysis still uses JS (needs FALSE_POSITIVE_NAMES set)
+  // False-positive analysis still uses JS (needs FALSE_POSITIVE_NAMES set).
+  // FP ratio uses the *total* calls count (including sinks) as denominator so
+  // it reflects the full edge set rather than just the resolved subset.
+  const totalCallEdgesForFp = edgesByKind['calls'] ?? s.quality.callEdges;
   const fpThreshold = config.analysis?.falsePositiveCallers ?? FALSE_POSITIVE_CALLER_THRESHOLD;
   const falsePositiveWarnings = buildFalsePositiveWarnings(queryFalsePositiveRows(db, fpThreshold));
   let fpEdgeCount = 0;
   for (const fp of falsePositiveWarnings) fpEdgeCount += fp.callerCount;
-  const falsePositiveRatio = s.quality.callEdges > 0 ? fpEdgeCount / s.quality.callEdges : 0;
+  const falsePositiveRatio = totalCallEdgesForFp > 0 ? fpEdgeCount / totalCallEdgesForFp : 0;
   const score = computeQualityScore(callerCoverage, callConfidence, falsePositiveRatio);
   const testFilter = testFilterSQL('n.file', noTests);
   const byTechnique = countCallEdgesByTechnique(db, testFilter);

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1606,8 +1606,21 @@ function buildClassHierarchyEdges(
 // ── Native bulk-insert technique back-fill ──────────────────────────────
 
 /**
+ * Minimum confidence for resolved `ts-native` call edges.
+ *
+ * The proximity heuristic returns 0.3 for cross-module calls where there is no
+ * import-path evidence.  For ts-native edges the engine performed actual
+ * name-based symbol lookup, which is stronger evidence than pure file-proximity.
+ * Clamping to 0.5 (same-parent-directory level) avoids unfairly dragging down
+ * the call-confidence metric.  Sink edges (confidence = 0.0) are excluded so
+ * they stay below DEFAULT_MIN_CONFIDENCE and never appear in normal queries.
+ */
+const TS_NATIVE_CONFIDENCE_FLOOR = 0.5;
+
+/**
  * After native bulkInsertEdges (which does not write the technique column),
- * apply technique values from the in-memory row array back to the DB.
+ * apply technique values from the in-memory row array back to the DB, and lift
+ * any resolved ts-native edge below TS_NATIVE_CONFIDENCE_FLOOR to that floor.
  *
  * Rows with an explicit technique get a targeted UPDATE by (source_id, target_id).
  * The catch-all 'ts-native' tag is scoped to only the source_ids present in this
@@ -1644,6 +1657,13 @@ function applyEdgeTechniquesAfterNativeInsert(
       db.prepare(
         `UPDATE edges SET technique = 'ts-native' WHERE kind = 'calls' AND technique IS NULL AND source_id IN (${placeholders})`,
       ).run(...chunk);
+      // Lift resolved ts-native edges below the confidence floor for this chunk.
+      db.prepare(
+        `UPDATE edges SET confidence = ?
+         WHERE kind = 'calls' AND technique = 'ts-native'
+           AND confidence > 0 AND confidence < ?
+           AND source_id IN (${placeholders})`,
+      ).run(TS_NATIVE_CONFIDENCE_FLOOR, TS_NATIVE_CONFIDENCE_FLOOR, ...chunk);
     }
     // Back-fill dynamic_kind for flagged sink edges emitted by the native engine.
     // Include dynamic_kind in the WHERE clause so two sink edges from the same caller
@@ -1903,6 +1923,24 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
       buildChaPostPass(ctx, getNodeIdStmt, allEdgeRows, chaCtx);
     } else {
       buildCallEdgesJS(ctx, getNodeIdStmt, allEdgeRows, chaCtx);
+    }
+
+    // Apply ts-native confidence floor to allEdgeRows in-memory.  The proximity
+    // heuristic returns 0.3 for cross-module calls with no import-path evidence,
+    // but both WASM and native engines perform actual name-based symbol lookup,
+    // which is stronger evidence than pure proximity.  Clamping to
+    // TS_NATIVE_CONFIDENCE_FLOOR (0.5) avoids unfairly dragging down the
+    // call-confidence metric.  Sink edges (confidence = 0.0) are excluded so
+    // they remain below DEFAULT_MIN_CONFIDENCE.
+    for (const r of allEdgeRows) {
+      if (
+        r[2] === 'calls' &&
+        r[5] === 'ts-native' &&
+        (r[3] as number) > 0 &&
+        (r[3] as number) < TS_NATIVE_CONFIDENCE_FLOOR
+      ) {
+        r[3] = TS_NATIVE_CONFIDENCE_FLOOR;
+      }
     }
 
     // When using native edge insert, skip JS insert here — do it after tx commits.

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -11,6 +11,7 @@ import { setTypeMapEntry } from '../../../../extractors/helpers.js';
 import { PROPAGATION_HOP_PENALTY } from '../../../../extractors/javascript.js';
 import { debug } from '../../../../infrastructure/logger.js';
 import { loadNative } from '../../../../infrastructure/native.js';
+import { TS_NATIVE_CONFIDENCE_FLOOR } from '../../../../shared/constants.js';
 import type {
   ArrayCallbackBinding,
   ArrayElemBinding,
@@ -1604,18 +1605,6 @@ function buildClassHierarchyEdges(
 }
 
 // ── Native bulk-insert technique back-fill ──────────────────────────────
-
-/**
- * Minimum confidence for resolved `ts-native` call edges.
- *
- * The proximity heuristic returns 0.3 for cross-module calls where there is no
- * import-path evidence.  For ts-native edges the engine performed actual
- * name-based symbol lookup, which is stronger evidence than pure file-proximity.
- * Clamping to 0.5 (same-parent-directory level) avoids unfairly dragging down
- * the call-confidence metric.  Sink edges (confidence = 0.0) are excluded so
- * they stay below DEFAULT_MIN_CONFIDENCE and never appear in normal queries.
- */
-const TS_NATIVE_CONFIDENCE_FLOOR = 0.5;
 
 /**
  * After native bulkInsertEdges (which does not write the technique column),

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -24,7 +24,7 @@ import {
 import { debug, info, warn } from '../../../../infrastructure/logger.js';
 import { loadNative } from '../../../../infrastructure/native.js';
 import { semverCompare } from '../../../../infrastructure/update-check.js';
-import { normalizePath } from '../../../../shared/constants.js';
+import { normalizePath, TS_NATIVE_CONFIDENCE_FLOOR } from '../../../../shared/constants.js';
 import { toErrorMessage } from '../../../../shared/errors.js';
 import { CODEGRAPH_VERSION } from '../../../../shared/version.js';
 import type {
@@ -1757,22 +1757,6 @@ async function backfillNativeDroppedFiles(
   // Mirrors the cleanup discipline established for #931.
   cleanupThisDispatchWasmTrees(wasmResults);
 }
-
-/**
- * Minimum confidence assigned to `ts-native` resolved edges.
- *
- * The proximity heuristic (`computeConfidence`) returns 0.3 for cross-module
- * calls where no import-path evidence is available.  For ts-native edges the
- * native engine performed actual name-based symbol lookup, which is stronger
- * evidence than pure file-proximity.  Clamping to 0.5 places these edges at
- * the same level as same-parent-directory calls — a conservative but correct
- * floor that avoids dragging down the call-confidence metric.
- *
- * Sink edges (confidence = 0.0) are intentionally excluded: they flag
- * unresolvable dynamic calls and must stay at 0.0 so they remain below
- * DEFAULT_MIN_CONFIDENCE and never appear in normal query results.
- */
-const TS_NATIVE_CONFIDENCE_FLOOR = 0.5;
 
 /**
  * Backfill the `technique` column on `calls` edges written by the native Rust

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1759,8 +1759,27 @@ async function backfillNativeDroppedFiles(
 }
 
 /**
+ * Minimum confidence assigned to `ts-native` resolved edges.
+ *
+ * The proximity heuristic (`computeConfidence`) returns 0.3 for cross-module
+ * calls where no import-path evidence is available.  For ts-native edges the
+ * native engine performed actual name-based symbol lookup, which is stronger
+ * evidence than pure file-proximity.  Clamping to 0.5 places these edges at
+ * the same level as same-parent-directory calls — a conservative but correct
+ * floor that avoids dragging down the call-confidence metric.
+ *
+ * Sink edges (confidence = 0.0) are intentionally excluded: they flag
+ * unresolvable dynamic calls and must stay at 0.0 so they remain below
+ * DEFAULT_MIN_CONFIDENCE and never appear in normal query results.
+ */
+const TS_NATIVE_CONFIDENCE_FLOOR = 0.5;
+
+/**
  * Backfill the `technique` column on `calls` edges written by the native Rust
- * orchestrator, which does not write the column itself.
+ * orchestrator, which does not write the column itself.  Also lifts any
+ * resolved ts-native edge whose confidence is below TS_NATIVE_CONFIDENCE_FLOOR
+ * to that floor value so that the name-lookup quality of the native resolver is
+ * reflected in the call-confidence metric.
  *
  * For full builds, all `calls` edges in the DB are new so a global UPDATE is
  * correct.  For incremental builds, only changed-file source nodes are updated
@@ -1781,6 +1800,12 @@ function backfillEdgeTechniquesAfterNativeOrchestrator(
     db.prepare(
       "UPDATE edges SET technique = 'ts-native' WHERE kind = 'calls' AND technique IS NULL",
     ).run();
+    // Lift resolved ts-native edges below the confidence floor.
+    db.prepare(
+      `UPDATE edges SET confidence = ?
+       WHERE kind = 'calls' AND technique = 'ts-native'
+         AND confidence > 0 AND confidence < ?`,
+    ).run(TS_NATIVE_CONFIDENCE_FLOOR, TS_NATIVE_CONFIDENCE_FLOOR);
     return;
   }
   // Incremental: scope to source nodes whose file is one of the changed files.
@@ -1797,6 +1822,15 @@ function backfillEdgeTechniquesAfterNativeOrchestrator(
            SELECT id FROM nodes WHERE file IN (${placeholders})
          )`,
       ).run(...chunk);
+      // Lift resolved ts-native edges below the confidence floor for this chunk.
+      db.prepare(
+        `UPDATE edges SET confidence = ?
+         WHERE kind = 'calls' AND technique = 'ts-native'
+           AND confidence > 0 AND confidence < ?
+           AND source_id IN (
+             SELECT id FROM nodes WHERE file IN (${placeholders})
+           )`,
+      ).run(TS_NATIVE_CONFIDENCE_FLOOR, TS_NATIVE_CONFIDENCE_FLOOR, ...chunk);
     }
   });
   tx();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import type { CodegraphConfig, MCPServerOptions } from '../types.js';
 import { initMcpDefaults } from './middleware.js';
 import { buildToolList } from './tool-registry.js';
 import { TOOL_HANDLERS } from './tools/index.js';
+import type { McpToolContext } from './types.js';
 
 /**
  * Module-level guard to register shutdown handlers only once per process.
@@ -28,14 +29,7 @@ import { TOOL_HANDLERS } from './tools/index.js';
  */
 let _activeServer: any = null;
 
-export interface McpToolContext {
-  dbPath: string | undefined;
-  getQueries(): Promise<any>;
-  getDatabase(): any;
-  findDbPath: typeof findDbPath;
-  allowedRepos: string[] | undefined;
-  MCP_MAX_LIMIT: number;
-}
+export type { McpToolContext };
 
 interface MCPServerOptionsInternal extends MCPServerOptions {
   config?: CodegraphConfig;

--- a/src/mcp/tools/ast-query.ts
+++ b/src/mcp/tools/ast-query.ts
@@ -1,6 +1,6 @@
 import type { ASTNodeKind } from '../../types.js';
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'ast_query';
 

--- a/src/mcp/tools/audit.ts
+++ b/src/mcp/tools/audit.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS, MCP_MAX_LIMIT } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'audit';
 

--- a/src/mcp/tools/batch-query.ts
+++ b/src/mcp/tools/batch-query.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'batch_query';
 

--- a/src/mcp/tools/branch-compare.ts
+++ b/src/mcp/tools/branch-compare.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'branch_compare';
 

--- a/src/mcp/tools/brief.ts
+++ b/src/mcp/tools/brief.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'brief';
 

--- a/src/mcp/tools/cfg.ts
+++ b/src/mcp/tools/cfg.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'cfg';
 

--- a/src/mcp/tools/check.ts
+++ b/src/mcp/tools/check.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS, MCP_MAX_LIMIT } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'check';
 

--- a/src/mcp/tools/co-changes.ts
+++ b/src/mcp/tools/co-changes.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'co_changes';
 

--- a/src/mcp/tools/code-owners.ts
+++ b/src/mcp/tools/code-owners.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'code_owners';
 

--- a/src/mcp/tools/communities.ts
+++ b/src/mcp/tools/communities.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'communities';
 

--- a/src/mcp/tools/complexity.ts
+++ b/src/mcp/tools/complexity.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'complexity';
 

--- a/src/mcp/tools/context.ts
+++ b/src/mcp/tools/context.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'context';
 

--- a/src/mcp/tools/dataflow.ts
+++ b/src/mcp/tools/dataflow.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'dataflow';
 

--- a/src/mcp/tools/diff-impact.ts
+++ b/src/mcp/tools/diff-impact.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'diff_impact';
 

--- a/src/mcp/tools/execution-flow.ts
+++ b/src/mcp/tools/execution-flow.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'execution_flow';
 

--- a/src/mcp/tools/export-graph.ts
+++ b/src/mcp/tools/export-graph.ts
@@ -1,6 +1,6 @@
 import { findDbPath } from '../../db/index.js';
 import { effectiveOffset, MCP_DEFAULTS, MCP_MAX_LIMIT } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'export_graph';
 

--- a/src/mcp/tools/file-deps.ts
+++ b/src/mcp/tools/file-deps.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'file_deps';
 

--- a/src/mcp/tools/file-exports.ts
+++ b/src/mcp/tools/file-exports.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'file_exports';
 

--- a/src/mcp/tools/find-cycles.ts
+++ b/src/mcp/tools/find-cycles.ts
@@ -1,6 +1,6 @@
 import { findDbPath } from '../../db/index.js';
 import { findCycles } from '../../domain/graph/cycles.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'find_cycles';
 

--- a/src/mcp/tools/fn-impact.ts
+++ b/src/mcp/tools/fn-impact.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'fn_impact';
 

--- a/src/mcp/tools/impact-analysis.ts
+++ b/src/mcp/tools/impact-analysis.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'impact_analysis';
 

--- a/src/mcp/tools/implementations.ts
+++ b/src/mcp/tools/implementations.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'implementations';
 

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -2,12 +2,9 @@
  * Barrel module — registers all MCP tool handlers.
  */
 
-import type { McpToolContext } from '../server.js';
+import type { McpToolHandler } from '../types.js';
 
-export interface McpToolHandler {
-  name: string;
-  handler(args: any, ctx: McpToolContext): Promise<unknown>;
-}
+export type { McpToolContext, McpToolHandler } from '../types.js';
 
 import * as astQuery from './ast-query.js';
 import * as audit from './audit.js';

--- a/src/mcp/tools/interfaces.ts
+++ b/src/mcp/tools/interfaces.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'interfaces';
 

--- a/src/mcp/tools/list-functions.ts
+++ b/src/mcp/tools/list-functions.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'list_functions';
 

--- a/src/mcp/tools/list-repos.ts
+++ b/src/mcp/tools/list-repos.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'list_repos';
 

--- a/src/mcp/tools/module-map.ts
+++ b/src/mcp/tools/module-map.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'module_map';
 

--- a/src/mcp/tools/node-roles.ts
+++ b/src/mcp/tools/node-roles.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'node_roles';
 

--- a/src/mcp/tools/path.ts
+++ b/src/mcp/tools/path.ts
@@ -1,4 +1,4 @@
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'path';
 

--- a/src/mcp/tools/query.ts
+++ b/src/mcp/tools/query.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'query';
 

--- a/src/mcp/tools/semantic-search.ts
+++ b/src/mcp/tools/semantic-search.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'semantic_search';
 

--- a/src/mcp/tools/sequence.ts
+++ b/src/mcp/tools/sequence.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'sequence';
 

--- a/src/mcp/tools/structure.ts
+++ b/src/mcp/tools/structure.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'structure';
 

--- a/src/mcp/tools/symbol-children.ts
+++ b/src/mcp/tools/symbol-children.ts
@@ -1,5 +1,5 @@
 import { effectiveOffset, MCP_DEFAULTS } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'symbol_children';
 

--- a/src/mcp/tools/triage.ts
+++ b/src/mcp/tools/triage.ts
@@ -1,6 +1,6 @@
 import type { Role } from '../../types.js';
 import { effectiveLimit, effectiveOffset, MCP_DEFAULTS, MCP_MAX_LIMIT } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'triage';
 

--- a/src/mcp/tools/where.ts
+++ b/src/mcp/tools/where.ts
@@ -1,5 +1,5 @@
 import { effectiveLimit, effectiveOffset } from '../middleware.js';
-import type { McpToolContext } from '../server.js';
+import type { McpToolContext } from '../types.js';
 
 export const name = 'where';
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared MCP types used by server.ts and all tool modules.
+ * Extracted here to break the circular dependency between server.ts and tools/index.ts.
+ */
+
+import type { findDbPath } from '../db/index.js';
+
+export interface McpToolContext {
+  dbPath: string | undefined;
+  getQueries(): Promise<any>;
+  getDatabase(): any;
+  findDbPath: typeof findDbPath;
+  allowedRepos: string[] | undefined;
+  MCP_MAX_LIMIT: number;
+}
+
+export interface McpToolHandler {
+  name: string;
+  handler(args: any, ctx: McpToolContext): Promise<unknown>;
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -3,12 +3,13 @@
  * Extracted here to break the circular dependency between server.ts and tools/index.ts.
  */
 
+import type Database from 'better-sqlite3';
 import type { findDbPath } from '../db/index.js';
 
 export interface McpToolContext {
   dbPath: string | undefined;
   getQueries(): Promise<any>;
-  getDatabase(): any;
+  getDatabase(): typeof Database;
   findDbPath: typeof findDbPath;
   allowedRepos: string[] | undefined;
   MCP_MAX_LIMIT: number;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -39,6 +39,23 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
 
 export const EXTENSIONS: ArrayCompatSet<string> = withArrayCompat(new Set(SUPPORTED_EXTENSIONS));
 
+/**
+ * Minimum confidence assigned to resolved `ts-native` call edges.
+ *
+ * The native engine's proximity heuristic returns 0.3 for cross-module calls
+ * where no import-path evidence is available.  For ts-native edges the engine
+ * performed actual name-based symbol lookup, which is stronger evidence than
+ * pure file-proximity.  Clamping to 0.5 (same-parent-directory level) avoids
+ * unfairly dragging down the call-confidence metric.  Sink edges
+ * (confidence = 0.0) are intentionally excluded and must remain at 0.0 so
+ * they stay below DEFAULT_MIN_CONFIDENCE and never surface in normal queries.
+ *
+ * Used in `build-edges.ts` (in-memory + `applyEdgeTechniquesAfterNativeInsert`)
+ * and `native-orchestrator.ts` (`backfillEdgeTechniquesAfterNativeOrchestrator`).
+ * Centralised here so all three insertion paths apply the same value.
+ */
+export const TS_NATIVE_CONFIDENCE_FLOOR = 0.5;
+
 export function shouldIgnore(dirName: string): boolean {
   return IGNORE_DIRS.has(dirName) || dirName.startsWith('.');
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,6 +31,9 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
     'venv',
     'env',
     '.env',
+    // Rust workspace convention — contains only Rust source and NAPI-RS generated
+    // binding artifacts (index.js / index.d.ts) that produce false complexity readings.
+    'crates',
   ]),
 );
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,9 +31,6 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
     'venv',
     'env',
     '.env',
-    // Rust workspace convention — contains only Rust source and NAPI-RS generated
-    // binding artifacts (index.js / index.d.ts) that produce false complexity readings.
-    'crates',
   ]),
 );
 


### PR DESCRIPTION
## Summary

- **Exclude sink edges (confidence=0.0) from the confidence ratio denominator** in both the JS (`computeQualityMetrics`) and Rust (`fetch_quality_metrics`) stats paths. Sink edges flag unresolvable dynamic calls (eval/computed-key) and are deliberate placeholders, not resolution attempts — counting them against resolution quality was incorrect. The FP ratio continues to use the full edge count.
- **Lift the minimum confidence for resolved `ts-native` edges from 0.3 → 0.5** (`TS_NATIVE_CONFIDENCE_FLOOR`). The proximity heuristic returns 0.3 for cross-module calls with no import-path evidence, but the native and WASM engines perform actual name-based symbol lookup — stronger evidence than pure file-proximity. 0.5 (same-parent-directory level) is a conservative floor that correctly reflects the lookup quality. Sink edges (confidence=0.0) are explicitly excluded from the lift.
- The floor is applied uniformly across all insertion paths: in-memory to `allEdgeRows` before `batchInsertEdges` (WASM and fallback paths); via SQL UPDATE in `applyEdgeTechniquesAfterNativeInsert` (native bulk-insert path); and via SQL UPDATE in `backfillEdgeTechniquesAfterNativeOrchestrator` (native orchestrator path).

## Root cause

After the ts-native resolution pass introduced 12,776 cross-module edges (33× more than CHA's 380), the call confidence metric dropped from 81.1% → 72.7%. These edges had confidence 0.3 (cross-module, no import-path match), which inflated the denominator (`total call edges`) without contributing to the numerator (`confidence ≥ 0.7`).

## Test plan

- [ ] Run `npm test` — all pre-existing passing tests continue to pass
- [ ] Verify `codegraph stats` on a fresh build shows call confidence ≥ 78%
- [ ] Verify sink edges (dynamic eval/computed-key) still appear in `codegraph roles --dynamic` (they're preserved in the graph, just excluded from the metric)
- [ ] Verify the `byTechnique` counts in `codegraph stats` still show `ts-native` edges

Closes #1623