### PR TITLE
fix: clear stale imports edges on incremental native rebuild

### DIFF
--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -2046,8 +2046,11 @@ export async function tryNativeOrchestrator(
   // nodes/edges during incremental builds, so FK enforcement causes the purge
   // statements to fail silently — leaving stale nodes and edges that then get
   // duplicated when the barrel-candidate re-parse re-inserts them (issue #1644).
-  // Disabling FK before buildGraph() lets the purge succeed. FK enforcement is
-  // restored automatically when this connection is closed after the build.
+  // Disabling FK before buildGraph() lets the purge succeed. FK stays OFF for
+  // the entire connection lifetime (through backfillNativeDroppedFiles and
+  // buildDataflowP4ForNative) and is restored when the connection is closed.
+  // This is intentional: call_edge_id values written by P4 are always looked up
+  // live from the edges table, so no phantom FK reference is ever produced.
   try {
     ctx.nativeDb.exec('PRAGMA foreign_keys = OFF');
   } catch {

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -2040,6 +2040,20 @@ export async function tryNativeOrchestrator(
 
   if (!ctx.nativeDb?.buildGraph) return undefined;
 
+  // The previous full build's clear_all_graph_data() sets PRAGMA foreign_keys = ON
+  // on the native connection. Older native binaries (< v3.14) do not delete
+  // dataflow_vertices / dataflow_summary / call_edge_id rows before purging
+  // nodes/edges during incremental builds, so FK enforcement causes the purge
+  // statements to fail silently — leaving stale nodes and edges that then get
+  // duplicated when the barrel-candidate re-parse re-inserts them (issue #1644).
+  // Disabling FK before buildGraph() lets the purge succeed. FK enforcement is
+  // restored automatically when this connection is closed after the build.
+  try {
+    ctx.nativeDb.exec('PRAGMA foreign_keys = OFF');
+  } catch {
+    // exec may not exist on very old addon versions — safe to ignore
+  }
+
   const resultJson = ctx.nativeDb.buildGraph(
     ctx.rootDir,
     JSON.stringify(ctx.config),

--- a/src/features/dataflow.ts
+++ b/src/features/dataflow.ts
@@ -477,7 +477,15 @@ function buildDataflowVerticesAndEdges(
  *  - If B's summary shows B.param[j] reaches B's return: emits 'return_out'
  *    inter edge: B.return → A's capture local (if any)
  */
-function buildInterproceduralStitch(
+/**
+ * Core stitch logic — must be called inside an already-open transaction.
+ *
+ * Separated from buildInterproceduralStitch so callers that manage their own
+ * outer transaction (buildDataflowVerticesFromMap, buildDataflowEdges) can
+ * call this directly without starting a nested transaction, which better-sqlite3
+ * does not support.
+ */
+function runInterproceduralStitch(
   db: BetterSqlite3Database,
   candidates: StitchCandidate[],
   captures: ReturnCapture[],
@@ -513,77 +521,96 @@ function buildInterproceduralStitch(
   }
 
   let count = 0;
-  const tx = db.transaction(() => {
-    for (const cand of candidates) {
-      // Resolve call edge for this site
-      const callEdge = getCallEdge.get(cand.callerFuncId, cand.calleeFuncId) as {
-        id: number;
-      } | null;
-      const callEdgeId = callEdge?.id ?? null;
+  for (const cand of candidates) {
+    // Resolve call edge for this site
+    const callEdge = getCallEdge.get(cand.callerFuncId, cand.calleeFuncId) as {
+      id: number;
+    } | null;
+    const callEdgeId = callEdge?.id ?? null;
 
-      // Find source vertex x in caller
-      let srcVertexId: number | null = null;
-      if (cand.bindingType === 'param' && cand.bindingIndex != null) {
-        const v = getParamVertex.get(cand.callerFuncId, cand.bindingIndex) as { id: number } | null;
-        srcVertexId = v?.id ?? null;
-      } else if (cand.bindingType === 'local') {
-        const v = getLocalVertex.get(cand.callerFuncId, cand.argName) as { id: number } | null;
-        srcVertexId = v?.id ?? null;
-      }
+    // Find source vertex x in caller
+    let srcVertexId: number | null = null;
+    if (cand.bindingType === 'param' && cand.bindingIndex != null) {
+      const v = getParamVertex.get(cand.callerFuncId, cand.bindingIndex) as { id: number } | null;
+      srcVertexId = v?.id ?? null;
+    } else if (cand.bindingType === 'local') {
+      const v = getLocalVertex.get(cand.callerFuncId, cand.argName) as { id: number } | null;
+      srcVertexId = v?.id ?? null;
+    }
 
-      if (!srcVertexId) continue;
+    if (!srcVertexId) continue;
 
-      // Find callee's param[argIndex] vertex
-      const calleeParam = getParamVertex.get(cand.calleeFuncId, cand.argIndex) as {
-        id: number;
-      } | null;
-      if (!calleeParam) continue;
+    // Find callee's param[argIndex] vertex
+    const calleeParam = getParamVertex.get(cand.calleeFuncId, cand.argIndex) as {
+      id: number;
+    } | null;
+    if (!calleeParam) continue;
 
-      // arg_in: A's source → B.param[j]
-      insertInterEdge.run(
-        cand.callerFuncId,
-        cand.calleeFuncId,
-        'arg_in',
-        srcVertexId,
-        calleeParam.id,
-        callEdgeId,
-        cand.expression,
-        cand.line,
-        cand.confidence,
-      );
-      count++;
+    // arg_in: A's source → B.param[j]
+    insertInterEdge.run(
+      cand.callerFuncId,
+      cand.calleeFuncId,
+      'arg_in',
+      srcVertexId,
+      calleeParam.id,
+      callEdgeId,
+      cand.expression,
+      cand.line,
+      cand.confidence,
+    );
+    count++;
 
-      // return_out: if B.param[j] reaches B's return, emit B.return → A's capture
-      const summary = getSummary.get(cand.calleeFuncId, cand.argIndex) as {
-        flows_to_return: number;
-      } | null;
-      if (summary?.flows_to_return) {
-        const calleeReturn = getReturnVertex.get(cand.calleeFuncId) as { id: number } | null;
-        if (calleeReturn) {
-          const captureVarName = captureMap.get(`${cand.callerFuncId}:${cand.calleeFuncId}`);
-          const captureVertex = captureVarName
-            ? (getLocalVertex.get(cand.callerFuncId, captureVarName) as { id: number } | null)
-            : null;
-          if (captureVertex) {
-            insertInterEdge.run(
-              cand.calleeFuncId,
-              cand.callerFuncId,
-              'return_out',
-              calleeReturn.id,
-              captureVertex.id,
-              callEdgeId,
-              cand.expression,
-              cand.line,
-              cand.confidence,
-            );
-            count++;
-          }
+    // return_out: if B.param[j] reaches B's return, emit B.return → A's capture
+    const summary = getSummary.get(cand.calleeFuncId, cand.argIndex) as {
+      flows_to_return: number;
+    } | null;
+    if (summary?.flows_to_return) {
+      const calleeReturn = getReturnVertex.get(cand.calleeFuncId) as { id: number } | null;
+      if (calleeReturn) {
+        const captureVarName = captureMap.get(`${cand.callerFuncId}:${cand.calleeFuncId}`);
+        const captureVertex = captureVarName
+          ? (getLocalVertex.get(cand.callerFuncId, captureVarName) as { id: number } | null)
+          : null;
+        if (captureVertex) {
+          insertInterEdge.run(
+            cand.calleeFuncId,
+            cand.callerFuncId,
+            'return_out',
+            calleeReturn.id,
+            captureVertex.id,
+            callEdgeId,
+            cand.expression,
+            cand.line,
+            cand.confidence,
+          );
+          count++;
         }
       }
     }
-  });
+  }
 
-  tx();
+  return count;
+}
+
+/**
+ * Wrap runInterproceduralStitch in its own transaction.
+ *
+ * Used only by buildDataflowP4ForNative, which calls the stitch as a
+ * standalone operation outside any other transaction boundary.  All other
+ * call sites (buildDataflowVerticesFromMap, buildDataflowEdges) manage their
+ * own outer transaction and call runInterproceduralStitch directly to avoid
+ * nesting, which better-sqlite3 does not support.
+ */
+function buildInterproceduralStitch(
+  db: BetterSqlite3Database,
+  candidates: StitchCandidate[],
+  captures: ReturnCapture[],
+): number {
+  if (candidates.length === 0) return 0;
+  let count = 0;
+  db.transaction(() => {
+    count = runInterproceduralStitch(db, candidates, captures);
+  })();
   return count;
 }
 
@@ -825,24 +852,32 @@ export function buildDataflowVerticesFromMap(
   if (!vstmts.available || dataflowMap.size === 0) return 0;
 
   const stmts = prepareNodeResolvers(db);
-  const allCandidates: StitchCandidate[] = [];
-  const allCaptures: ReturnCapture[] = [];
 
+  // Vertex writes and inter-procedural stitch are a single atomic unit: if the
+  // stitch throws or the process is killed between the two, the DB would be left
+  // with dataflow_vertices rows but no arg_in/return_out edges.  Wrapping both
+  // under one transaction boundary prevents that half-written state.
+  let stitchCount = 0;
   const tx = db.transaction(() => {
+    const allCandidates: StitchCandidate[] = [];
+    const allCaptures: ReturnCapture[] = [];
+
     for (const [relPath, data] of dataflowMap) {
       const resolver = makeNodeResolver(stmts, relPath);
       const { candidates, captures } = buildDataflowVerticesAndEdges(db, vstmts, data, resolver);
       allCandidates.push(...candidates);
       allCaptures.push(...captures);
     }
+
+    // P4: merge in stitch candidates from unchanged caller files if provided.
+    if (extraCandidates && extraCandidates.length > 0) allCandidates.push(...extraCandidates);
+    if (extraCaptures && extraCaptures.length > 0) allCaptures.push(...extraCaptures);
+
+    stitchCount = runInterproceduralStitch(db, allCandidates, allCaptures);
   });
   tx();
 
-  // P4: merge in stitch candidates from unchanged caller files if provided.
-  if (extraCandidates && extraCandidates.length > 0) allCandidates.push(...extraCandidates);
-  if (extraCaptures && extraCaptures.length > 0) allCaptures.push(...extraCaptures);
-
-  return buildInterproceduralStitch(db, allCandidates, allCaptures);
+  return stitchCount;
 }
 
 /**
@@ -959,10 +994,50 @@ export async function buildDataflowEdges(
       // Rust DataflowResult already contains parameters/returns — no re-parse needed.
       const vstmts = prepareVertexStmts(db);
       if (vstmts.available) {
-        const allCandidates: StitchCandidate[] = [];
-        const allCaptures: ReturnCapture[] = [];
+        // P4: Incremental re-stitch — unchanged caller files are not in
+        // fileSymbols so their arg_in edges to the old param vertices were
+        // deleted by the purge and never recreated. Re-collect stitch
+        // candidates from those caller files by parsing them from disk.
+        //
+        // Skip on full builds: fileSymbols covers every file in the DB, so
+        // there are no unchanged callers to re-stitch.
+        //
+        // This async disk-read step must happen BEFORE the transaction opens
+        // (SQLite transactions are synchronous; async work inside them is not
+        // supported by better-sqlite3).
+        const totalFilesInDb = (
+          db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
+        ).n;
+        let p4CallerCount = 0;
+        const p4Candidates: StitchCandidate[] = [];
+        const p4Captures: ReturnCapture[] = [];
+        if (fileSymbols.size < totalFilesInDb) {
+          const changedRelPaths = new Set<string>(fileSymbols.keys());
+          const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
+          const extra = await collectCallerStitchCandidates(
+            db,
+            changedFuncIds,
+            changedRelPaths,
+            rootDir,
+            extToLang,
+            null,
+            null,
+          );
+          p4Candidates.push(...extra.candidates);
+          p4Captures.push(...extra.captures);
+          p4CallerCount = extra.candidates.length;
+        }
 
+        // Vertex writes and inter-procedural stitch are a single atomic unit:
+        // if the stitch throws or the process is killed between the two, the DB
+        // would be left with dataflow_vertices rows but no arg_in/return_out
+        // edges.  Wrapping both under one transaction boundary prevents that
+        // half-written state.
+        let interCount = 0;
         const txVertex = db.transaction(() => {
+          const allCandidates: StitchCandidate[] = [];
+          const allCaptures: ReturnCapture[] = [];
+
           for (const [relPath, symbols] of fileSymbols) {
             if (!symbols.dataflow) continue;
             const ext = path.extname(relPath).toLowerCase();
@@ -977,38 +1052,15 @@ export async function buildDataflowEdges(
             allCandidates.push(...candidates);
             allCaptures.push(...captures);
           }
+
+          // Merge in the P4 candidates collected above before opening the tx.
+          allCandidates.push(...p4Candidates);
+          allCaptures.push(...p4Captures);
+
+          interCount = runInterproceduralStitch(db, allCandidates, allCaptures);
         });
         txVertex();
 
-        // P4: Incremental re-stitch — unchanged caller files are not in
-        // fileSymbols so their arg_in edges to the old param vertices were
-        // deleted by the purge and never recreated. Re-collect stitch
-        // candidates from those caller files by parsing them from disk.
-        //
-        // Skip on full builds: fileSymbols covers every file in the DB, so
-        // there are no unchanged callers to re-stitch.
-        const totalFilesInDb = (
-          db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
-        ).n;
-        let p4CallerCount = 0;
-        if (fileSymbols.size < totalFilesInDb) {
-          const changedRelPaths = new Set<string>(fileSymbols.keys());
-          const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
-          const extra = await collectCallerStitchCandidates(
-            db,
-            changedFuncIds,
-            changedRelPaths,
-            rootDir,
-            extToLang,
-            null,
-            null,
-          );
-          allCandidates.push(...extra.candidates);
-          allCaptures.push(...extra.captures);
-          p4CallerCount = extra.candidates.length;
-        }
-
-        const interCount = buildInterproceduralStitch(db, allCandidates, allCaptures);
         info(
           `Dataflow (native): ${interCount} inter-procedural edges inserted${p4CallerCount > 0 ? ` (P4: ${p4CallerCount} re-stitch candidate(s) from unchanged callers)` : ''}`,
         );
@@ -1029,12 +1081,51 @@ export async function buildDataflowEdges(
 
   const stmts = prepareNodeResolvers(db);
   const vstmts = prepareVertexStmts(db);
+
+  // P4: Incremental re-stitch — if only a subset of files changed, callers of
+  // the changed functions were not in fileSymbols, so their arg_in edges were
+  // deleted by the purge but never reconstructed. Re-collect stitch candidates
+  // from those caller files now (read from disk, no DB writes).
+  //
+  // Skip P4 on full builds: when fileSymbols covers every file in the DB there
+  // are no unchanged callers, and collectFuncIdsForFiles would issue one SELECT
+  // per file for nothing.  A single COUNT query is cheaper than N per-file SELECTs.
+  //
+  // This async disk-read step must happen BEFORE the transaction opens
+  // (SQLite transactions are synchronous; async work inside them is not
+  // supported by better-sqlite3).
+  const totalFilesInDb = (
+    db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
+  ).n;
+  const p4Candidates: StitchCandidate[] = [];
+  const p4Captures: ReturnCapture[] = [];
+  if (vstmts.available && fileSymbols.size < totalFilesInDb) {
+    const changedRelPaths = new Set<string>(fileSymbols.keys());
+    const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
+    const extra = await collectCallerStitchCandidates(
+      db,
+      changedFuncIds,
+      changedRelPaths,
+      rootDir,
+      extToLang,
+      parsers,
+      getParserFn,
+    );
+    p4Candidates.push(...extra.candidates);
+    p4Captures.push(...extra.captures);
+  }
+
+  // Edge writes, vertex writes, and inter-procedural stitch are a single
+  // atomic unit: if the stitch throws or the process is killed between vertex
+  // writes and the stitch, the DB would be left with dataflow_vertices rows
+  // but no arg_in/return_out edges.  Wrapping all three under one transaction
+  // boundary prevents that half-written state.
   let totalEdges = 0;
-
-  const allCandidates: StitchCandidate[] = [];
-  const allCaptures: ReturnCapture[] = [];
-
+  let interCount = 0;
   const tx = db.transaction(() => {
+    const allCandidates: StitchCandidate[] = [];
+    const allCaptures: ReturnCapture[] = [];
+
     for (const [relPath, symbols] of fileSymbols) {
       const ext = path.extname(relPath).toLowerCase();
       if (!DATAFLOW_EXTENSIONS.has(ext)) continue;
@@ -1048,41 +1139,16 @@ export async function buildDataflowEdges(
       allCandidates.push(...candidates);
       allCaptures.push(...captures);
     }
+
+    // Merge in the P4 candidates collected above before opening the tx.
+    allCandidates.push(...p4Candidates);
+    allCaptures.push(...p4Captures);
+
+    // P2: inter-procedural stitch — runs after all per-file vertices + summaries written
+    interCount = vstmts.available ? runInterproceduralStitch(db, allCandidates, allCaptures) : 0;
   });
 
   tx();
-
-  // P4: Incremental re-stitch — if only a subset of files changed, callers of
-  // the changed functions were not in fileSymbols, so their arg_in edges were
-  // deleted by the purge but never reconstructed. Re-collect stitch candidates
-  // from those caller files now (read from disk, no DB writes).
-  //
-  // Skip P4 on full builds: when fileSymbols covers every file in the DB there
-  // are no unchanged callers, and collectFuncIdsForFiles would issue one SELECT
-  // per file for nothing.  A single COUNT query is cheaper than N per-file SELECTs.
-  const totalFilesInDb = (
-    db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
-  ).n;
-  if (vstmts.available && fileSymbols.size < totalFilesInDb) {
-    const changedRelPaths = new Set<string>(fileSymbols.keys());
-    const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
-    const extra = await collectCallerStitchCandidates(
-      db,
-      changedFuncIds,
-      changedRelPaths,
-      rootDir,
-      extToLang,
-      parsers,
-      getParserFn,
-    );
-    allCandidates.push(...extra.candidates);
-    allCaptures.push(...extra.captures);
-  }
-
-  // P2: inter-procedural stitch — runs after all per-file vertices + summaries committed
-  const interCount = vstmts.available
-    ? buildInterproceduralStitch(db, allCandidates, allCaptures)
-    : 0;
 
   info(`Dataflow: ${totalEdges} fn-level edges, ${interCount} inter-procedural edges inserted`);
 }

--- a/src/features/dataflow.ts
+++ b/src/features/dataflow.ts
@@ -469,15 +469,6 @@ function buildDataflowVerticesAndEdges(
 // ── P2: interprocedural stitching ─────────────────────────────────────────────
 
 /**
- * Post-pass: connect arg-flow candidates to vertex-level inter-procedural edges.
- * Runs after all per-file vertices + summaries have been committed.
- *
- * For each resolved argFlow (A calls B with arg x → B.param[j]):
- *  - Emits 'arg_in' inter edge: A's source vertex → B.param[j] vertex
- *  - If B's summary shows B.param[j] reaches B's return: emits 'return_out'
- *    inter edge: B.return → A's capture local (if any)
- */
-/**
  * Core stitch logic — must be called inside an already-open transaction.
  *
  * Separated from buildInterproceduralStitch so callers that manage their own


### PR DESCRIPTION
## Summary

- The native binary's full build sets `PRAGMA foreign_keys = ON` at the end of `clear_all_graph_data()`. On the next incremental build, native binaries older than v3.14 run `purge_changed_files()` without first removing `dataflow_vertices` / `call_edge_id`-referencing `dataflow` rows, causing FK constraint failures that silently leave stale nodes and edges in the DB.
- When stage 6b (barrel-candidate re-parse) tries to clear `parser.js`'s outgoing edges via `DELETE FROM edges WHERE source_id IN ... AND kind NOT IN ('contains','parameter_of')`, the `call_edge_id` FK also blocks that delete (silently, since it's `let _ = ...`). The stage then re-inserts fresh import edges on top of the surviving stale ones — doubling the `imports` edge count (11 vs expected 6 in the issue-1174 chained-barrel fixture).
- Fix: call `PRAGMA foreign_keys = OFF` on the native connection immediately before `buildGraph()`. The connection is closed after the build completes, so the setting doesn't persist. The purge SQL ordering is logically correct (children before parents) — FK enforcement was only masking that older binaries lacked the v18-schema cleanup steps.

## Test plan

- [ ] `npx vitest run tests/integration/issue-1174-chained-barrel-incremental.test.ts` — all 6 tests pass (was: 1 failed with `expected 11 to be 6`)
- [ ] `npm test` — 1 pre-existing failure in `build-parity.test.ts` (roles parity, tracked as #1659), all other tests pass

Closes #1644