### PR TITLE
fix(wasm): emit dyn=0 for f.call/bind alias calls (closes #1687)

### DIFF
--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -3120,10 +3120,16 @@ function extractMemberExprCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode)
     };
   }
 
-  // .call()/.apply()/.bind() — this-rebinding; target is statically known
+  // .call()/.apply()/.bind() — this-rebinding; the wrapped function is the real callee.
+  // When the object is a plain identifier (e.g. `f.call({})`), the target is statically
+  // known so we emit a static call (no dynamic flag).  This keeps parity with the native
+  // Rust engine, which also resolves these as dyn=0, and prevents the dynZeroEdgeRows
+  // upgrade path in emitDirectCallEdgesForCall from wrongly converting a dyn=0 edge
+  // (emitted by a prior direct `f()` call) to dyn=1.
+  // When the object is a member_expression (e.g. `obj.method.call({})`), we still mark
+  // it dynamic/reflection because the inner callee requires a second resolution hop.
   if (propText === 'call' || propText === 'apply' || propText === 'bind') {
-    if (obj && obj.type === 'identifier')
-      return { name: obj.text, line: callLine, dynamic: true, dynamicKind: 'reflection' };
+    if (obj && obj.type === 'identifier') return { name: obj.text, line: callLine };
     if (obj && obj.type === 'member_expression') {
       const innerProp = obj.childForFieldName('property');
       if (innerProp)

--- a/tests/engines/dynamic-call-ffi.test.ts
+++ b/tests/engines/dynamic-call-ffi.test.ts
@@ -65,23 +65,28 @@ describe('dynamic call classification — dynamicKind and keyExpr fields', () =>
     expect(c?.dynamic).toBe(true);
   });
 
-  it('tags fn.call(ctx) as reflection kind', () => {
+  it('resolves fn.call(ctx) as a static call — no dynamic flag (#1687)', () => {
+    // `greet.call(ctx, 'world')` — plain-identifier receiver; target is statically known.
+    // We emit a static call (no dynamic, no dynamicKind) to match native Rust parity and
+    // prevent the dynZeroEdgeRows upgrade from promoting a prior dyn=0 edge to dyn=1.
     const out = parseJS(`
       function test(ctx) { greet.call(ctx, 'world'); }
     `);
     const c = out.calls.find((c) => c.name === 'greet');
     expect(c).toBeDefined();
-    expect(c?.dynamicKind).toBe('reflection');
-    expect(c?.dynamic).toBe(true);
+    expect(c?.dynamic).toBeFalsy();
+    expect(c?.dynamicKind).toBeUndefined();
   });
 
-  it('tags fn.apply(ctx, args) as reflection kind', () => {
+  it('resolves fn.apply(ctx, args) as a static call — no dynamic flag (#1687)', () => {
+    // Same as .call(): plain-identifier receiver → static call.
     const out = parseJS(`
       function test(ctx) { greet.apply(ctx, ['world']); }
     `);
     const c = out.calls.find((c) => c.name === 'greet');
     expect(c).toBeDefined();
-    expect(c?.dynamicKind).toBe('reflection');
+    expect(c?.dynamic).toBeFalsy();
+    expect(c?.dynamicKind).toBeUndefined();
   });
 
   it('tags obj[a + b]() as unresolved-dynamic kind', () => {

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -155,10 +155,17 @@ describe('JavaScript parser', () => {
     expect(symbols.imports[0].reexport).toBe(true);
   });
 
-  it('detects dynamic call patterns', () => {
+  it('resolves .call()/.apply() on plain identifiers as static calls', () => {
+    // `fn.call(null, arg)` — plain-identifier receiver; target is statically known,
+    // so we emit a static call (dyn=0).  This keeps parity with the native Rust engine
+    // and prevents the dynZeroEdgeRows upgrade from wrongly promoting dyn=0 → dyn=1.
     const symbols = parseJS(`fn.call(null, arg); obj.apply(undefined, args);`);
-    const dynamicCalls = symbols.calls.filter((c) => c.dynamic);
-    expect(dynamicCalls.length).toBeGreaterThanOrEqual(1);
+    const fnCall = symbols.calls.find((c) => c.name === 'fn');
+    expect(fnCall).toBeDefined();
+    expect(fnCall.dynamic).toBeFalsy();
+    const objCall = symbols.calls.find((c) => c.name === 'obj');
+    expect(objCall).toBeDefined();
+    expect(objCall.dynamic).toBeFalsy();
   });
 
   it('captures receiver for method calls', () => {
@@ -633,6 +640,26 @@ describe('JavaScript parser', () => {
     const fnCall = symbols.calls.find((c) => c.name === 'fn');
     expect(fnCall).toBeDefined();
     expect(fnCall.receiver).toBeUndefined();
+  });
+
+  it('emits static call for .call/.apply/.bind on plain identifier (#1687)', () => {
+    // `f.call({})` where f is a plain identifier — target is statically known;
+    // must emit dyn=0 (no dynamic flag) to match native Rust engine parity.
+    const symbols = parseJS(`const f = function () {}.bind({}); f(); f.call({});`);
+    const fCallCalls = symbols.calls.filter((c) => c.name === 'f');
+    expect(fCallCalls.length).toBeGreaterThanOrEqual(1);
+    for (const c of fCallCalls) {
+      expect(c.dynamic).toBeFalsy(); // all f() / f.call({}) calls must be dyn=0
+    }
+  });
+
+  it('still emits dynamic/reflection for .call on member-expression object', () => {
+    // `obj.method.call({})` — inner callee requires a resolution hop; stays dynamic.
+    const symbols = parseJS(`obj.method.call({});`);
+    const methodCall = symbols.calls.find((c) => c.name === 'method');
+    expect(methodCall).toBeDefined();
+    expect(methodCall.dynamic).toBe(true);
+    expect(methodCall.dynamicKind).toBe('reflection');
   });
 
   describe('callback pattern extraction', () => {


### PR DESCRIPTION
## Summary

- In `extractMemberExprCallInfo`, change `.call/.apply/.bind` on plain identifiers from emitting `{ dynamic: true, dynamicKind: 'reflection' }` to emitting a static call (no dynamic flag)
- Fixes WASM/native parity divergence for the jelly-micro `bind.js` fixture: WASM was emitting `dyn=1` while native emitted `dyn=0` for `f.call({})` patterns
- Update `dynamic-call-ffi.test.ts` and `javascript.test.ts` to assert the new static-call behavior

## Root Cause

When `f.call({})` precedes or follows a direct `f()` call for the same target, the WASM edge builder's `dynZeroEdgeRows` upgrade path in `emitDirectCallEdgesForCall` was converting a `dyn=0` edge (emitted by `f()`) to `dyn=1` because the `f.call({})` call had `dynamicKind: 'reflection'` set, triggering the upgrade condition `isDynamic === 1 && hasDynamicKind`.

The native Rust engine silently drops the second call (the `f.call({})` one) once the edge is already in `seenEdges`, preserving `dyn=0`. The fix aligns WASM behavior: when the `.call/.apply/.bind` receiver is a plain identifier, the target is statically known so we emit a static call — `isDynamic = 0` — which never triggers the upgrade.

Member-expression objects (`obj.method.call({})`) still receive `dynamicKind: 'reflection'` since the inner callee requires a second resolution hop.

Closes #1687