### PR TITLE
feat(dynamic-calls): RES-3 — type-aware method name lookup for JVM getMethod patterns

### DIFF
--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1072,6 +1072,45 @@ function resolveFallbackTargets(
     }
   }
 
+  // RES-3: reflection with literal method name — JVM getMethod("name") / invokeMethod("name").
+  // Java/Scala/Groovy methods are stored as class-qualified names (e.g. Reflection.greet),
+  // so lookup.byNameAndFile('greet', relPath) finds nothing. When dynamicKind='reflection'
+  // and keyExpr is set (a string-literal method name was captured), try the qualified form:
+  //   1. typeMap[receiver] → resolvedType → lookup `resolvedType.keyExpr` (type-annotated local)
+  //   2. callerName class prefix → `CallerClass.keyExpr` (same-class sibling, e.g. Groovy obj)
+  // Scoped to non-JS/TS files to avoid interfering with the JS reflection path.
+  if (
+    targets.length === 0 &&
+    call.dynamicKind === 'reflection' &&
+    call.keyExpr &&
+    call.receiver &&
+    !isModuleScopedLanguage(relPath)
+  ) {
+    const typeEntry = typeMap.get(call.receiver);
+    const resolvedType = typeEntry
+      ? typeof typeEntry === 'string'
+        ? typeEntry
+        : (typeEntry as { type?: string }).type
+      : null;
+    if (resolvedType) {
+      const qualified = lookup
+        .byNameAndFile(`${resolvedType}.${call.keyExpr}`, relPath)
+        .filter((n) => n.kind === 'method' || n.kind === 'function');
+      if (qualified.length > 0) targets = qualified;
+    }
+    if (targets.length === 0 && caller.callerName != null) {
+      const lastDot = caller.callerName.lastIndexOf('.');
+      if (lastDot > 0) {
+        const prevDot = caller.callerName.lastIndexOf('.', lastDot - 1);
+        const callerClass = caller.callerName.slice(prevDot + 1, lastDot);
+        const qualified = lookup
+          .byNameAndFile(`${callerClass}.${call.keyExpr}`, relPath)
+          .filter((n) => n.kind === 'method' || n.kind === 'function');
+        if (qualified.length > 0) targets = qualified;
+      }
+    }
+  }
+
   // Object.defineProperty accessor fallback: when a function is registered as
   // a getter/setter via `Object.defineProperty(obj, "bar", { get: getter })`,
   // calls to `this.X()` inside `getter` resolve against `obj` (this === obj

--- a/tests/benchmarks/resolution/fixtures/dynamic-java/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/dynamic-java/expected-edges.json
@@ -4,11 +4,11 @@
   "description": "Phase 2 JVM fixture: Java reflection patterns. getMethod('name') resolved; invoke() flagged.",
   "edges": [
     {
-      "source": { "name": "runGetMethod", "file": "Reflection.java" },
-      "target": { "name": "greet", "file": "Reflection.java" },
+      "source": { "name": "Reflection.runGetMethod", "file": "Reflection.java" },
+      "target": { "name": "Reflection.greet", "file": "Reflection.java" },
       "kind": "calls",
       "mode": "dynamic",
-      "notes": "clazz.getMethod('greet') — reflection kind, resolved to greet() in same class"
+      "notes": "clazz.getMethod('greet') — reflection kind, resolved to Reflection.greet() via caller-class qualifier"
     }
   ]
 }

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -143,15 +143,14 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   //   3 expected edges (Reflect.apply → greet, Reflect.construct → UserService, Reflect.get → greet).
   'dynamic-typescript': { precision: 1.0, recall: 0.75 },
   // Phase 2 JVM fixtures — reflection and dynamic dispatch patterns.
-  // Java/Scala/Groovy: detection works but method names are class-qualified in the DB,
-  //   so lookup-by-name fails for getMethod("foo") → 0% recall until RES-3 adds type-aware lookup.
+  // RES-3: type-aware qualified lookup resolves getMethod("foo") → ClassName.foo.
   //   invoke() and forName() emit sink edges (confidence=0.0, excluded from metrics).
-  'dynamic-java': { precision: 0.0, recall: 0.0 },
+  'dynamic-java': { precision: 1.0, recall: 1.0 },
   // Kotlin: ::fn callable refs resolve correctly (top-level fns are unqualified in DB).
   //   invoke() emits sink edge (excluded). 100% recall achievable.
   'dynamic-kotlin': { precision: 1.0, recall: 1.0 },
-  'dynamic-scala': { precision: 0.0, recall: 0.0 },
-  'dynamic-groovy': { precision: 0.0, recall: 0.0 },
+  'dynamic-scala': { precision: 1.0, recall: 1.0 },
+  'dynamic-groovy': { precision: 1.0, recall: 1.0 },
   // TS 0.72: Phase 8.3e adds this.method() same-class resolution (Shape.describe → Shape.area),
   //   lifting recall from 69.4% to 72.2%.  Remaining gap (interface-dispatch, CHA) is tracked
   //   in Phase 8.5 (TSC enrichment) and Phase 8.7 (CHA on JS/TS).


### PR DESCRIPTION
## Summary

- Adds a RES-3 fallback in `resolveFallbackTargets` (`build-edges.ts`): when `dynamicKind='reflection'` and `keyExpr` is set (a string-literal method name was captured from `getMethod("name")`/`invokeMethod("name")`), try two class-qualified lookups — typeMap receiver type first, then caller class prefix — since Java/Scala/Groovy methods are stored as `ClassName.methodName` in the DB
- Corrects `dynamic-java` expected-edges.json to use class-qualified names (`Reflection.runGetMethod` / `Reflection.greet`) matching how Java symbols are stored in the DB
- Raises benchmark thresholds for `dynamic-java`, `dynamic-scala`, `dynamic-groovy` from 0% to 100% (now fully resolved)

## Test plan

- [x] `dynamic-java`: 100% precision / 100% recall (was 0%)
- [x] `dynamic-scala`: 100% precision / 100% recall (was 0%)
- [x] `dynamic-groovy`: 100% precision / 100% recall (was 0%)
- [x] `dynamic-kotlin`: remains 100% precision / 100% recall (unaffected)
- [x] No regressions — fix is scoped to `!isModuleScopedLanguage(relPath)` so JS/TS reflection path is untouched

Closes #1650