### PR TITLE
feat(dynamic-calls): ObjC performSelector / Dart Function.apply detection

### DIFF
--- a/.codegraphrc.json
+++ b/.codegraphrc.json
@@ -1,4 +1,5 @@
 {
   "embeddings": { "model": "bge-large" },
-  "exclude": ["crates/**"]
+  "exclude": ["crates/**"],
+  "ignoreAdditionalDirs": ["crates"]
 }

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -221,40 +221,100 @@ fn handle_using_directive(node: &Node, source: &[u8], symbols: &mut FileSymbols)
     }
 }
 
+/// Get the first string-literal argument text from a C# invocation node.
+fn get_cs_first_string_arg(node: &Node, source: &[u8]) -> Option<String> {
+    let args = node.child_by_field_name("argument_list")
+        .or_else(|| find_child(node, "argument_list"))?;
+    for i in 0..args.child_count() {
+        let Some(child) = args.child(i) else { continue };
+        let t = child.kind();
+        if matches!(t, "(" | ")" | ",") { continue; }
+        // argument node may wrap the literal
+        let target = if t == "argument" {
+            child.child(0).unwrap_or(child)
+        } else {
+            child
+        };
+        let tt = target.kind();
+        if tt == "string_literal" || tt == "verbatim_string_literal" {
+            let raw = node_text(&target, source);
+            return Some(raw.trim_matches(|c| c == '"' || c == '@').to_string());
+        }
+        break;
+    }
+    None
+}
+
 fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let fn_node = node.child_by_field_name("function").or_else(|| node.child(0));
     let Some(fn_node) = fn_node else { return };
+    let call_line = start_line(node);
     match fn_node.kind() {
         "identifier" => {
             symbols.calls.push(Call {
                 name: node_text(&fn_node, source).to_string(),
-                line: start_line(node),
-                dynamic: None,
-                receiver: None,
+                line: call_line,
                 ..Default::default()
             });
         }
         "member_access_expression" => {
-            if let Some(name) = fn_node.child_by_field_name("name") {
-                let receiver = named_child_text(&fn_node, "expression", source)
-                    .map(|s| s.to_string());
+            let Some(name) = fn_node.child_by_field_name("name") else { return };
+            let method_name = node_text(&name, source);
+            let receiver = named_child_text(&fn_node, "expression", source)
+                .map(|s| s.to_string());
+
+            // method.Invoke(target, args) — runtime reflection; target unknown
+            if method_name == "Invoke" {
                 symbols.calls.push(Call {
-                    name: node_text(&name, source).to_string(),
-                    line: start_line(node),
-                    dynamic: None,
+                    name: "<dynamic:unresolved>".to_string(),
+                    line: call_line,
+                    dynamic: Some(true),
+                    dynamic_kind: Some("unresolved-dynamic".to_string()),
                     receiver,
                     ..Default::default()
                 });
+                return;
             }
+
+            // type.GetMethod("name") / GetRuntimeMethod / GetDeclaredMethod — resolvable if literal
+            if matches!(method_name, "GetMethod" | "GetRuntimeMethod" | "GetDeclaredMethod") {
+                let literal = get_cs_first_string_arg(node, source);
+                if let Some(lit) = literal {
+                    symbols.calls.push(Call {
+                        name: lit.clone(),
+                        line: call_line,
+                        dynamic: Some(true),
+                        dynamic_kind: Some("reflection".to_string()),
+                        key_expr: Some(lit),
+                        receiver,
+                        ..Default::default()
+                    });
+                } else {
+                    symbols.calls.push(Call {
+                        name: "<dynamic:computed-key>".to_string(),
+                        line: call_line,
+                        dynamic: Some(true),
+                        dynamic_kind: Some("computed-key".to_string()),
+                        receiver,
+                        ..Default::default()
+                    });
+                }
+                return;
+            }
+
+            symbols.calls.push(Call {
+                name: method_name.to_string(),
+                line: call_line,
+                receiver,
+                ..Default::default()
+            });
         }
         "generic_name" | "member_binding_expression" => {
             let name = fn_node.child_by_field_name("name").or_else(|| fn_node.child(0));
             if let Some(name) = name {
                 symbols.calls.push(Call {
                     name: node_text(&name, source).to_string(),
-                    line: start_line(node),
-                    dynamic: None,
-                    receiver: None,
+                    line: call_line,
                     ..Default::default()
                 });
             }

--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -33,6 +33,7 @@ fn match_dart_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
         "library_import" => handle_dart_import(node, source, symbols),
         "constructor_invocation" | "new_expression" => handle_dart_constructor_call(node, source, symbols),
         "type_alias" => handle_dart_type_alias(node, source, symbols),
+        "selector" => handle_dart_selector(node, source, symbols),
         _ => {}
     }
 }
@@ -306,6 +307,44 @@ fn handle_dart_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             children: None,
         });
     }
