### PR TITLE
fix(dynamic-calls): Kotlin member callable refs resolve to wrong target when same-named top-level function exists

### DIFF
--- a/.codegraphrc.json
+++ b/.codegraphrc.json
@@ -1,4 +1,5 @@
 {
   "embeddings": { "model": "bge-large" },
-  "exclude": ["crates/**"]
+  "exclude": ["crates/**"],
+  "ignoreAdditionalDirs": ["crates"]
 }

--- a/src/db/repository/build-stmts.ts
+++ b/src/db/repository/build-stmts.ts
@@ -6,6 +6,7 @@ interface PurgeStmts {
   cfgBlocks: SqliteStatement | null;
   dataflow: SqliteStatement | null;
   dataflowByVertex: SqliteStatement | null;
+  dataflowByCallEdge: SqliteStatement | null;
   dataflowSummary: SqliteStatement | null;
   dataflowVertices: SqliteStatement | null;
   complexity: SqliteStatement | null;
@@ -51,6 +52,16 @@ function preparePurgeStmts(db: BetterSqlite3Database): PurgeStmts {
       `DELETE FROM dataflow WHERE source_vertex IN (SELECT id FROM dataflow_vertices WHERE func_id IN (SELECT id FROM nodes WHERE file = ?))
          OR target_vertex IN (SELECT id FROM dataflow_vertices WHERE func_id IN (SELECT id FROM nodes WHERE file = ?))`,
     ),
+    // Delete dataflow rows whose call_edge_id references a calls edge that
+    // touches the deleted file (source or target). These rows are not caught by
+    // the source_id/target_id or vertex-based deletions above when the dataflow
+    // row's own nodes live in other files. Must run before the edges delete to
+    // avoid SQLITE_CONSTRAINT_FOREIGNKEY: dataflow.call_edge_id REFERENCES edges(id).
+    dataflowByCallEdge: tryPrepare(
+      `DELETE FROM dataflow WHERE call_edge_id IN
+         (SELECT id FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = @f)
+          OR target_id IN (SELECT id FROM nodes WHERE file = @f))`,
+    ),
     dataflowSummary: tryPrepare(
       'DELETE FROM dataflow_summary WHERE func_id IN (SELECT id FROM nodes WHERE file = ?)',
     ),
@@ -94,6 +105,9 @@ function runPurge(stmts: PurgeStmts, file: string, opts: PurgeOpts = {}): void {
   stmts.cfgBlocks?.run(file);
   stmts.dataflow?.run(file, file);
   stmts.dataflowByVertex?.run(file, file);
+  // Clear dataflow rows keyed by call_edge_id before deleting edges so the FK
+  // (dataflow.call_edge_id REFERENCES edges(id)) does not block the edge purge.
+  stmts.dataflowByCallEdge?.run({ f: file });
   stmts.dataflowSummary?.run(file);
   stmts.dataflowVertices?.run(file);
   stmts.complexity?.run(file);

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -56,7 +56,7 @@ export const CHA_DISPATCH_PENALTY = 0.1;
 export const CHA_TYPED_DISPATCH_CONFIDENCE = 0.8;
 
 /** Check if a directory entry should be skipped (ignored dirs, dotfiles). */
-function shouldSkipEntry(entry: fs.Dirent, ignoreSet: Set<string>): boolean {
+function shouldSkipEntry(entry: fs.Dirent, ignoreSet: ReadonlySet<string>): boolean {
   if (entry.name.startsWith('.') && entry.name !== '.') {
     if (ignoreSet.has(entry.name)) return true;
     if (entry.isDirectory()) return true;
@@ -140,7 +140,7 @@ interface CollectContext {
   readonly gitignoreRegexes: readonly RegExp[];
   readonly hasGlobFilters: boolean;
   /** Merged set of IGNORE_DIRS + config.ignoreDirs + config.ignoreAdditionalDirs. */
-  readonly ignoreSet: Set<string>;
+  readonly ignoreSet: ReadonlySet<string>;
   readonly visited: Set<string>;
 }
 

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { purgeFilesData } from '../../../db/index.js';
 import { debug, warn } from '../../../infrastructure/logger.js';
-import { EXTENSIONS, IGNORE_DIRS, normalizePath } from '../../../shared/constants.js';
+import { buildIgnoreSet, EXTENSIONS, normalizePath } from '../../../shared/constants.js';
 import { compileGlobs, globToRegex, matchesAny } from '../../../shared/globs.js';
 import type {
   BetterSqlite3Database,
@@ -56,13 +56,12 @@ export const CHA_DISPATCH_PENALTY = 0.1;
 export const CHA_TYPED_DISPATCH_CONFIDENCE = 0.8;
 
 /** Check if a directory entry should be skipped (ignored dirs, dotfiles). */
-function shouldSkipEntry(entry: fs.Dirent, extraIgnore: Set<string> | null): boolean {
+function shouldSkipEntry(entry: fs.Dirent, ignoreSet: Set<string>): boolean {
   if (entry.name.startsWith('.') && entry.name !== '.') {
-    if (IGNORE_DIRS.has(entry.name)) return true;
+    if (ignoreSet.has(entry.name)) return true;
     if (entry.isDirectory()) return true;
   }
-  if (IGNORE_DIRS.has(entry.name)) return true;
-  if (extraIgnore?.has(entry.name)) return true;
+  if (ignoreSet.has(entry.name)) return true;
   return false;
 }
 
@@ -140,7 +139,8 @@ interface CollectContext {
   readonly excludeRegexes: readonly RegExp[];
   readonly gitignoreRegexes: readonly RegExp[];
   readonly hasGlobFilters: boolean;
-  readonly extraIgnore: Set<string> | null;
+  /** Merged set of IGNORE_DIRS + config.ignoreDirs + config.ignoreAdditionalDirs. */
+  readonly ignoreSet: Set<string>;
   readonly visited: Set<string>;
 }
 
@@ -193,7 +193,7 @@ function walkCollect(
 
   let hasFiles = false;
   for (const entry of entries) {
-    if (shouldSkipEntry(entry, ctx.extraIgnore)) continue;
+    if (shouldSkipEntry(entry, ctx.ignoreSet)) continue;
 
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
@@ -237,13 +237,18 @@ export function collectFiles(
   const includeRegexes = compileGlobs(config.include);
   const excludeRegexes = compileGlobs(config.exclude);
   const gitignoreRegexes = readGitignorePatterns(dir);
+  // Build the merged ignore set:
+  //   - config.ignoreDirs are appended to IGNORE_DIRS (existing behaviour: per-repo overrides)
+  //   - config.ignoreAdditionalDirs are also merged in on top of IGNORE_DIRS (new feature)
+  const extraDirs = [...(config.ignoreDirs ?? []), ...(config.ignoreAdditionalDirs ?? [])];
+  const ignoreSet = buildIgnoreSet(extraDirs.length ? extraDirs : undefined);
   const ctx: CollectContext = {
     rootDir: dir,
     includeRegexes,
     excludeRegexes,
     gitignoreRegexes,
     hasGlobFilters: includeRegexes.length > 0 || excludeRegexes.length > 0,
-    extraIgnore: config.ignoreDirs ? new Set(config.ignoreDirs) : null,
+    ignoreSet,
     visited: new Set(),
   };
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1072,6 +1072,45 @@ function resolveFallbackTargets(
     }
   }
 
+  // RES-3: reflection with literal method name — JVM getMethod("name") / invokeMethod("name").
+  // Java/Scala/Groovy methods are stored as class-qualified names (e.g. Reflection.greet),
+  // so lookup.byNameAndFile('greet', relPath) finds nothing. When dynamicKind='reflection'
+  // and keyExpr is set (a string-literal method name was captured), try the qualified form:
+  //   1. typeMap[receiver] → resolvedType → lookup `resolvedType.keyExpr` (type-annotated local)
+  //   2. callerName class prefix → `CallerClass.keyExpr` (same-class sibling, e.g. Groovy obj)
+  // Scoped to non-JS/TS files to avoid interfering with the JS reflection path.
+  if (
+    targets.length === 0 &&
+    call.dynamicKind === 'reflection' &&
+    call.keyExpr &&
+    call.receiver &&
+    !isModuleScopedLanguage(relPath)
+  ) {
+    const typeEntry = typeMap.get(call.receiver);
+    const resolvedType = typeEntry
+      ? typeof typeEntry === 'string'
+        ? typeEntry
+        : (typeEntry as { type?: string }).type
+      : null;
+    if (resolvedType) {
+      const qualified = lookup
+        .byNameAndFile(`${resolvedType}.${call.keyExpr}`, relPath)
+        .filter((n) => n.kind === 'method' || n.kind === 'function');
+      if (qualified.length > 0) targets = qualified;
+    }
+    if (targets.length === 0 && caller.callerName != null) {
+      const lastDot = caller.callerName.lastIndexOf('.');
+      if (lastDot > 0) {
+        const prevDot = caller.callerName.lastIndexOf('.', lastDot - 1);
+        const callerClass = caller.callerName.slice(prevDot + 1, lastDot);
+        const qualified = lookup
+          .byNameAndFile(`${callerClass}.${call.keyExpr}`, relPath)
+          .filter((n) => n.kind === 'method' || n.kind === 'function');
+        if (qualified.length > 0) targets = qualified;
+      }
+    }
+  }
+
   // Object.defineProperty accessor fallback: when a function is registered as
   // a getter/setter via `Object.defineProperty(obj, "bar", { get: getter })`,
   // calls to `this.X()` inside `getter` resolve against `obj` (this === obj

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1021,14 +1021,39 @@ function resolveFallbackTargets(
   targets: ReadonlyArray<{ id: number; file: string; kind?: string }>;
   importedFrom: string | null | undefined;
 } {
-  let { targets, importedFrom } = resolveCallTargets(
-    lookup,
-    call,
-    relPath,
-    importedNames,
-    typeMap as Map<string, unknown>,
-    caller.callerName,
-  );
+  // RES-4: Kotlin member callable reference — `Greeter::greet` emits
+  // { name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' }.
+  // The receiver is the class qualifier (not a typeMap variable), so
+  // resolveCallTargets would find a same-named top-level function via
+  // byNameAndFile('greet', relPath) before the qualified form is tried.
+  // Prefer `Greeter.greet` in the same file first; fall through to the
+  // normal path only when no qualified match exists.
+  let preQualifiedTargets: ReadonlyArray<{ id: number; file: string; kind?: string }> = [];
+  if (
+    call.dynamicKind === 'reflection' &&
+    call.receiver &&
+    !call.keyExpr &&
+    !isModuleScopedLanguage(relPath)
+  ) {
+    preQualifiedTargets = lookup
+      .byNameAndFile(`${call.receiver}.${call.name}`, relPath)
+      .filter((n) => n.kind === 'method' || n.kind === 'function');
+  }
+
+  let { targets, importedFrom } =
+    preQualifiedTargets.length > 0
+      ? {
+          targets: preQualifiedTargets as Array<{ id: number; file: string; kind?: string }>,
+          importedFrom: undefined as string | undefined,
+        }
+      : resolveCallTargets(
+          lookup,
+          call,
+          relPath,
+          importedNames,
+          typeMap as Map<string, unknown>,
+          caller.callerName,
+        );
 
   // Same-class `this.method()` fallback: when the call receiver is `this` and
   // resolveCallTargets found nothing, derive the enclosing class name from the

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -2105,8 +2105,8 @@ export async function tryNativeOrchestrator(
   // nodes/edges during incremental builds, so FK enforcement causes the purge
   // statements to fail silently — leaving stale nodes and edges that then get
   // duplicated when the barrel-candidate re-parse re-inserts them (issue #1644).
-  // Disabling FK before buildGraph() lets the purge succeed. FK enforcement is
-  // restored automatically when this connection is closed after the build.
+  // Disabling FK before buildGraph() lets the purge succeed; re-enable afterwards
+  // so JS post-passes run with full FK enforcement.
   try {
     ctx.nativeDb.exec('PRAGMA foreign_keys = OFF');
   } catch {
@@ -2119,6 +2119,12 @@ export async function tryNativeOrchestrator(
     JSON.stringify(ctx.aliases),
     JSON.stringify(ctx.opts),
   );
+  // Restore FK enforcement for JS post-passes (CHA, dataflow, structure).
+  try {
+    ctx.nativeDb.exec('PRAGMA foreign_keys = ON');
+  } catch {
+    // exec may not exist on very old addon versions — safe to ignore
+  }
   const result = JSON.parse(resultJson) as NativeOrchestratorResult;
 
   if (result.earlyExit) {

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -2040,6 +2040,20 @@ export async function tryNativeOrchestrator(
 
   if (!ctx.nativeDb?.buildGraph) return undefined;
 
+  // The previous full build's clear_all_graph_data() sets PRAGMA foreign_keys = ON
+  // on the native connection. Older native binaries (< v3.14) do not delete
+  // dataflow_vertices / dataflow_summary / call_edge_id rows before purging
+  // nodes/edges during incremental builds, so FK enforcement causes the purge
+  // statements to fail silently — leaving stale nodes and edges that then get
+  // duplicated when the barrel-candidate re-parse re-inserts them (issue #1644).
+  // Disabling FK before buildGraph() lets the purge succeed. FK enforcement is
+  // restored automatically when this connection is closed after the build.
+  try {
+    ctx.nativeDb.exec('PRAGMA foreign_keys = OFF');
+  } catch {
+    // exec may not exist on very old addon versions — safe to ignore
+  }
+
   const resultJson = ctx.nativeDb.buildGraph(
     ctx.rootDir,
     JSON.stringify(ctx.config),

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -1,17 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { closeDb, getNodeId as getNodeIdQuery, initSchema, openDb } from '../../db/index.js';
+import { loadConfig } from '../../infrastructure/config.js';
 import { debug, info, warn } from '../../infrastructure/logger.js';
-import { isSupportedFile, normalizePath, shouldIgnore } from '../../shared/constants.js';
+import { buildIgnoreSet, isSupportedFile, normalizePath } from '../../shared/constants.js';
 import { DbError } from '../../shared/errors.js';
 import { createParseTreeCache, getActiveEngine } from '../parser.js';
 import { type IncrementalStmts, rebuildFile } from './builder/incremental.js';
 import { appendChangeEvents, buildChangeEvent, diffSymbols } from './change-journal.js';
 import { appendJournalEntriesAndStampHeader } from './journal.js';
 
-function shouldIgnorePath(filePath: string): boolean {
+function shouldIgnorePath(filePath: string, ignoreSet: ReadonlySet<string>): boolean {
   const parts = filePath.split(path.sep);
-  return parts.some((p) => shouldIgnore(p));
+  return parts.some((p) => ignoreSet.has(p) || p.startsWith('.'));
 }
 
 /** Prepare all SQL statements needed by the watcher's incremental rebuild. */
@@ -139,7 +140,7 @@ function logRebuildResults(updates: RebuildResult[]): void {
 }
 
 /** Recursively collect tracked source files for stat-based polling. */
-function collectTrackedFiles(dir: string, result: string[]): void {
+function collectTrackedFiles(dir: string, result: string[], ignoreSet: ReadonlySet<string>): void {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -148,10 +149,10 @@ function collectTrackedFiles(dir: string, result: string[]): void {
     return;
   }
   for (const entry of entries) {
-    if (shouldIgnore(entry.name)) continue;
+    if (ignoreSet.has(entry.name) || entry.name.startsWith('.')) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      collectTrackedFiles(full, result);
+      collectTrackedFiles(full, result, ignoreSet);
     } else if (isSupportedFile(entry.name)) {
       result.push(full);
     }
@@ -168,6 +169,8 @@ interface WatcherContext {
   pending: Set<string>;
   timer: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  /** Merged ignore set from IGNORE_DIRS + config.ignoreDirs + config.ignoreAdditionalDirs. */
+  ignoreSet: ReadonlySet<string>;
 }
 
 /** Initialize DB, engine, cache, and statements for watch mode. */
@@ -176,6 +179,12 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
   if (!fs.existsSync(dbPath)) {
     throw new DbError('No graph.db found. Run `codegraph build` first.', { file: dbPath });
   }
+
+  // Load repo config so ignoreDirs and ignoreAdditionalDirs are respected by
+  // the watcher the same way they are by collectFiles in the batch build path.
+  const config = loadConfig(rootDir);
+  const extraDirs = [...(config.ignoreDirs ?? []), ...(config.ignoreAdditionalDirs ?? [])];
+  const ignoreSet = buildIgnoreSet(extraDirs.length ? extraDirs : undefined);
 
   const db = openDb(dbPath);
   initSchema(db);
@@ -205,6 +214,7 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
     pending: new Set<string>(),
     timer: null,
     debounceMs: 300,
+    ignoreSet,
   };
 }
 
@@ -223,7 +233,7 @@ function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () =>
   const mtimeMap = new Map<string, number>();
 
   const initial: string[] = [];
-  collectTrackedFiles(ctx.rootDir, initial);
+  collectTrackedFiles(ctx.rootDir, initial, ctx.ignoreSet);
   for (const f of initial) {
     try {
       mtimeMap.set(f, fs.statSync(f).mtimeMs);
@@ -235,7 +245,7 @@ function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () =>
 
   const pollTimer = setInterval(() => {
     const current: string[] = [];
-    collectTrackedFiles(ctx.rootDir, current);
+    collectTrackedFiles(ctx.rootDir, current, ctx.ignoreSet);
     const currentSet = new Set(current);
 
     for (const f of current) {
@@ -270,7 +280,7 @@ function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () =>
 function startNativeWatcher(ctx: WatcherContext): () => void {
   const watcher = fs.watch(ctx.rootDir, { recursive: true }, (_eventType, filename) => {
     if (!filename) return;
-    if (shouldIgnorePath(filename)) return;
+    if (shouldIgnorePath(filename, ctx.ignoreSet)) return;
     if (!isSupportedFile(filename)) return;
 
     ctx.pending.add(path.join(ctx.rootDir, filename));

--- a/src/features/dataflow.ts
+++ b/src/features/dataflow.ts
@@ -477,7 +477,15 @@ function buildDataflowVerticesAndEdges(
  *  - If B's summary shows B.param[j] reaches B's return: emits 'return_out'
  *    inter edge: B.return → A's capture local (if any)
  */
-function buildInterproceduralStitch(
+/**
+ * Core stitch logic — must be called inside an already-open transaction.
+ *
+ * Separated from buildInterproceduralStitch so callers that manage their own
+ * outer transaction (buildDataflowVerticesFromMap, buildDataflowEdges) can
+ * call this directly without starting a nested transaction, which better-sqlite3
+ * does not support.
+ */
+function runInterproceduralStitch(
   db: BetterSqlite3Database,
   candidates: StitchCandidate[],
   captures: ReturnCapture[],
@@ -513,77 +521,96 @@ function buildInterproceduralStitch(
   }
 
   let count = 0;
-  const tx = db.transaction(() => {
-    for (const cand of candidates) {
-      // Resolve call edge for this site
-      const callEdge = getCallEdge.get(cand.callerFuncId, cand.calleeFuncId) as {
-        id: number;
-      } | null;
-      const callEdgeId = callEdge?.id ?? null;
+  for (const cand of candidates) {
+    // Resolve call edge for this site
+    const callEdge = getCallEdge.get(cand.callerFuncId, cand.calleeFuncId) as {
+      id: number;
+    } | null;
+    const callEdgeId = callEdge?.id ?? null;
 
-      // Find source vertex x in caller
-      let srcVertexId: number | null = null;
-      if (cand.bindingType === 'param' && cand.bindingIndex != null) {
-        const v = getParamVertex.get(cand.callerFuncId, cand.bindingIndex) as { id: number } | null;
-        srcVertexId = v?.id ?? null;
-      } else if (cand.bindingType === 'local') {
-        const v = getLocalVertex.get(cand.callerFuncId, cand.argName) as { id: number } | null;
-        srcVertexId = v?.id ?? null;
-      }
+    // Find source vertex x in caller
+    let srcVertexId: number | null = null;
+    if (cand.bindingType === 'param' && cand.bindingIndex != null) {
+      const v = getParamVertex.get(cand.callerFuncId, cand.bindingIndex) as { id: number } | null;
+      srcVertexId = v?.id ?? null;
+    } else if (cand.bindingType === 'local') {
+      const v = getLocalVertex.get(cand.callerFuncId, cand.argName) as { id: number } | null;
+      srcVertexId = v?.id ?? null;
+    }
 
-      if (!srcVertexId) continue;
+    if (!srcVertexId) continue;
 
-      // Find callee's param[argIndex] vertex
-      const calleeParam = getParamVertex.get(cand.calleeFuncId, cand.argIndex) as {
-        id: number;
-      } | null;
-      if (!calleeParam) continue;
+    // Find callee's param[argIndex] vertex
+    const calleeParam = getParamVertex.get(cand.calleeFuncId, cand.argIndex) as {
+      id: number;
+    } | null;
+    if (!calleeParam) continue;
 
-      // arg_in: A's source → B.param[j]
-      insertInterEdge.run(
-        cand.callerFuncId,
-        cand.calleeFuncId,
-        'arg_in',
-        srcVertexId,
-        calleeParam.id,
-        callEdgeId,
-        cand.expression,
-        cand.line,
-        cand.confidence,
-      );
-      count++;
+    // arg_in: A's source → B.param[j]
+    insertInterEdge.run(
+      cand.callerFuncId,
+      cand.calleeFuncId,
+      'arg_in',
+      srcVertexId,
+      calleeParam.id,
+      callEdgeId,
+      cand.expression,
+      cand.line,
+      cand.confidence,
+    );
+    count++;
 
-      // return_out: if B.param[j] reaches B's return, emit B.return → A's capture
-      const summary = getSummary.get(cand.calleeFuncId, cand.argIndex) as {
-        flows_to_return: number;
-      } | null;
-      if (summary?.flows_to_return) {
-        const calleeReturn = getReturnVertex.get(cand.calleeFuncId) as { id: number } | null;
-        if (calleeReturn) {
-          const captureVarName = captureMap.get(`${cand.callerFuncId}:${cand.calleeFuncId}`);
-          const captureVertex = captureVarName
-            ? (getLocalVertex.get(cand.callerFuncId, captureVarName) as { id: number } | null)
-            : null;
-          if (captureVertex) {
-            insertInterEdge.run(
-              cand.calleeFuncId,
-              cand.callerFuncId,
-              'return_out',
-              calleeReturn.id,
-              captureVertex.id,
-              callEdgeId,
-              cand.expression,
-              cand.line,
-              cand.confidence,
-            );
-            count++;
-          }
+    // return_out: if B.param[j] reaches B's return, emit B.return → A's capture
+    const summary = getSummary.get(cand.calleeFuncId, cand.argIndex) as {
+      flows_to_return: number;
+    } | null;
+    if (summary?.flows_to_return) {
+      const calleeReturn = getReturnVertex.get(cand.calleeFuncId) as { id: number } | null;
+      if (calleeReturn) {
+        const captureVarName = captureMap.get(`${cand.callerFuncId}:${cand.calleeFuncId}`);
+        const captureVertex = captureVarName
+          ? (getLocalVertex.get(cand.callerFuncId, captureVarName) as { id: number } | null)
+          : null;
+        if (captureVertex) {
+          insertInterEdge.run(
+            cand.calleeFuncId,
+            cand.callerFuncId,
+            'return_out',
+            calleeReturn.id,
+            captureVertex.id,
+            callEdgeId,
+            cand.expression,
+            cand.line,
+            cand.confidence,
+          );
+          count++;
         }
       }
     }
-  });
+  }
 
-  tx();
+  return count;
+}
+
+/**
+ * Wrap runInterproceduralStitch in its own transaction.
+ *
+ * Used only by buildDataflowP4ForNative, which calls the stitch as a
+ * standalone operation outside any other transaction boundary.  All other
+ * call sites (buildDataflowVerticesFromMap, buildDataflowEdges) manage their
+ * own outer transaction and call runInterproceduralStitch directly to avoid
+ * nesting, which better-sqlite3 does not support.
+ */
+function buildInterproceduralStitch(
+  db: BetterSqlite3Database,
+  candidates: StitchCandidate[],
+  captures: ReturnCapture[],
+): number {
+  if (candidates.length === 0) return 0;
+  let count = 0;
+  db.transaction(() => {
+    count = runInterproceduralStitch(db, candidates, captures);
+  })();
   return count;
 }
 
@@ -825,24 +852,32 @@ export function buildDataflowVerticesFromMap(
   if (!vstmts.available || dataflowMap.size === 0) return 0;
 
   const stmts = prepareNodeResolvers(db);
-  const allCandidates: StitchCandidate[] = [];
-  const allCaptures: ReturnCapture[] = [];
 
+  // Vertex writes and inter-procedural stitch are a single atomic unit: if the
+  // stitch throws or the process is killed between the two, the DB would be left
+  // with dataflow_vertices rows but no arg_in/return_out edges.  Wrapping both
+  // under one transaction boundary prevents that half-written state.
+  let stitchCount = 0;
   const tx = db.transaction(() => {
+    const allCandidates: StitchCandidate[] = [];
+    const allCaptures: ReturnCapture[] = [];
+
     for (const [relPath, data] of dataflowMap) {
       const resolver = makeNodeResolver(stmts, relPath);
       const { candidates, captures } = buildDataflowVerticesAndEdges(db, vstmts, data, resolver);
       allCandidates.push(...candidates);
       allCaptures.push(...captures);
     }
+
+    // P4: merge in stitch candidates from unchanged caller files if provided.
+    if (extraCandidates && extraCandidates.length > 0) allCandidates.push(...extraCandidates);
+    if (extraCaptures && extraCaptures.length > 0) allCaptures.push(...extraCaptures);
+
+    stitchCount = runInterproceduralStitch(db, allCandidates, allCaptures);
   });
   tx();
 
-  // P4: merge in stitch candidates from unchanged caller files if provided.
-  if (extraCandidates && extraCandidates.length > 0) allCandidates.push(...extraCandidates);
-  if (extraCaptures && extraCaptures.length > 0) allCaptures.push(...extraCaptures);
-
-  return buildInterproceduralStitch(db, allCandidates, allCaptures);
+  return stitchCount;
 }
 
 /**
@@ -959,10 +994,50 @@ export async function buildDataflowEdges(
       // Rust DataflowResult already contains parameters/returns — no re-parse needed.
       const vstmts = prepareVertexStmts(db);
       if (vstmts.available) {
-        const allCandidates: StitchCandidate[] = [];
-        const allCaptures: ReturnCapture[] = [];
+        // P4: Incremental re-stitch — unchanged caller files are not in
+        // fileSymbols so their arg_in edges to the old param vertices were
+        // deleted by the purge and never recreated. Re-collect stitch
+        // candidates from those caller files by parsing them from disk.
+        //
+        // Skip on full builds: fileSymbols covers every file in the DB, so
+        // there are no unchanged callers to re-stitch.
+        //
+        // This async disk-read step must happen BEFORE the transaction opens
+        // (SQLite transactions are synchronous; async work inside them is not
+        // supported by better-sqlite3).
+        const totalFilesInDb = (
+          db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
+        ).n;
+        let p4CallerCount = 0;
+        const p4Candidates: StitchCandidate[] = [];
+        const p4Captures: ReturnCapture[] = [];
+        if (fileSymbols.size < totalFilesInDb) {
+          const changedRelPaths = new Set<string>(fileSymbols.keys());
+          const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
+          const extra = await collectCallerStitchCandidates(
+            db,
+            changedFuncIds,
+            changedRelPaths,
+            rootDir,
+            extToLang,
+            null,
+            null,
+          );
+          p4Candidates.push(...extra.candidates);
+          p4Captures.push(...extra.captures);
+          p4CallerCount = extra.candidates.length;
+        }
 
+        // Vertex writes and inter-procedural stitch are a single atomic unit:
+        // if the stitch throws or the process is killed between the two, the DB
+        // would be left with dataflow_vertices rows but no arg_in/return_out
+        // edges.  Wrapping both under one transaction boundary prevents that
+        // half-written state.
+        let interCount = 0;
         const txVertex = db.transaction(() => {
+          const allCandidates: StitchCandidate[] = [];
+          const allCaptures: ReturnCapture[] = [];
+
           for (const [relPath, symbols] of fileSymbols) {
             if (!symbols.dataflow) continue;
             const ext = path.extname(relPath).toLowerCase();
@@ -977,38 +1052,15 @@ export async function buildDataflowEdges(
             allCandidates.push(...candidates);
             allCaptures.push(...captures);
           }
+
+          // Merge in the P4 candidates collected above before opening the tx.
+          allCandidates.push(...p4Candidates);
+          allCaptures.push(...p4Captures);
+
+          interCount = runInterproceduralStitch(db, allCandidates, allCaptures);
         });
         txVertex();
 
-        // P4: Incremental re-stitch — unchanged caller files are not in
-        // fileSymbols so their arg_in edges to the old param vertices were
-        // deleted by the purge and never recreated. Re-collect stitch
-        // candidates from those caller files by parsing them from disk.
-        //
-        // Skip on full builds: fileSymbols covers every file in the DB, so
-        // there are no unchanged callers to re-stitch.
-        const totalFilesInDb = (
-          db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
-        ).n;
-        let p4CallerCount = 0;
-        if (fileSymbols.size < totalFilesInDb) {
-          const changedRelPaths = new Set<string>(fileSymbols.keys());
-          const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
-          const extra = await collectCallerStitchCandidates(
-            db,
-            changedFuncIds,
-            changedRelPaths,
-            rootDir,
-            extToLang,
-            null,
-            null,
-          );
-          allCandidates.push(...extra.candidates);
-          allCaptures.push(...extra.captures);
-          p4CallerCount = extra.candidates.length;
-        }
-
-        const interCount = buildInterproceduralStitch(db, allCandidates, allCaptures);
         info(
           `Dataflow (native): ${interCount} inter-procedural edges inserted${p4CallerCount > 0 ? ` (P4: ${p4CallerCount} re-stitch candidate(s) from unchanged callers)` : ''}`,
         );
@@ -1029,12 +1081,51 @@ export async function buildDataflowEdges(
 
   const stmts = prepareNodeResolvers(db);
   const vstmts = prepareVertexStmts(db);
+
+  // P4: Incremental re-stitch — if only a subset of files changed, callers of
+  // the changed functions were not in fileSymbols, so their arg_in edges were
+  // deleted by the purge but never reconstructed. Re-collect stitch candidates
+  // from those caller files now (read from disk, no DB writes).
+  //
+  // Skip P4 on full builds: when fileSymbols covers every file in the DB there
+  // are no unchanged callers, and collectFuncIdsForFiles would issue one SELECT
+  // per file for nothing.  A single COUNT query is cheaper than N per-file SELECTs.
+  //
+  // This async disk-read step must happen BEFORE the transaction opens
+  // (SQLite transactions are synchronous; async work inside them is not
+  // supported by better-sqlite3).
+  const totalFilesInDb = (
+    db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
+  ).n;
+  const p4Candidates: StitchCandidate[] = [];
+  const p4Captures: ReturnCapture[] = [];
+  if (vstmts.available && fileSymbols.size < totalFilesInDb) {
+    const changedRelPaths = new Set<string>(fileSymbols.keys());
+    const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
+    const extra = await collectCallerStitchCandidates(
+      db,
+      changedFuncIds,
+      changedRelPaths,
+      rootDir,
+      extToLang,
+      parsers,
+      getParserFn,
+    );
+    p4Candidates.push(...extra.candidates);
+    p4Captures.push(...extra.captures);
+  }
+
+  // Edge writes, vertex writes, and inter-procedural stitch are a single
+  // atomic unit: if the stitch throws or the process is killed between vertex
+  // writes and the stitch, the DB would be left with dataflow_vertices rows
+  // but no arg_in/return_out edges.  Wrapping all three under one transaction
+  // boundary prevents that half-written state.
   let totalEdges = 0;
-
-  const allCandidates: StitchCandidate[] = [];
-  const allCaptures: ReturnCapture[] = [];
-
+  let interCount = 0;
   const tx = db.transaction(() => {
+    const allCandidates: StitchCandidate[] = [];
+    const allCaptures: ReturnCapture[] = [];
+
     for (const [relPath, symbols] of fileSymbols) {
       const ext = path.extname(relPath).toLowerCase();
       if (!DATAFLOW_EXTENSIONS.has(ext)) continue;
@@ -1048,41 +1139,16 @@ export async function buildDataflowEdges(
       allCandidates.push(...candidates);
       allCaptures.push(...captures);
     }
+
+    // Merge in the P4 candidates collected above before opening the tx.
+    allCandidates.push(...p4Candidates);
+    allCaptures.push(...p4Captures);
+
+    // P2: inter-procedural stitch — runs after all per-file vertices + summaries written
+    interCount = vstmts.available ? runInterproceduralStitch(db, allCandidates, allCaptures) : 0;
   });
 
   tx();
-
-  // P4: Incremental re-stitch — if only a subset of files changed, callers of
-  // the changed functions were not in fileSymbols, so their arg_in edges were
-  // deleted by the purge but never reconstructed. Re-collect stitch candidates
-  // from those caller files now (read from disk, no DB writes).
-  //
-  // Skip P4 on full builds: when fileSymbols covers every file in the DB there
-  // are no unchanged callers, and collectFuncIdsForFiles would issue one SELECT
-  // per file for nothing.  A single COUNT query is cheaper than N per-file SELECTs.
-  const totalFilesInDb = (
-    db.prepare(`SELECT COUNT(DISTINCT file) AS n FROM nodes`).get() as { n: number }
-  ).n;
-  if (vstmts.available && fileSymbols.size < totalFilesInDb) {
-    const changedRelPaths = new Set<string>(fileSymbols.keys());
-    const changedFuncIds = collectFuncIdsForFiles(db, changedRelPaths);
-    const extra = await collectCallerStitchCandidates(
-      db,
-      changedFuncIds,
-      changedRelPaths,
-      rootDir,
-      extToLang,
-      parsers,
-      getParserFn,
-    );
-    allCandidates.push(...extra.candidates);
-    allCaptures.push(...extra.captures);
-  }
-
-  // P2: inter-procedural stitch — runs after all per-file vertices + summaries committed
-  const interCount = vstmts.available
-    ? buildInterproceduralStitch(db, allCandidates, allCaptures)
-    : 0;
 
   info(`Dataflow: ${totalEdges} fn-level edges, ${interCount} inter-procedural edges inserted`);
 }

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -21,6 +21,7 @@ export const DEFAULTS = {
   include: [] as string[],
   exclude: [] as string[],
   ignoreDirs: [] as string[],
+  ignoreAdditionalDirs: [] as string[],
   extensions: [] as string[],
   aliases: {} as Record<string, string>,
   build: {
@@ -452,6 +453,7 @@ const BUILD_HASH_KEYS: ReadonlyArray<keyof CodegraphConfig> = [
   'include',
   'exclude',
   'ignoreDirs',
+  'ignoreAdditionalDirs',
   'extensions',
   'aliases',
   'build',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -34,6 +34,15 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
   ]),
 );
 
+/**
+ * Merge the global IGNORE_DIRS set with a per-repo additional list from config.
+ * Returns a new Set — does not mutate IGNORE_DIRS.
+ */
+export function buildIgnoreSet(additionalDirs?: string[]): Set<string> {
+  if (!additionalDirs || additionalDirs.length === 0) return IGNORE_DIRS;
+  return new Set([...IGNORE_DIRS, ...additionalDirs]);
+}
+
 export const EXTENSIONS: ArrayCompatSet<string> = withArrayCompat(new Set(SUPPORTED_EXTENSIONS));
 
 /**

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,7 +38,7 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
  * Merge the global IGNORE_DIRS set with a per-repo additional list from config.
  * Returns a new Set — does not mutate IGNORE_DIRS.
  */
-export function buildIgnoreSet(additionalDirs?: string[]): Set<string> {
+export function buildIgnoreSet(additionalDirs?: string[]): ReadonlySet<string> {
   if (!additionalDirs || additionalDirs.length === 0) return IGNORE_DIRS;
   return new Set([...IGNORE_DIRS, ...additionalDirs]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1351,6 +1351,8 @@ export interface CodegraphConfig {
   include: string[];
   exclude: string[];
   ignoreDirs: string[];
+  /** Additional directory names to ignore on top of the built-in IGNORE_DIRS set. */
+  ignoreAdditionalDirs: string[];
   extensions: string[];
   aliases: Record<string, unknown>;
 

--- a/tests/benchmarks/resolution/fixtures/dynamic-java/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/dynamic-java/expected-edges.json
@@ -4,11 +4,11 @@
   "description": "Phase 2 JVM fixture: Java reflection patterns. getMethod('name') resolved; invoke() flagged.",
   "edges": [
     {
-      "source": { "name": "runGetMethod", "file": "Reflection.java" },
-      "target": { "name": "greet", "file": "Reflection.java" },
+      "source": { "name": "Reflection.runGetMethod", "file": "Reflection.java" },
+      "target": { "name": "Reflection.greet", "file": "Reflection.java" },
       "kind": "calls",
       "mode": "dynamic",
-      "notes": "clazz.getMethod('greet') — reflection kind, resolved to greet() in same class"
+      "notes": "clazz.getMethod('greet') — reflection kind, resolved to Reflection.greet() via caller-class qualifier"
     }
   ]
 }

--- a/tests/benchmarks/resolution/fixtures/dynamic-kotlin/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/dynamic-kotlin/expected-edges.json
@@ -16,6 +16,13 @@
       "kind": "calls",
       "mode": "dynamic",
       "notes": "::farewell callable reference — reflection kind, resolves to top-level farewell()"
+    },
+    {
+      "source": { "name": "runMemberCallableRef", "file": "reflection.kt" },
+      "target": { "name": "Greeter.greet", "file": "reflection.kt" },
+      "kind": "calls",
+      "mode": "dynamic",
+      "notes": "Greeter::greet member callable ref must resolve to Greeter.greet, not top-level greet()"
     }
   ]
 }

--- a/tests/benchmarks/resolution/fixtures/dynamic-kotlin/reflection.kt
+++ b/tests/benchmarks/resolution/fixtures/dynamic-kotlin/reflection.kt
@@ -20,3 +20,13 @@ fun runFarewellRef(): (String) -> String {
 fun runInvoke(fn: (String) -> String): String {
     return fn.invoke("world")
 }
+
+// Member callable reference: Greeter::greet must resolve to Greeter.greet,
+// not the top-level greet() above, even though both share the same name.
+class Greeter {
+    fun greet(name: String): String = "Hi, $name"
+}
+
+fun runMemberCallableRef(): (Greeter, String) -> String {
+    return Greeter::greet
+}

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -143,15 +143,14 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   //   3 expected edges (Reflect.apply → greet, Reflect.construct → UserService, Reflect.get → greet).
   'dynamic-typescript': { precision: 1.0, recall: 0.75 },
   // Phase 2 JVM fixtures — reflection and dynamic dispatch patterns.
-  // Java/Scala/Groovy: detection works but method names are class-qualified in the DB,
-  //   so lookup-by-name fails for getMethod("foo") → 0% recall until RES-3 adds type-aware lookup.
+  // RES-3: type-aware qualified lookup resolves getMethod("foo") → ClassName.foo.
   //   invoke() and forName() emit sink edges (confidence=0.0, excluded from metrics).
-  'dynamic-java': { precision: 0.0, recall: 0.0 },
+  'dynamic-java': { precision: 1.0, recall: 1.0 },
   // Kotlin: ::fn callable refs resolve correctly (top-level fns are unqualified in DB).
   //   invoke() emits sink edge (excluded). 100% recall achievable.
   'dynamic-kotlin': { precision: 1.0, recall: 1.0 },
-  'dynamic-scala': { precision: 0.0, recall: 0.0 },
-  'dynamic-groovy': { precision: 0.0, recall: 0.0 },
+  'dynamic-scala': { precision: 1.0, recall: 1.0 },
+  'dynamic-groovy': { precision: 1.0, recall: 1.0 },
   // TS 0.72: Phase 8.3e adds this.method() same-class resolution (Shape.describe → Shape.area),
   //   lifting recall from 69.4% to 72.2%.  Remaining gap (interface-dispatch, CHA) is tracked
   //   in Phase 8.5 (TSC enrichment) and Phase 8.7 (CHA on JS/TS).

--- a/tests/unit/builder.test.ts
+++ b/tests/unit/builder.test.ts
@@ -105,6 +105,22 @@ describe('collectFiles', () => {
     expect(basenames).toContain('app.js');
   });
 
+  it('respects config.ignoreAdditionalDirs', () => {
+    const files = collectFiles(tmpDir, [], { ignoreAdditionalDirs: ['lib'] });
+    const basenames = files.map((f) => path.basename(f));
+    expect(basenames).not.toContain('helper.py');
+    // src files still present
+    expect(basenames).toContain('app.js');
+  });
+
+  it('merges ignoreAdditionalDirs with ignoreDirs when both are set', () => {
+    // ignoreDirs excludes 'lib', ignoreAdditionalDirs excludes 'src'
+    const files = collectFiles(tmpDir, [], { ignoreDirs: ['lib'], ignoreAdditionalDirs: ['src'] });
+    const basenames = files.map((f) => path.basename(f));
+    expect(basenames).not.toContain('helper.py'); // lib excluded
+    expect(basenames).not.toContain('app.js'); // src excluded
+  });
+
   it('returns empty array for non-existent directory (graceful)', () => {
     const files = collectFiles(path.join(tmpDir, 'does-not-exist'));
     expect(files).toEqual([]);

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -5,6 +5,7 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  buildIgnoreSet,
   EXTENSIONS,
   IGNORE_DIRS,
   isSupportedFile,
@@ -48,6 +49,36 @@ describe('IGNORE_DIRS', () => {
     for (const dir of expected) {
       expect(IGNORE_DIRS.has(dir)).toBe(true);
     }
+  });
+
+  it('does not contain crates (repo-specific dirs belong in ignoreAdditionalDirs config)', () => {
+    expect(IGNORE_DIRS.has('crates')).toBe(false);
+  });
+});
+
+describe('buildIgnoreSet', () => {
+  it('returns IGNORE_DIRS when no additional dirs provided', () => {
+    const result = buildIgnoreSet();
+    expect(result).toBe(IGNORE_DIRS);
+  });
+
+  it('returns IGNORE_DIRS when empty array provided', () => {
+    const result = buildIgnoreSet([]);
+    expect(result).toBe(IGNORE_DIRS);
+  });
+
+  it('merges additional dirs on top of IGNORE_DIRS', () => {
+    const result = buildIgnoreSet(['crates', 'generated']);
+    expect(result.has('node_modules')).toBe(true); // from IGNORE_DIRS
+    expect(result.has('crates')).toBe(true); // additional
+    expect(result.has('generated')).toBe(true); // additional
+  });
+
+  it('does not mutate IGNORE_DIRS', () => {
+    const before = new Set(IGNORE_DIRS);
+    buildIgnoreSet(['crates']);
+    expect(IGNORE_DIRS.size).toBe(before.size);
+    expect(IGNORE_DIRS.has('crates')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- `Greeter::greet` emits `{ name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' }` but `resolveCallTargets` was finding the top-level `greet()` via `byNameAndFile('greet', relPath)` before the qualified form was tried, producing a false edge
- RES-4: in `resolveFallbackTargets`, when `dynamicKind === 'reflection'`, `receiver` is set, and `keyExpr` is absent (Kotlin member callable ref, not JVM `getMethod`), try `byNameAndFile('Greeter.greet', relPath)` first and short-circuit if a qualified match is found — scoped to non-JS/TS files
- Adds a `Greeter::greet` test case to the `dynamic-kotlin` fixture alongside a same-named top-level `greet()` to guard against regression

## Test plan

- [ ] `resolution-benchmark` passes (206 tests, including new `dynamic-kotlin` edge)
- [ ] `call-resolver` unit tests pass (14 tests)
- [ ] `builder` tests pass (152 tests)
- [ ] No regressions in build-parity / incremental-parity tests

Closes #1651