### PR TITLE
test(native): add regression test for crates/ directory not being ignored

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
@@ -557,4 +557,28 @@ mod tests {
             "fast path must filter out excluded files so incremental builds honor config changes"
         );
     }
+
+    /// Regression test for issue #1674 — files under a `crates/` directory must
+    /// NOT be silently dropped by the native engine. A `crates/` entry was
+    /// mistakenly present in DEFAULT_IGNORE_DIRS; this verifies it is absent.
+    #[test]
+    fn collect_does_not_skip_crates_dir() {
+        let tmp = std::env::temp_dir().join("codegraph_collect_crates_test");
+        let _ = fs::remove_dir_all(&tmp);
+        let crate_src = tmp.join("crates").join("my-crate").join("src");
+        fs::create_dir_all(&crate_src).unwrap();
+        fs::write(crate_src.join("lib.rs"), "").unwrap();
+
+        let result = collect_files(tmp.to_str().unwrap(), &[], &[], &[]);
+        assert!(
+            !result.files.is_empty(),
+            "files inside crates/ must not be silently ignored by DEFAULT_IGNORE_DIRS"
+        );
+        assert!(
+            result.files.iter().any(|f| f.contains("lib.rs")),
+            "crates/my-crate/src/lib.rs must appear in collected files"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a Rust unit test to `collect_files.rs` verifying that files under a `crates/` directory are collected by the native engine
- The test guards against re-introduction of the `"crates"` entry that was mistakenly in `DEFAULT_IGNORE_DIRS`, causing the native engine to silently skip all files under any `crates/` directory in user repositories (while the WASM engine did not — parity divergence)
- The actual removal of `"crates"` from `DEFAULT_IGNORE_DIRS` landed in commit `53cc57d5` (shipped in v3.14.x); this PR adds the regression test coverage that was missing

## Test plan

- [x] New Rust unit test `collect_does_not_skip_crates_dir` passes: `cargo test collect_does_not_skip_crates_dir`
- [x] Parity integration tests pass: `npx vitest run tests/integration/build-parity.test.ts`
- [x] `DEFAULT_IGNORE_DIRS` in `collect_files.rs` does not contain `"crates"` (verified at commit `53cc57d5`)
- [x] TypeScript `IGNORE_DIRS` in `constants.ts` does not contain `"crates"` (verified)

Fixes #1674