+}
+
+fn handle_dart_selector(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    // selector with argument_part represents a function call; mirrors handleDartSelector in dart.ts
+    if find_child(node, "argument_part").is_none() {
+        return;
+    }
+    let unconditional = match find_child(node, "unconditional_assignable_selector") {
+        Some(n) => n,
+        None => return,
+    };
+    let id = match find_child(&unconditional, "identifier") {
+        Some(n) => n,
+        None => return,
+    };
+    let method_name = node_text(&id, source);
+
+    // Function.apply(fn, positionalArgs, namedArgs) — dynamic higher-order dispatch
+    if method_name == "apply" {
+        if let Some(parent) = node.parent() {
+            for i in 0..parent.child_count() {
+                if let Some(sibling) = parent.child(i) {
+                    if sibling.id() != node.id() && node_text(&sibling, source) == "Function" {
+                        symbols.calls.push(Call {
+                            name: "<dynamic:unresolved>".to_string(),
+                            line: start_line(node),
+                            dynamic: Some(true),
+                            dynamic_kind: Some("unresolved-dynamic".to_string()),
+                            ..Default::default()
+                        });
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    push_simple_call(symbols, node, method_name);
 }
 
 fn is_inside_class(node: &Node) -> bool {

--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -34,6 +34,7 @@ fn match_elixir_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
             "defprotocol" => handle_defprotocol(node, source, symbols),
             "defimpl" => handle_defimpl(node, source, symbols),
             "import" | "use" | "require" | "alias" => handle_elixir_import(node, source, symbols, keyword),
+            "apply" => handle_elixir_apply(node, source, symbols),
             _ => {
                 symbols.calls.push(Call {
                     name: keyword.to_string(),
@@ -364,6 +365,72 @@ fn handle_elixir_import(node: &Node, source: &[u8], symbols: &mut FileSymbols, k
         vec![keyword.to_string()],
         start_line(node),
     ));
+}
+
+/// apply(module, :function, args) — Elixir dynamic dispatch.
+/// Second argument is an atom literal → reflection; variable → computed-key.
+fn handle_elixir_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let args = match find_child(node, "arguments") {
+        Some(a) => a,
+        None => {
+            symbols.calls.push(Call {
+                name: "apply".to_string(),
+                line: start_line(node),
+                ..Default::default()
+            });
+            return;
+        }
+    };
+
+    // Locate the second argument (skip punctuation and the first arg)
+    let mut arg_idx = 0u32;
+    let mut second_arg: Option<Node> = None;
+    for i in 0..args.child_count() {
+        let Some(child) = args.child(i) else { continue };
+        let t = child.kind();
+        if matches!(t, "(" | ")" | ",") { continue; }
+        if arg_idx == 1 {
+            second_arg = Some(child);
+            break;
+        }
+        arg_idx += 1;
+    }
+
+    let Some(second) = second_arg else {
+        symbols.calls.push(Call {
+            name: "apply".to_string(),
+            line: start_line(node),
+            ..Default::default()
+        });
+        return;
+    };
+
+    let t = second.kind();
+    if t == "atom" || t == "atom_literal" {
+        // :atom — strip leading colon to get function name
+        let raw = node_text(&second, source);
+        let fn_name = raw.trim_start_matches(':').to_string();
+        let key_expr = raw.to_string();
+        symbols.calls.push(Call {
+            name: fn_name,
+            line: start_line(node),
+            dynamic: Some(true),
+            dynamic_kind: Some("reflection".to_string()),
+            key_expr: Some(key_expr),
+            ..Default::default()
+        });
+    } else {
+        // Variable function name — computed-key
+        let key_expr = node_text(&second, source).to_string();
+        symbols.calls.push(Call {
+            name: "<dynamic:computed-key>".to_string(),
+            line: start_line(node),
+            dynamic: Some(true),
+            dynamic_kind: Some("computed-key".to_string()),
+            key_expr: Some(key_expr),
+            ..Default::default()
+        });
+    }
 }
 
 fn handle_dot_call(node: &Node, dot_node: &Node, source: &[u8], symbols: &mut FileSymbols) {

--- a/crates/codegraph-core/src/extractors/lua.rs
+++ b/crates/codegraph-core/src/extractors/lua.rs
@@ -94,6 +94,21 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
         None => return,
     };
 
+    // load(chunk) / loadstring(chunk) / dofile — dynamic code execution; always undecidable
+    if name_node.kind() == "identifier" {
+        let ident = node_text(&name_node, source);
+        if matches!(ident, "load" | "loadstring" | "dofile") {
+            symbols.calls.push(Call {
+                name: "<dynamic:eval>".to_string(),
+                line: start_line(node),
+                dynamic: Some(true),
+                dynamic_kind: Some("eval".to_string()),
+                ..Default::default()
+            });
+            return;
+        }
+    }
+
     // Check for require() as import
     if name_node.kind() == "identifier" && node_text(&name_node, source) == "require" {
         if let Some(args) = node.child_by_field_name("arguments") {
@@ -135,6 +150,42 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
                     receiver: table.map(|t| node_text(&t, source).to_string()),
                     ..Default::default()
                 });
+            }
+        }
+        "bracket_index_expression" => {
+            // t[k]() — bracket-index call; key may be variable.
+            let table = name_node.child_by_field_name("table");
+            let table_id = table.as_ref().map(|n| n.id());
+            let mut key: Option<Node> = None;
+            for i in 0..name_node.child_count() {
+                let Some(ch) = name_node.child(i) else { continue };
+                if matches!(ch.kind(), "[" | "]") { continue; }
+                if table_id == Some(ch.id()) { continue; }
+                key = Some(ch);
+                break;
+            }
+            if let Some(k) = key {
+                if k.kind() == "string" || k.kind() == "string_literal" {
+                    let raw = node_text(&k, source);
+                    let call_name = raw.trim_matches(|c| c == '\'' || c == '"').to_string();
+                    symbols.calls.push(Call {
+                        name: call_name,
+                        line: start_line(node),
+                        receiver: table.map(|t| node_text(&t, source).to_string()),
+                        ..Default::default()
+                    });
+                } else {
+                    let key_expr = node_text(&k, source).to_string();
+                    symbols.calls.push(Call {
+                        name: "<dynamic:computed-key>".to_string(),
+                        line: start_line(node),
+                        dynamic: Some(true),
+                        dynamic_kind: Some("computed-key".to_string()),
+                        key_expr: Some(key_expr),
+                        receiver: table.map(|t| node_text(&t, source).to_string()),
+                        ..Default::default()
+                    });
+                }
             }
         }
         _ => {

--- a/crates/codegraph-core/src/extractors/objc.rs
+++ b/crates/codegraph-core/src/extractors/objc.rs
@@ -325,6 +325,19 @@ fn handle_c_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         (node_text(&fn_node, source).to_string(), None)
     };
 
+    // objc_msgSend(obj, sel, ...) — raw ObjC runtime call; selector is a SEL value
+    if name == "objc_msgSend" {
+        symbols.calls.push(Call {
+            name: "<dynamic:unresolved>".to_string(),
+            line: start_line(node),
+            dynamic: Some(true),
+            dynamic_kind: Some("unresolved-dynamic".to_string()),
+            receiver,
+            ..Default::default()
+        });
+        return;
+    }
+
     push_call(symbols, node, name, receiver, None);
 }
 
@@ -336,6 +349,20 @@ fn handle_message_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         .map(|n| node_text(&n, source).to_string());
 
     let selector = build_message_selector(node, source);
+
+    // performSelector: / performSelector:withObject: — SEL dispatch; not statically resolvable
+    if selector == "performSelector:" || selector.starts_with("performSelector:withObject") {
+        symbols.calls.push(Call {
+            name: "<dynamic:unresolved>".to_string(),
+            line: start_line(node),
+            dynamic: Some(true),
+            dynamic_kind: Some("unresolved-dynamic".to_string()),
+            receiver,
+            ..Default::default()
+        });
+        return;
+    }
+
     push_call(symbols, node, selector, receiver, None);
 }
 
@@ -762,5 +789,42 @@ mod tests {
         assert_eq!(params.len(), 1);
         assert_eq!(params[0].name, "callback");
         assert_eq!(params[0].kind, "parameter");
+    }
+
+    #[test]
+    fn flags_perform_selector_as_unresolved_dynamic() {
+        let code = "\
+@implementation Foo
+- (void)go {
+    [self performSelector:@selector(greet)];
+}
+@end";
+        let s = parse_objc(code);
+        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
+        assert_eq!(dyn_call.dynamic, Some(true));
+        assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
+    }
+
+    #[test]
+    fn flags_perform_selector_with_object_as_unresolved_dynamic() {
+        let code = "\
+@implementation Foo
+- (void)go {
+    [self performSelector:@selector(greet) withObject:arg];
+}
+@end";
+        let s = parse_objc(code);
+        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
+        assert_eq!(dyn_call.dynamic, Some(true));
+        assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
+    }
+
+    #[test]
+    fn flags_objc_msg_send_as_unresolved_dynamic() {
+        let code = "void run(id obj, SEL sel) { objc_msgSend(obj, sel); }";
+        let s = parse_objc(code);
+        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
+        assert_eq!(dyn_call.dynamic, Some(true));
+        assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
     }
 }

--- a/crates/codegraph-core/src/extractors/swift.rs
+++ b/crates/codegraph-core/src/extractors/swift.rs
@@ -189,6 +189,39 @@ fn extract_swift_inheritance(node: &Node, source: &[u8], class_name: &str, symbo
     }
 }
 
+/// Extract the text content of the first string literal argument in a Swift call_expression.
+/// Inspects call_suffix → value_arguments → value_argument → line_string_literal.
+fn get_swift_first_string_literal(call_node: &Node, source: &[u8]) -> Option<String> {
+    let call_suffix = find_child(call_node, "call_suffix")?;
+    let value_args = find_child(&call_suffix, "value_arguments")
+        .unwrap_or(call_suffix);
+    for i in 0..value_args.child_count() {
+        let Some(arg) = value_args.child(i) else { continue };
+        let t = arg.kind();
+        if matches!(t, "(" | ")" | ",") { continue; }
+        let value_node = if t == "value_argument" {
+            arg.child_by_field_name("value")
+                .or_else(|| arg.child(arg.child_count().saturating_sub(1)))
+                .unwrap_or(arg)
+        } else {
+            arg
+        };
+        let vt = value_node.kind();
+        if vt == "line_string_literal" || vt == "string_literal" {
+            for j in 0..value_node.child_count() {
+                let Some(ch) = value_node.child(j) else { continue };
+                if ch.kind() == "line_str_text" || ch.kind() == "string_content" {
+                    return Some(node_text(&ch, source).to_string());
+                }
+            }
+            let raw = node_text(&value_node, source);
+            return Some(raw.trim_matches(|c| c == '"' || c == '\'').to_string());
+        }
+        break;
+    }
+    None
+}
+
 fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "class_declaration" => {
@@ -288,16 +321,8 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
 
         "call_expression" => {
             if let Some(fn_node) = node.child(0) {
-                match fn_node.kind() {
-                    "simple_identifier" => {
-                        symbols.calls.push(Call {
-                            name: node_text(&fn_node, source).to_string(),
-                            line: start_line(node),
-                            dynamic: None,
-                            receiver: None,
-                            ..Default::default()
-                        });
-                    }
+                let call_line = start_line(node);
+                let (call_name, call_receiver) = match fn_node.kind() {
                     "navigation_expression" => {
                         let last = fn_node.child(fn_node.child_count().saturating_sub(1));
                         // Swift's grammar wraps the method name in a `navigation_suffix` node
@@ -318,24 +343,52 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                         }).unwrap_or_else(|| node_text(&fn_node, source).to_string());
                         let receiver = fn_node.child(0)
                             .map(|n| node_text(&n, source).to_string());
-                        symbols.calls.push(Call {
-                            name,
-                            line: start_line(node),
-                            dynamic: None,
-                            receiver,
-                            ..Default::default()
-                        });
+                        (name, receiver)
                     }
-                    _ => {
-                        symbols.calls.push(Call {
-                            name: node_text(&fn_node, source).to_string(),
-                            line: start_line(node),
-                            dynamic: None,
-                            receiver: None,
-                            ..Default::default()
-                        });
-                    }
+                    _ => (node_text(&fn_node, source).to_string(), None),
+                };
+
+                if call_name.is_empty() {
+                    return;
                 }
+
+                // performSelector — ObjC-style dynamic dispatch; selector not statically knowable
+                if call_name == "performSelector" {
+                    symbols.calls.push(Call {
+                        name: "<dynamic:unresolved>".to_string(),
+                        line: call_line,
+                        dynamic: Some(true),
+                        dynamic_kind: Some("unresolved-dynamic".to_string()),
+                        receiver: call_receiver,
+                        ..Default::default()
+                    });
+                    return;
+                }
+
+                // NSSelectorFromString("name") — selector from literal string
+                if call_name == "NSSelectorFromString" {
+                    let literal = get_swift_first_string_literal(node, source);
+                    symbols.calls.push(Call {
+                        name: literal.clone().unwrap_or_else(|| "<dynamic:unresolved>".to_string()),
+                        line: call_line,
+                        dynamic: Some(true),
+                        dynamic_kind: Some(if literal.is_some() {
+                            "reflection".to_string()
+                        } else {
+                            "unresolved-dynamic".to_string()
+                        }),
+                        key_expr: literal,
+                        ..Default::default()
+                    });
+                    return;
+                }
+
+                symbols.calls.push(Call {
+                    name: call_name,
+                    line: call_line,
+                    receiver: call_receiver,
+                    ..Default::default()
+                });
             }
         }
 

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -56,7 +56,7 @@ export const CHA_DISPATCH_PENALTY = 0.1;
 export const CHA_TYPED_DISPATCH_CONFIDENCE = 0.8;
 
 /** Check if a directory entry should be skipped (ignored dirs, dotfiles). */
-function shouldSkipEntry(entry: fs.Dirent, ignoreSet: Set<string>): boolean {
+function shouldSkipEntry(entry: fs.Dirent, ignoreSet: ReadonlySet<string>): boolean {
   if (entry.name.startsWith('.') && entry.name !== '.') {
     if (ignoreSet.has(entry.name)) return true;
     if (entry.isDirectory()) return true;
@@ -140,7 +140,7 @@ interface CollectContext {
   readonly gitignoreRegexes: readonly RegExp[];
   readonly hasGlobFilters: boolean;
   /** Merged set of IGNORE_DIRS + config.ignoreDirs + config.ignoreAdditionalDirs. */
-  readonly ignoreSet: Set<string>;
+  readonly ignoreSet: ReadonlySet<string>;
   readonly visited: Set<string>;
 }
 

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { purgeFilesData } from '../../../db/index.js';
 import { debug, warn } from '../../../infrastructure/logger.js';
-import { EXTENSIONS, IGNORE_DIRS, normalizePath } from '../../../shared/constants.js';
+import { buildIgnoreSet, EXTENSIONS, normalizePath } from '../../../shared/constants.js';
 import { compileGlobs, globToRegex, matchesAny } from '../../../shared/globs.js';
 import type {
   BetterSqlite3Database,
@@ -56,13 +56,12 @@ export const CHA_DISPATCH_PENALTY = 0.1;
 export const CHA_TYPED_DISPATCH_CONFIDENCE = 0.8;
 
 /** Check if a directory entry should be skipped (ignored dirs, dotfiles). */
-function shouldSkipEntry(entry: fs.Dirent, extraIgnore: Set<string> | null): boolean {
+function shouldSkipEntry(entry: fs.Dirent, ignoreSet: Set<string>): boolean {
   if (entry.name.startsWith('.') && entry.name !== '.') {
-    if (IGNORE_DIRS.has(entry.name)) return true;
+    if (ignoreSet.has(entry.name)) return true;
     if (entry.isDirectory()) return true;
   }
-  if (IGNORE_DIRS.has(entry.name)) return true;
-  if (extraIgnore?.has(entry.name)) return true;
+  if (ignoreSet.has(entry.name)) return true;
   return false;
 }
 
@@ -140,7 +139,8 @@ interface CollectContext {
   readonly excludeRegexes: readonly RegExp[];
   readonly gitignoreRegexes: readonly RegExp[];
   readonly hasGlobFilters: boolean;
-  readonly extraIgnore: Set<string> | null;
+  /** Merged set of IGNORE_DIRS + config.ignoreDirs + config.ignoreAdditionalDirs. */
+  readonly ignoreSet: Set<string>;
   readonly visited: Set<string>;
 }
 
@@ -193,7 +193,7 @@ function walkCollect(
 
   let hasFiles = false;
   for (const entry of entries) {
-    if (shouldSkipEntry(entry, ctx.extraIgnore)) continue;
+    if (shouldSkipEntry(entry, ctx.ignoreSet)) continue;
 
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
@@ -237,13 +237,18 @@ export function collectFiles(
   const includeRegexes = compileGlobs(config.include);
   const excludeRegexes = compileGlobs(config.exclude);
   const gitignoreRegexes = readGitignorePatterns(dir);
+  // Build the merged ignore set:
+  //   - config.ignoreDirs are appended to IGNORE_DIRS (existing behaviour: per-repo overrides)
+  //   - config.ignoreAdditionalDirs are also merged in on top of IGNORE_DIRS (new feature)
+  const extraDirs = [...(config.ignoreDirs ?? []), ...(config.ignoreAdditionalDirs ?? [])];
+  const ignoreSet = buildIgnoreSet(extraDirs.length ? extraDirs : undefined);
   const ctx: CollectContext = {
     rootDir: dir,
     includeRegexes,
     excludeRegexes,
     gitignoreRegexes,
     hasGlobFilters: includeRegexes.length > 0 || excludeRegexes.length > 0,
-    extraIgnore: config.ignoreDirs ? new Set(config.ignoreDirs) : null,
+    ignoreSet,
     visited: new Set(),
   };
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1072,6 +1072,45 @@ function resolveFallbackTargets(
     }
   }
 
+  // RES-3: reflection with literal method name — JVM getMethod("name") / invokeMethod("name").
+  // Java/Scala/Groovy methods are stored as class-qualified names (e.g. Reflection.greet),
+  // so lookup.byNameAndFile('greet', relPath) finds nothing. When dynamicKind='reflection'
+  // and keyExpr is set (a string-literal method name was captured), try the qualified form:
+  //   1. typeMap[receiver] → resolvedType → lookup `resolvedType.keyExpr` (type-annotated local)
+  //   2. callerName class prefix → `CallerClass.keyExpr` (same-class sibling, e.g. Groovy obj)
+  // Scoped to non-JS/TS files to avoid interfering with the JS reflection path.
+  if (
+    targets.length === 0 &&
+    call.dynamicKind === 'reflection' &&
+    call.keyExpr &&
+    call.receiver &&
+    !isModuleScopedLanguage(relPath)
+  ) {
+    const typeEntry = typeMap.get(call.receiver);
+    const resolvedType = typeEntry
+      ? typeof typeEntry === 'string'
+        ? typeEntry
+        : (typeEntry as { type?: string }).type
+      : null;
+    if (resolvedType) {
+      const qualified = lookup
+        .byNameAndFile(`${resolvedType}.${call.keyExpr}`, relPath)
+        .filter((n) => n.kind === 'method' || n.kind === 'function');
+      if (qualified.length > 0) targets = qualified;
+    }
+    if (targets.length === 0 && caller.callerName != null) {
+      const lastDot = caller.callerName.lastIndexOf('.');
+      if (lastDot > 0) {
+        const prevDot = caller.callerName.lastIndexOf('.', lastDot - 1);
+        const callerClass = caller.callerName.slice(prevDot + 1, lastDot);
+        const qualified = lookup
+          .byNameAndFile(`${callerClass}.${call.keyExpr}`, relPath)
+          .filter((n) => n.kind === 'method' || n.kind === 'function');
+        if (qualified.length > 0) targets = qualified;
+      }
+    }
+  }
+
   // Object.defineProperty accessor fallback: when a function is registered as
   // a getter/setter via `Object.defineProperty(obj, "bar", { get: getter })`,
   // calls to `this.X()` inside `getter` resolve against `obj` (this === obj

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1446,13 +1446,16 @@ function emitChaCallEdgesForCall(
 }
 
 /**
- * Dynamic kinds that can never be resolved statically — emit a sink edge to the
+ * Dynamic kinds that cannot be resolved statically — emit a sink edge to the
  * file node instead of silently dropping the call site.  confidence=0.0 keeps
  * these below DEFAULT_MIN_CONFIDENCE so they never appear in normal query results.
+ * Includes reflection so that Reflect.apply/getMethod/callable-ref calls whose
+ * target is not found in the codebase still produce a visible sink edge.
  */
 const FLAG_ONLY_KINDS: ReadonlySet<DynamicKind> = new Set([
   'eval',
   'computed-key',
+  'reflection',
   'unresolved-dynamic',
 ]);
 
@@ -1467,7 +1470,7 @@ const FLAG_ONLY_KINDS: ReadonlySet<DynamicKind> = new Set([
  *   4. `emitPtsReceiverEdges`    — Phase 8.3f pts fallback for rest-param receiver calls
  *   5. Inline `resolveReceiverEdge` — emit `receiver` edge for external receivers
  *   6. `emitChaCallEdgesForCall` — Phase 8.5 CHA + RTA dispatch expansion
- *   7. Sink edge for flag-only dynamic kinds (eval, computed-key, unresolved-dynamic)
+ *   7. Sink edge for flag-only dynamic kinds (eval, computed-key, reflection, unresolved-dynamic)
  */
 function buildFileCallEdges(
   relPath: string,

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -844,6 +844,16 @@ function buildCallEdgesJS(
 
     const seenCallEdges = new Set<string>();
     const ptsMap = buildPointsToMapForFile(symbols, importedNames);
+    // Build the import-artifact name set: importedNames plus CJS require bindings.
+    // Used only by resolveReceiverEdge to distinguish local definitions from CJS
+    // import shadows — does NOT affect call-target resolution or DB edges (#1661).
+    const importArtifactNames = buildImportArtifactNames(
+      importedNames,
+      symbols,
+      ctx,
+      relPath,
+      rootDir,
+    );
 
     buildFileCallEdges(
       relPath,
@@ -856,6 +866,7 @@ function buildCallEdgesJS(
       typeMap,
       ptsMap,
       chaCtx,
+      importArtifactNames,
     );
     buildClassHierarchyEdges(ctx, relPath, symbols, allEdgeRows);
   }
@@ -898,6 +909,38 @@ function buildImportedNamesMap(
     }
   }
   return importedNames;
+}
+
+/**
+ * Build a map of all names that are import artifacts in this file — includes
+ * both ES module imports (already in importedNames) and CJS require destructuring
+ * bindings (`const { X } = require('./path')`). Used exclusively by resolveReceiverEdge
+ * to classify same-file function-kind nodes as import artifacts vs. local definitions.
+ * Does NOT affect call resolution or DB edge creation (#1661).
+ */
+function buildImportArtifactNames(
+  importedNames: Map<string, string>,
+  symbols: ExtractorOutput,
+  ctx: PipelineContext,
+  relPath: string,
+  rootDir: string,
+): ReadonlyMap<string, string> {
+  if (!symbols.cjsRequireBindings?.length) return importedNames;
+  const combined = new Map(importedNames);
+  const traceBarrel = (resolvedPath: string, cleanName: string): string => {
+    if (!isBarrelFile(ctx, resolvedPath)) return resolvedPath;
+    const actual = resolveBarrelExportCached(ctx, resolvedPath, cleanName);
+    return actual ?? resolvedPath;
+  };
+  for (const binding of symbols.cjsRequireBindings) {
+    const resolvedPath = getResolved(ctx, path.join(rootDir, relPath), binding.source);
+    for (const name of binding.names) {
+      if (!combined.has(name)) {
+        combined.set(name, traceBarrel(resolvedPath, name));
+      }
+    }
+  }
+  return combined;
 }
 
 function makeContextLookup(ctx: PipelineContext, getNodeIdStmt: NodeIdStmt): CallNodeLookup {
@@ -1483,6 +1526,7 @@ function buildFileCallEdges(
   typeMap: Map<string, TypeMapEntry | string>,
   ptsMap?: PointsToMap | null,
   chaCtx?: ChaContext,
+  importArtifactNames?: ReadonlyMap<string, string>,
 ): void {
   // Tracks edges that were inserted by the pts fallback (edgeKey → allEdgeRows index).
   // Kept separate from seenCallEdges so that a subsequent direct-call edge for the same
@@ -1584,7 +1628,7 @@ function buildFileCallEdges(
         relPath,
         typeMap as Map<string, unknown>,
         seenCallEdges,
-        importedNames,
+        importArtifactNames ?? importedNames,
       );
       if (recv) {
         allEdgeRows.push([

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1021,14 +1021,39 @@ function resolveFallbackTargets(
   targets: ReadonlyArray<{ id: number; file: string; kind?: string }>;
   importedFrom: string | null | undefined;
 } {
-  let { targets, importedFrom } = resolveCallTargets(
-    lookup,
-    call,
-    relPath,
-    importedNames,
-    typeMap as Map<string, unknown>,
-    caller.callerName,
-  );
+  // RES-4: Kotlin member callable reference — `Greeter::greet` emits
+  // { name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' }.
+  // The receiver is the class qualifier (not a typeMap variable), so
+  // resolveCallTargets would find a same-named top-level function via
+  // byNameAndFile('greet', relPath) before the qualified form is tried.
+  // Prefer `Greeter.greet` in the same file first; fall through to the
+  // normal path only when no qualified match exists.
+  let preQualifiedTargets: ReadonlyArray<{ id: number; file: string; kind?: string }> = [];
+  if (
+    call.dynamicKind === 'reflection' &&
+    call.receiver &&
+    !call.keyExpr &&
+    !isModuleScopedLanguage(relPath)
+  ) {
+    preQualifiedTargets = lookup
+      .byNameAndFile(`${call.receiver}.${call.name}`, relPath)
+      .filter((n) => n.kind === 'method' || n.kind === 'function');
+  }
+
+  let { targets, importedFrom } =
+    preQualifiedTargets.length > 0
+      ? {
+          targets: preQualifiedTargets as Array<{ id: number; file: string; kind?: string }>,
+          importedFrom: undefined as string | undefined,
+        }
+      : resolveCallTargets(
+          lookup,
+          call,
+          relPath,
+          importedNames,
+          typeMap as Map<string, unknown>,
+          caller.callerName,
+        );
 
   // Same-class `this.method()` fallback: when the call receiver is `this` and
   // resolveCallTargets found nothing, derive the enclosing class name from the

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1988,23 +1988,45 @@ async function runPostNativePasses(
   );
   const chaMs = performance.now() - chaStart;
 
-  // Role re-classification after JS edge-writing post-passes.
-  // The Rust orchestrator classifies roles before these post-passes (CHA,
-  // this-dispatch) add edges, so roles for the edge endpoints are stale.
-  // Scoped to the files containing those endpoints: a new edge only changes
-  // fan-in/out for its own source and target nodes, so re-classifying their
-  // files restores correctness without re-running the classifier over the
-  // whole graph (which cost ~130ms per build on codegraph itself and was a
-  // major part of the v3.12.0 native full-build benchmark regression).
+  // Role re-classification after the Rust orchestrator build.
+  //
+  // Two reasons to re-classify:
+  //
+  // 1. Post-pass edges (CHA, this-dispatch): the Rust orchestrator classifies
+  //    roles before these passes add edges, so fan-in/out for their endpoints
+  //    is stale. On incremental builds, scope to the affected files for speed.
+  //
+  // 2. hasActiveFileSiblings parity: the Rust classifier does not implement the
+  //    JS hasActiveFileSiblings heuristic. That heuristic promotes functions with
+  //    fan_in=0 but fan_out>0 to 'leaf' when their file has other connected
+  //    callables — preventing false dead-unresolved classifications for functions
+  //    like `main` or `square` that call others but are never called themselves.
+  //    On full builds, always run a full JS re-classification so the Rust roles
+  //    are replaced by the canonical JS classifier output (#1659).
+  //
+  // Strategy:
+  //   - Full build: always run full JS classifyNodeRoles(db, null).
+  //   - Incremental build with post-pass edges: run scoped re-classification
+  //     for the affected files (same as before). The full-build pass already
+  //     produced correct JS roles for all unchanged files on the previous build.
+  //   - Incremental build with no post-pass edges: skip re-classification
+  //     (Rust roles on unchanged files are not stale, and the heuristic gap
+  //     was corrected on the last full build).
   let reclassifyMs = 0;
-  if (chaEdgeCount > 0 || thisDispatchTargetIds.size > 0) {
-    const affectedFiles = [...new Set([...chaAffectedFiles, ...thisDispatchAffectedFiles])];
-    // When edges were inserted but all their endpoint nodes have null `file`
-    // columns (rare but possible), affectedFiles stays empty even though
-    // fan-in/out changed. Fall back to full-graph re-classification in that
-    // case — scoped classification with an empty set would be a no-op, leaving
-    // roles stale for those nodes.
-    const scopedFiles = affectedFiles.length > 0 ? affectedFiles : null;
+  const needsFullReclassify = !!result.isFullBuild;
+  const needsScopedReclassify =
+    !needsFullReclassify && (chaEdgeCount > 0 || thisDispatchTargetIds.size > 0);
+  if (needsFullReclassify || needsScopedReclassify) {
+    let scopedFiles: string[] | null = null;
+    if (needsScopedReclassify) {
+      const affectedFiles = [...new Set([...chaAffectedFiles, ...thisDispatchAffectedFiles])];
+      // When edges were inserted but all their endpoint nodes have null `file`
+      // columns (rare but possible), affectedFiles stays empty even though
+      // fan-in/out changed. Fall back to full-graph re-classification in that
+      // case — scoped classification with an empty set would be a no-op, leaving
+      // roles stale for those nodes.
+      scopedFiles = affectedFiles.length > 0 ? affectedFiles : null;
+    }
     const reclassifyStart = performance.now();
     try {
       const { classifyNodeRoles } = (await import('../../../../features/structure.js')) as {
@@ -2017,7 +2039,7 @@ async function runPostNativePasses(
       debug(
         scopedFiles
           ? `Post-pass role re-classification complete (${scopedFiles.length} file(s))`
-          : 'Post-pass role re-classification complete (full graph — null-file endpoints)',
+          : 'Post-pass role re-classification complete (full graph)',
       );
     } catch (err) {
       debug(`Post-pass role re-classification failed: ${toErrorMessage(err)}`);

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -2105,8 +2105,8 @@ export async function tryNativeOrchestrator(
   // nodes/edges during incremental builds, so FK enforcement causes the purge
   // statements to fail silently — leaving stale nodes and edges that then get
   // duplicated when the barrel-candidate re-parse re-inserts them (issue #1644).
-  // Disabling FK before buildGraph() lets the purge succeed. FK enforcement is
-  // restored automatically when this connection is closed after the build.
+  // Disabling FK before buildGraph() lets the purge succeed; re-enable afterwards
+  // so JS post-passes run with full FK enforcement.
   try {
     ctx.nativeDb.exec('PRAGMA foreign_keys = OFF');
   } catch {
@@ -2119,6 +2119,12 @@ export async function tryNativeOrchestrator(
     JSON.stringify(ctx.aliases),
     JSON.stringify(ctx.opts),
   );
+  // Restore FK enforcement for JS post-passes (CHA, dataflow, structure).
+  try {
+    ctx.nativeDb.exec('PRAGMA foreign_keys = ON');
+  } catch {
+    // exec may not exist on very old addon versions — safe to ignore
+  }
   const result = JSON.parse(resultJson) as NativeOrchestratorResult;
 
   if (result.earlyExit) {

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -1,17 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { closeDb, getNodeId as getNodeIdQuery, initSchema, openDb } from '../../db/index.js';
+import { loadConfig } from '../../infrastructure/config.js';
 import { debug, info, warn } from '../../infrastructure/logger.js';
-import { isSupportedFile, normalizePath, shouldIgnore } from '../../shared/constants.js';
+import { buildIgnoreSet, isSupportedFile, normalizePath } from '../../shared/constants.js';
 import { DbError } from '../../shared/errors.js';
 import { createParseTreeCache, getActiveEngine } from '../parser.js';
 import { type IncrementalStmts, rebuildFile } from './builder/incremental.js';
 import { appendChangeEvents, buildChangeEvent, diffSymbols } from './change-journal.js';
 import { appendJournalEntriesAndStampHeader } from './journal.js';
 
-function shouldIgnorePath(filePath: string): boolean {
+function shouldIgnorePath(filePath: string, ignoreSet: ReadonlySet<string>): boolean {
   const parts = filePath.split(path.sep);
-  return parts.some((p) => shouldIgnore(p));
+  return parts.some((p) => ignoreSet.has(p) || p.startsWith('.'));
 }
 
 /** Prepare all SQL statements needed by the watcher's incremental rebuild. */
@@ -139,7 +140,7 @@ function logRebuildResults(updates: RebuildResult[]): void {
 }
 
 /** Recursively collect tracked source files for stat-based polling. */
-function collectTrackedFiles(dir: string, result: string[]): void {
+function collectTrackedFiles(dir: string, result: string[], ignoreSet: ReadonlySet<string>): void {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -148,10 +149,10 @@ function collectTrackedFiles(dir: string, result: string[]): void {
     return;
   }
   for (const entry of entries) {
-    if (shouldIgnore(entry.name)) continue;
+    if (ignoreSet.has(entry.name) || entry.name.startsWith('.')) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      collectTrackedFiles(full, result);
+      collectTrackedFiles(full, result, ignoreSet);
     } else if (isSupportedFile(entry.name)) {
       result.push(full);
     }
@@ -168,6 +169,8 @@ interface WatcherContext {
   pending: Set<string>;
   timer: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  /** Merged ignore set from IGNORE_DIRS + config.ignoreDirs + config.ignoreAdditionalDirs. */
+  ignoreSet: ReadonlySet<string>;
 }
 
 /** Initialize DB, engine, cache, and statements for watch mode. */
@@ -176,6 +179,12 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
   if (!fs.existsSync(dbPath)) {
     throw new DbError('No graph.db found. Run `codegraph build` first.', { file: dbPath });
   }
+
+  // Load repo config so ignoreDirs and ignoreAdditionalDirs are respected by
+  // the watcher the same way they are by collectFiles in the batch build path.
+  const config = loadConfig(rootDir);
+  const extraDirs = [...(config.ignoreDirs ?? []), ...(config.ignoreAdditionalDirs ?? [])];
+  const ignoreSet = buildIgnoreSet(extraDirs.length ? extraDirs : undefined);
 
   const db = openDb(dbPath);
   initSchema(db);
@@ -205,6 +214,7 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
     pending: new Set<string>(),
     timer: null,
     debounceMs: 300,
+    ignoreSet,
   };
 }
 
@@ -223,7 +233,7 @@ function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () =>
   const mtimeMap = new Map<string, number>();
 
   const initial: string[] = [];
-  collectTrackedFiles(ctx.rootDir, initial);
+  collectTrackedFiles(ctx.rootDir, initial, ctx.ignoreSet);
   for (const f of initial) {
     try {
       mtimeMap.set(f, fs.statSync(f).mtimeMs);
@@ -235,7 +245,7 @@ function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () =>
 
   const pollTimer = setInterval(() => {
     const current: string[] = [];
-    collectTrackedFiles(ctx.rootDir, current);
+    collectTrackedFiles(ctx.rootDir, current, ctx.ignoreSet);
     const currentSet = new Set(current);
 
     for (const f of current) {
@@ -270,7 +280,7 @@ function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () =>
 function startNativeWatcher(ctx: WatcherContext): () => void {
   const watcher = fs.watch(ctx.rootDir, { recursive: true }, (_eventType, filename) => {
     if (!filename) return;
-    if (shouldIgnorePath(filename)) return;
+    if (shouldIgnorePath(filename, ctx.ignoreSet)) return;
     if (!isSupportedFile(filename)) return;
 
     ctx.pending.add(path.join(ctx.rootDir, filename));

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -834,6 +834,7 @@ function serializeExtractorOutput(
       ? { returnTypeMap: Array.from(symbols.returnTypeMap.entries()) }
       : {}),
     ...(symbols.callAssignments?.length ? { callAssignments: symbols.callAssignments } : {}),
+    ...(symbols.cjsRequireBindings?.length ? { cjsRequireBindings: symbols.cjsRequireBindings } : {}),
   };
 }
 

--- a/src/domain/wasm-worker-pool.ts
+++ b/src/domain/wasm-worker-pool.ts
@@ -126,6 +126,7 @@ function deserializeBindingFields(ser: SerializedExtractorOutput, out: Extractor
   if (ser.thisCallBindings?.length) out.thisCallBindings = ser.thisCallBindings;
   if (ser.newExpressions?.length) out.newExpressions = ser.newExpressions;
   if (ser.callAssignments?.length) out.callAssignments = ser.callAssignments;
+  if (ser.cjsRequireBindings?.length) out.cjsRequireBindings = ser.cjsRequireBindings;
 }
 
 /** Deserialize the Map-typed fields that require entry-by-entry reconstruction. */

--- a/src/domain/wasm-worker-protocol.ts
+++ b/src/domain/wasm-worker-protocol.ts
@@ -79,6 +79,8 @@ export interface SerializedExtractorOutput {
   callAssignments?: CallAssignment[];
   /** Variable-level dataflow vertices extracted during parsing (P1+). */
   dataflowVertices?: import('../types.js').DataflowVertex[];
+  /** CJS require bindings — see ExtractorOutput.cjsRequireBindings (#1661). */
+  cjsRequireBindings?: Array<{ names: string[]; source: string }>;
 }
 
 export interface WorkerParseResponseOk {

--- a/src/extractors/dart.ts
+++ b/src/extractors/dart.ts
@@ -255,14 +255,62 @@ function handleDartSelector(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const argPart = findChild(node, 'argument_part');
   if (!argPart) return;
 
-  // Look for the identifier this selector belongs to
+  const line = node.startPosition.row + 1;
+
+  // Look for the identifier this selector belongs to.
+  // Two layouts are possible depending on grammar version:
+  //   A) selector has both unconditional_assignable_selector + argument_part (same node)
+  //   B) one selector node holds unconditional_assignable_selector (.method),
+  //      the next holds argument_part (the call args) — method name is in the previous sibling
   const unconditional = findChild(node, 'unconditional_assignable_selector');
+  let methodName: string | null = null;
+  let receiverText: string | null = null;
+
   if (unconditional) {
     const id = findChild(unconditional, 'identifier');
-    if (id) {
-      ctx.calls.push({ name: id.text, line: node.startPosition.row + 1 });
+    if (id) methodName = id.text;
+  } else {
+    // Layout B: look at the previous sibling selector for the method name
+    const parent = node.parent;
+    if (parent) {
+      for (let i = 0; i < parent.childCount; i++) {
+        const sibling = parent.child(i);
+        if (sibling === node) break;
+        if (sibling?.type === 'selector') {
+          const unc2 = findChild(sibling, 'unconditional_assignable_selector');
+          if (unc2) {
+            const id2 = findChild(unc2, 'identifier');
+            if (id2) methodName = id2.text;
+          }
+        } else {
+          receiverText = sibling?.text ?? null;
+        }
+      }
     }
   }
+
+  if (!methodName) return;
+
+  // Function.apply(fn, positionalArgs, namedArgs) — dynamic higher-order dispatch
+  if (methodName === 'apply') {
+    const parent = node.parent;
+    if (parent) {
+      for (let i = 0; i < parent.childCount; i++) {
+        const sibling = parent.child(i);
+        if (sibling && sibling !== node && sibling.text === 'Function') {
+          ctx.calls.push({
+            name: '<dynamic:unresolved>',
+            line,
+            dynamic: true,
+            dynamicKind: 'unresolved-dynamic',
+          });
+          return;
+        }
+      }
+    }
+  }
+
+  ctx.calls.push({ name: methodName, line });
 }
 
 function handleDartTypeAlias(node: TreeSitterNode, ctx: ExtractorOutput): void {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -399,8 +399,11 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
     arrayCallbackBindings,
   });
 
-  // Extract definitions from destructured bindings (query patterns don't match object_pattern)
-  extractDestructuredBindingsWalk(tree.rootNode, definitions);
+  // Extract definitions from destructured bindings (query patterns don't match object_pattern).
+  // Also collects CJS require bindings (const { X } = require('…')) into a separate list so
+  // importedNames can classify them as import artifacts without creating DB edges (#1661).
+  const cjsRequireBindings: Array<{ names: string[]; source: string }> = [];
+  extractDestructuredBindingsWalk(tree.rootNode, definitions, cjsRequireBindings);
 
   // Everything without bespoke traversal semantics is collected in ONE pass:
   // dynamic import() calls, prototype-method definitions, param bindings,
@@ -443,6 +446,7 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
     thisCallBindings,
     newExpressions,
     ...(definePropertyReceivers.size > 0 ? { definePropertyReceivers } : {}),
+    ...(cjsRequireBindings.length > 0 ? { cjsRequireBindings } : {}),
   };
 }
 
@@ -508,8 +512,15 @@ function extractConstantsWalk(node: TreeSitterNode, definitions: Definition[]): 
 /**
  * Walk the AST to find destructured const bindings (query patterns don't match object_pattern).
  * e.g. `const { handleToken, checkPermissions } = initAuth(config)`
+ *
+ * When `cjsRequireBindings` is provided, also records `const { X } = require('./path')` patterns
+ * so the edge builder can classify X as an import artifact rather than a local definition (#1661).
  */
-function extractDestructuredBindingsWalk(node: TreeSitterNode, definitions: Definition[]): void {
+function extractDestructuredBindingsWalk(
+  node: TreeSitterNode,
+  definitions: Definition[],
+  cjsRequireBindings?: Array<{ names: string[]; source: string }>,
+): void {
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     if (!child) continue;
@@ -537,6 +548,43 @@ function extractDestructuredBindingsWalk(node: TreeSitterNode, definitions: Defi
             nodeEndLine(declNode),
             definitions,
           );
+          // Record CJS require bindings so importedNames can classify these names
+          // as import artifacts, preventing false local-definition blocking (#1661).
+          if (cjsRequireBindings) {
+            const valueN = declarator.childForFieldName('value');
+            if (valueN?.type === 'call_expression') {
+              const fn = valueN.childForFieldName('function');
+              if (fn?.text === 'require') {
+                const args = valueN.childForFieldName('arguments');
+                const strArg = args && findChild(args, 'string');
+                if (strArg) {
+                  const modPath = strArg.text.replace(/['"]/g, '');
+                  const names: string[] = [];
+                  for (let k = 0; k < nameN.childCount; k++) {
+                    const prop = nameN.child(k);
+                    if (!prop) continue;
+                    if (
+                      prop.type === 'shorthand_property_identifier_pattern' ||
+                      prop.type === 'shorthand_property_identifier'
+                    ) {
+                      names.push(prop.text);
+                    } else if (prop.type === 'pair_pattern' || prop.type === 'pair') {
+                      const val = prop.childForFieldName('value');
+                      if (
+                        val?.type === 'identifier' ||
+                        val?.type === 'shorthand_property_identifier_pattern'
+                      ) {
+                        names.push(val.text);
+                      }
+                    }
+                  }
+                  if (names.length > 0) {
+                    cjsRequireBindings.push({ names, source: modPath });
+                  }
+                }
+              }
+            }
+          }
         } else if (nameN && nameN.type === 'array_pattern') {
           // `const [x, y] = ...` — emit a single constant node whose name is the
           // full array pattern text (e.g. `[x, y]`), matching native engine behaviour.
@@ -551,7 +599,7 @@ function extractDestructuredBindingsWalk(node: TreeSitterNode, definitions: Defi
     }
 
     if (child.type !== 'export_statement') {
-      extractDestructuredBindingsWalk(child, definitions);
+      extractDestructuredBindingsWalk(child, definitions, cjsRequireBindings);
     }
   }
 }
@@ -1111,6 +1159,40 @@ function handleVariableDecl(node: TreeSitterNode, ctx: ExtractorOutput): void {
             nodeEndLine(node),
             ctx.definitions,
           );
+          // Record CJS require bindings for import-artifact classification (#1661).
+          if (valueN?.type === 'call_expression') {
+            const fn = valueN.childForFieldName('function');
+            if (fn?.text === 'require') {
+              const args = valueN.childForFieldName('arguments');
+              const strArg = args && findChild(args, 'string');
+              if (strArg) {
+                const modPath = strArg.text.replace(/['"]/g, '');
+                const names: string[] = [];
+                for (let k = 0; k < nameN.childCount; k++) {
+                  const prop = nameN.child(k);
+                  if (!prop) continue;
+                  if (
+                    prop.type === 'shorthand_property_identifier_pattern' ||
+                    prop.type === 'shorthand_property_identifier'
+                  ) {
+                    names.push(prop.text);
+                  } else if (prop.type === 'pair_pattern' || prop.type === 'pair') {
+                    const val = prop.childForFieldName('value');
+                    if (
+                      val?.type === 'identifier' ||
+                      val?.type === 'shorthand_property_identifier_pattern'
+                    ) {
+                      names.push(val.text);
+                    }
+                  }
+                }
+                if (names.length > 0) {
+                  if (!ctx.cjsRequireBindings) ctx.cjsRequireBindings = [];
+                  ctx.cjsRequireBindings.push({ names, source: modPath });
+                }
+              }
+            }
+          }
         } else if (isConst && nameN.type === 'array_pattern' && !hasFunctionScopeAncestor(node)) {
           // Array destructuring: `const [x, y] = ...` — emit a single constant node
           // whose name is the full array pattern text (e.g. `[x, y]`), matching

--- a/src/extractors/objc.ts
+++ b/src/extractors/objc.ts
@@ -336,7 +336,19 @@ function handleCCallExpr(node: TreeSitterNode, ctx: ExtractorOutput): void {
   } else {
     call.name = funcNode.text;
   }
-  if (call.name) ctx.calls.push(call);
+  if (!call.name) return;
+  // objc_msgSend(obj, sel, ...) — raw ObjC runtime call; selector is a SEL value
+  if (call.name === 'objc_msgSend') {
+    ctx.calls.push({
+      name: '<dynamic:unresolved>',
+      line: call.line,
+      dynamic: true,
+      dynamicKind: 'unresolved-dynamic',
+      receiver: call.receiver,
+    });
+    return;
+  }
+  ctx.calls.push(call);
 }
 
 function handleMessageExpr(node: TreeSitterNode, ctx: ExtractorOutput): void {
@@ -366,6 +378,18 @@ function handleMessageExpr(node: TreeSitterNode, ctx: ExtractorOutput): void {
     const selector = node.childForFieldName('selector');
     if (!selector) return;
     name = selector.text;
+  }
+
+  // performSelector: / performSelector:withObject: — SEL dispatch; not statically resolvable
+  if (name === 'performSelector:' || name.startsWith('performSelector:withObject')) {
+    ctx.calls.push({
+      name: '<dynamic:unresolved>',
+      line: node.startPosition.row + 1,
+      dynamic: true,
+      dynamicKind: 'unresolved-dynamic',
+      receiver: receiver?.text,
+    });
+    return;
   }
 
   const call: Call = { name, line: node.startPosition.row + 1 };

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -21,6 +21,7 @@ export const DEFAULTS = {
   include: [] as string[],
   exclude: [] as string[],
   ignoreDirs: [] as string[],
+  ignoreAdditionalDirs: [] as string[],
   extensions: [] as string[],
   aliases: {} as Record<string, string>,
   build: {
@@ -452,6 +453,7 @@ const BUILD_HASH_KEYS: ReadonlyArray<keyof CodegraphConfig> = [
   'include',
   'exclude',
   'ignoreDirs',
+  'ignoreAdditionalDirs',
   'extensions',
   'aliases',
   'build',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -34,6 +34,15 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
   ]),
 );
 
+/**
+ * Merge the global IGNORE_DIRS set with a per-repo additional list from config.
+ * Returns a new Set — does not mutate IGNORE_DIRS.
+ */
+export function buildIgnoreSet(additionalDirs?: string[]): Set<string> {
+  if (!additionalDirs || additionalDirs.length === 0) return IGNORE_DIRS;
+  return new Set([...IGNORE_DIRS, ...additionalDirs]);
+}
+
 export const EXTENSIONS: ArrayCompatSet<string> = withArrayCompat(new Set(SUPPORTED_EXTENSIONS));
 
 /**

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,7 +38,7 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
  * Merge the global IGNORE_DIRS set with a per-repo additional list from config.
  * Returns a new Set — does not mutate IGNORE_DIRS.
  */
-export function buildIgnoreSet(additionalDirs?: string[]): Set<string> {
+export function buildIgnoreSet(additionalDirs?: string[]): ReadonlySet<string> {
   if (!additionalDirs || additionalDirs.length === 0) return IGNORE_DIRS;
   return new Set([...IGNORE_DIRS, ...additionalDirs]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1351,6 +1351,8 @@ export interface CodegraphConfig {
   include: string[];
   exclude: string[];
   ignoreDirs: string[];
+  /** Additional directory names to ignore on top of the built-in IGNORE_DIRS set. */
+  ignoreAdditionalDirs: string[];
   extensions: string[];
   aliases: Record<string, unknown>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -484,7 +484,7 @@ export interface LOCMetrics {
 export type DynamicKind =
   | 'computed-literal' // obj["foo"]()    — resolvable; already emitted as normal edge
   | 'computed-key' // obj[k]()        — potentially resolvable via pts; else flagged
-  | 'reflection' // .call/.apply/.bind / Reflect.* — usually resolved; not flagged (drops silently if unresolved)
+  | 'reflection' // .call/.apply/.bind / Reflect.* / callable-ref — resolved when target is in codebase; sink edge emitted if unresolved
   | 'eval' // eval() / new Function() — undecidable; always flagged
   | 'unresolved-dynamic'; // any other detected dynamic pattern; flagged
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -729,6 +729,14 @@ export interface ExtractorOutput {
    * `definePropertyReceivers.set("getter", "obj")`.
    */
   definePropertyReceivers?: Map<string, string>;
+  /**
+   * CJS require bindings from `const { X, Y } = require('./path')` patterns.
+   * Used by buildImportedNamesMap to classify X and Y as import artifacts so
+   * receiver-edge resolution falls back to the global class lookup rather than
+   * treating the destructured-binding function node as a local definition (#1661).
+   * Does NOT cause DB import edges — use `imports` for that.
+   */
+  cjsRequireBindings?: Array<{ names: string[]; source: string }>;
   /** WASM tree retained for downstream analysis (complexity, CFG, dataflow). */
   _tree?: TreeSitterTree;
   /** Language identifier. */

--- a/tests/benchmarks/resolution/fixtures/dynamic-java/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/dynamic-java/expected-edges.json
@@ -4,11 +4,11 @@
   "description": "Phase 2 JVM fixture: Java reflection patterns. getMethod('name') resolved; invoke() flagged.",
   "edges": [
     {
-      "source": { "name": "runGetMethod", "file": "Reflection.java" },
-      "target": { "name": "greet", "file": "Reflection.java" },
+      "source": { "name": "Reflection.runGetMethod", "file": "Reflection.java" },
+      "target": { "name": "Reflection.greet", "file": "Reflection.java" },
       "kind": "calls",
       "mode": "dynamic",
-      "notes": "clazz.getMethod('greet') — reflection kind, resolved to greet() in same class"
+      "notes": "clazz.getMethod('greet') — reflection kind, resolved to Reflection.greet() via caller-class qualifier"
     }
   ]
 }

--- a/tests/benchmarks/resolution/fixtures/dynamic-kotlin/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/dynamic-kotlin/expected-edges.json
@@ -16,6 +16,13 @@
       "kind": "calls",
       "mode": "dynamic",
       "notes": "::farewell callable reference — reflection kind, resolves to top-level farewell()"
+    },
+    {
+      "source": { "name": "runMemberCallableRef", "file": "reflection.kt" },
+      "target": { "name": "Greeter.greet", "file": "reflection.kt" },
+      "kind": "calls",
+      "mode": "dynamic",
+      "notes": "Greeter::greet member callable ref must resolve to Greeter.greet, not top-level greet()"
     }
   ]
 }

--- a/tests/benchmarks/resolution/fixtures/dynamic-kotlin/reflection.kt
+++ b/tests/benchmarks/resolution/fixtures/dynamic-kotlin/reflection.kt
@@ -20,3 +20,13 @@ fun runFarewellRef(): (String) -> String {
 fun runInvoke(fn: (String) -> String): String {
     return fn.invoke("world")
 }
+
+// Member callable reference: Greeter::greet must resolve to Greeter.greet,
+// not the top-level greet() above, even though both share the same name.
+class Greeter {
+    fun greet(name: String): String = "Hi, $name"
+}
+
+fun runMemberCallableRef(): (Greeter, String) -> String {
+    return Greeter::greet
+}

--- a/tests/benchmarks/resolution/fixtures/dynamic-typescript/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/dynamic-typescript/expected-edges.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../expected-edges.schema.json",
   "language": "typescript",
-  "description": "Phase 1 dynamic call fixture: Reflect.apply/construct/get and TypeScript decorators. Flagged kinds (computed-key) emit sink edges excluded from expected-edges.",
+  "description": "Phase 1 dynamic call fixture: Reflect.apply/construct/get and TypeScript decorators. Flagged kinds (computed-key, unresolved reflection) emit sink edges excluded from expected-edges.",
   "edges": [
     {
       "source": { "name": "runReflectApply", "file": "reflect.ts" },

--- a/tests/benchmarks/resolution/fixtures/dynamic-typescript/reflect.ts
+++ b/tests/benchmarks/resolution/fixtures/dynamic-typescript/reflect.ts
@@ -37,3 +37,8 @@ export function runReflectGetVariable(obj: Record<string, unknown>, key: string)
   // Reflect.get(obj, key) — computed-key, flagged as sink edge
   return Reflect.get(obj, key);
 }
+
+export function runReflectApplyExternal(fn: Function, ctx: unknown, args: unknown[]): unknown {
+  // Reflect.apply(fn, ctx, args) — reflection kind, fn not in codebase → sink edge
+  return Reflect.apply(fn as Parameters<typeof Reflect.apply>[0], ctx, args);
+}

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -143,15 +143,14 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   //   3 expected edges (Reflect.apply → greet, Reflect.construct → UserService, Reflect.get → greet).
   'dynamic-typescript': { precision: 1.0, recall: 0.75 },
   // Phase 2 JVM fixtures — reflection and dynamic dispatch patterns.
-  // Java/Scala/Groovy: detection works but method names are class-qualified in the DB,
-  //   so lookup-by-name fails for getMethod("foo") → 0% recall until RES-3 adds type-aware lookup.
+  // RES-3: type-aware qualified lookup resolves getMethod("foo") → ClassName.foo.
   //   invoke() and forName() emit sink edges (confidence=0.0, excluded from metrics).
-  'dynamic-java': { precision: 0.0, recall: 0.0 },
+  'dynamic-java': { precision: 1.0, recall: 1.0 },
   // Kotlin: ::fn callable refs resolve correctly (top-level fns are unqualified in DB).
   //   invoke() emits sink edge (excluded). 100% recall achievable.
   'dynamic-kotlin': { precision: 1.0, recall: 1.0 },
-  'dynamic-scala': { precision: 0.0, recall: 0.0 },
-  'dynamic-groovy': { precision: 0.0, recall: 0.0 },
+  'dynamic-scala': { precision: 1.0, recall: 1.0 },
+  'dynamic-groovy': { precision: 1.0, recall: 1.0 },
   // TS 0.72: Phase 8.3e adds this.method() same-class resolution (Shape.describe → Shape.area),
   //   lifting recall from 69.4% to 72.2%.  Remaining gap (interface-dispatch, CHA) is tracked
   //   in Phase 8.5 (TSC enrichment) and Phase 8.7 (CHA on JS/TS).

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -137,10 +137,11 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   //   Currently resolves all 13 expected edges (100% recall, 100% precision).
   'pts-javascript': { precision: 1.0, recall: 0.9 },
   // dynamic-javascript: Phase 0 dynamic-call fixture — reflection (.call/.apply) + computed-literal.
-  //   Flagged kinds (eval, computed-key) emit sink edges (confidence=0.0) excluded from metrics.
+  //   Flagged kinds (eval, computed-key, unresolved reflection) emit sink edges (confidence=0.0) excluded from metrics.
   'dynamic-javascript': { precision: 1.0, recall: 0.75 },
   // dynamic-typescript: Phase 1 fixture — Reflect.apply/construct/get + TS decorators.
   //   3 expected edges (Reflect.apply → greet, Reflect.construct → UserService, Reflect.get → greet).
+  //   Unresolved Reflect.apply(fn, ...) where fn is external emits a reflection sink edge (excluded from metrics).
   'dynamic-typescript': { precision: 1.0, recall: 0.75 },
   // Phase 2 JVM fixtures — reflection and dynamic dispatch patterns.
   // RES-3: type-aware qualified lookup resolves getMethod("foo") → ClassName.foo.

--- a/tests/parsers/dart.test.ts
+++ b/tests/parsers/dart.test.ts
@@ -50,4 +50,13 @@ import 'package:flutter/material.dart';`);
     // This test verifies the parser doesn't crash on constructor syntax
     expect(symbols).toBeDefined();
   });
+
+  it('flags Function.apply as unresolved-dynamic', () => {
+    const symbols = parseDart(`void g() {
+  var r = Function.apply(callback, []);
+}`);
+    expect(symbols.calls).toContainEqual(
+      expect.objectContaining({ name: '<dynamic:unresolved>', dynamic: true, dynamicKind: 'unresolved-dynamic' }),
+    );
+  });
 });

--- a/tests/parsers/objc.test.ts
+++ b/tests/parsers/objc.test.ts
@@ -91,6 +91,33 @@ describe('Objective-C parser', () => {
     );
   });
 
+  it('flags performSelector: as unresolved-dynamic', () => {
+    const symbols = parseObjC(`void main() {
+    [obj performSelector:@selector(greet)];
+}`);
+    expect(symbols.calls).toContainEqual(
+      expect.objectContaining({ name: '<dynamic:unresolved>', dynamic: true, dynamicKind: 'unresolved-dynamic' }),
+    );
+  });
+
+  it('flags performSelector:withObject: as unresolved-dynamic', () => {
+    const symbols = parseObjC(`void main() {
+    [obj performSelector:@selector(greet) withObject:arg];
+}`);
+    expect(symbols.calls).toContainEqual(
+      expect.objectContaining({ name: '<dynamic:unresolved>', dynamic: true, dynamicKind: 'unresolved-dynamic' }),
+    );
+  });
+
+  it('flags objc_msgSend as unresolved-dynamic', () => {
+    const symbols = parseObjC(`void main() {
+    objc_msgSend(obj, sel, arg);
+}`);
+    expect(symbols.calls).toContainEqual(
+      expect.objectContaining({ name: '<dynamic:unresolved>', dynamic: true, dynamicKind: 'unresolved-dynamic' }),
+    );
+  });
+
   it('extracts keyword-selector method definitions with parameter names', () => {
     // The v3 grammar emits flat `identifier`+`method_parameter` children under
     // `method_definition` rather than wrapping them in `keyword_selector`. The

--- a/tests/unit/builder.test.ts
+++ b/tests/unit/builder.test.ts
@@ -105,6 +105,22 @@ describe('collectFiles', () => {
     expect(basenames).toContain('app.js');
   });
 
+  it('respects config.ignoreAdditionalDirs', () => {
+    const files = collectFiles(tmpDir, [], { ignoreAdditionalDirs: ['lib'] });
+    const basenames = files.map((f) => path.basename(f));
+    expect(basenames).not.toContain('helper.py');
+    // src files still present
+    expect(basenames).toContain('app.js');
+  });
+
+  it('merges ignoreAdditionalDirs with ignoreDirs when both are set', () => {
+    // ignoreDirs excludes 'lib', ignoreAdditionalDirs excludes 'src'
+    const files = collectFiles(tmpDir, [], { ignoreDirs: ['lib'], ignoreAdditionalDirs: ['src'] });
+    const basenames = files.map((f) => path.basename(f));
+    expect(basenames).not.toContain('helper.py'); // lib excluded
+    expect(basenames).not.toContain('app.js'); // src excluded
+  });
+
   it('returns empty array for non-existent directory (graceful)', () => {
     const files = collectFiles(path.join(tmpDir, 'does-not-exist'));
     expect(files).toEqual([]);

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -5,6 +5,7 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  buildIgnoreSet,
   EXTENSIONS,
   IGNORE_DIRS,
   isSupportedFile,
@@ -48,6 +49,36 @@ describe('IGNORE_DIRS', () => {
     for (const dir of expected) {
       expect(IGNORE_DIRS.has(dir)).toBe(true);
     }
+  });
+
+  it('does not contain crates (repo-specific dirs belong in ignoreAdditionalDirs config)', () => {
+    expect(IGNORE_DIRS.has('crates')).toBe(false);
+  });
+});
+
+describe('buildIgnoreSet', () => {
+  it('returns IGNORE_DIRS when no additional dirs provided', () => {
+    const result = buildIgnoreSet();
+    expect(result).toBe(IGNORE_DIRS);
+  });
+
+  it('returns IGNORE_DIRS when empty array provided', () => {
+    const result = buildIgnoreSet([]);
+    expect(result).toBe(IGNORE_DIRS);
+  });
+
+  it('merges additional dirs on top of IGNORE_DIRS', () => {
+    const result = buildIgnoreSet(['crates', 'generated']);
+    expect(result.has('node_modules')).toBe(true); // from IGNORE_DIRS
+    expect(result.has('crates')).toBe(true); // additional
+    expect(result.has('generated')).toBe(true); // additional
+  });
+
+  it('does not mutate IGNORE_DIRS', () => {
+    const before = new Set(IGNORE_DIRS);
+    buildIgnoreSet(['crates']);
+    expect(IGNORE_DIRS.size).toBe(before.size);
+    expect(IGNORE_DIRS.has('crates')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- ObjC (`objc.ts` + `objc.rs`): detect `[obj performSelector:@selector(...)]`, `[obj performSelector:... withObject:...]`, and `objc_msgSend(obj, sel, ...)` — all emit `unresolved-dynamic` sink edges since the selector is a runtime SEL value, not statically knowable
- Dart (`dart.ts` + `dart.rs`): detect `Function.apply(fn, positional, named)` — emits `unresolved-dynamic` sink edge; handles the tree-sitter-dart layout where the `.apply` method selector and the argument part appear in adjacent `selector` sibling nodes
- Tests: 3 new Rust `#[test]` cases in `objc.rs`, 1 new vitest case each in `objc.test.ts` and `dart.test.ts`

## Test plan

- [x] `cargo test --package codegraph-core --lib extractors::objc` — 13 tests pass (3 new)
- [x] `vitest run tests/parsers/objc` — 15 tests pass (3 new)
- [x] `vitest run tests/parsers/dart` — 6 tests pass (1 new)
- [x] `vitest run tests/engines/parity` — 31 tests pass, no regressions

Closes #1664