### PR TITLE
perf(native): fix full-build regression in the P6 dataflow vertex pass

### DIFF
--- a/crates/codegraph-core/src/lib.rs
+++ b/crates/codegraph-core/src/lib.rs
@@ -187,3 +187,28 @@ pub fn extract_dataflow_analysis(
 ) -> Option<types::DataflowResult> {
     ast_analysis::engine::extract_dataflow_standalone(&source, &file_path, lang_id.as_deref())
 }
+
+/// Batch counterpart to `extract_dataflow_analysis`: read and analyse many files
+/// in parallel in a single NAPI call.
+///
+/// The native orchestrator's P6 vertex pass needs a `DataflowResult` for every
+/// dataflow-bearing file on a full build. Calling `extract_dataflow_analysis`
+/// once per file serialised hundreds of parses on the JS event loop and dominated
+/// the native full-build benchmark. This reads each path from disk and runs the
+/// dataflow extractor across the rayon thread pool, returning results positionally
+/// (`None` where the file could not be read or the language has no dataflow rules),
+/// so the caller maps them straight back onto its input list. Each `parse_source`
+/// builds its own tree-sitter `Parser`, so the work is embarrassingly parallel.
+#[napi]
+pub fn extract_dataflow_analysis_batch(
+    file_paths: Vec<String>,
+) -> Vec<Option<types::DataflowResult>> {
+    use rayon::prelude::*;
+    file_paths
+        .par_iter()
+        .map(|file_path| {
+            let source = std::fs::read_to_string(file_path).ok()?;
+            ast_analysis::engine::extract_dataflow_standalone(&source, file_path, None)
+        })
+        .collect()
+}

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -370,22 +370,41 @@ async function runDataflowVertexPass(
   const nativeDataflow = new Map<string, DataflowResult>();
   const wasmStubs = new Map<string, { definitions: []; _langId: null; _tree: null }>();
 
-  for (const relPath of filesToProcess) {
-    const absPath = path.join(ctx.rootDir, relPath);
-    const source = readFileSafe(absPath);
-    if (!source) continue;
-    let result: DataflowResult | null = null;
+  const absPaths = filesToProcess.map((relPath) => path.join(ctx.rootDir, relPath));
+
+  // Batch the per-file dataflow extraction into one NAPI call so the parses run
+  // across the rayon thread pool instead of serially on the event loop — this is
+  // the dominant cost of a native full build (#perf). Older addons predate the
+  // batch export, so fall back to the per-file path when it is unavailable.
+  let batchResults: (DataflowResult | null)[] | null = null;
+  if (typeof native.extractDataflowAnalysisBatch === 'function') {
     try {
-      result = native.extractDataflowAnalysis(source, absPath);
+      batchResults = native.extractDataflowAnalysisBatch(absPaths);
     } catch {
-      // Language-specific parse failure — fall through to WASM.
+      batchResults = null; // fall through to per-file extraction below
+    }
+  }
+
+  for (let i = 0; i < filesToProcess.length; i++) {
+    const relPath = filesToProcess[i]!;
+    let result: DataflowResult | null = null;
+    if (batchResults) {
+      result = batchResults[i] ?? null;
+    } else {
+      const source = readFileSafe(absPaths[i]!);
+      if (!source) continue;
+      try {
+        result = native.extractDataflowAnalysis(source, absPaths[i]!);
+      } catch {
+        // Language-specific parse failure — fall through to WASM.
+      }
     }
     if (result) {
       // Normalise the native DataflowResult: Rust emits `bindingType: string | null`
       // (flat) while the TS dataflow layer expects `binding: { type, index? }` (object).
       // patchNativeResult handles this via patchDataflow for the full parse path;
-      // extractDataflowAnalysis is a vertex-only fast path that bypasses patchNativeResult,
-      // so we apply the same normalisation here.
+      // extractDataflowAnalysis(Batch) is a vertex-only fast path that bypasses
+      // patchNativeResult, so we apply the same normalisation here.
       patchDataflowResult(result);
       nativeDataflow.set(relPath, result);
     } else {

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -391,8 +391,19 @@ async function runDataflowVertexPass(
     if (batchResults) {
       result = batchResults[i] ?? null;
     } else {
-      const source = readFileSafe(absPaths[i]!);
-      if (!source) continue;
+      let source: string;
+      try {
+        source = readFileSafe(absPaths[i]!);
+      } catch {
+        // Unreadable file — mirror batch-path behaviour and route to WASM.
+        wasmStubs.set(relPath, { definitions: [], _langId: null, _tree: null });
+        continue;
+      }
+      if (!source) {
+        // Empty file — same treatment as batch returning null.
+        wasmStubs.set(relPath, { definitions: [], _langId: null, _tree: null });
+        continue;
+      }
       try {
         result = native.extractDataflowAnalysis(source, absPaths[i]!);
       } catch {

--- a/src/features/dataflow.ts
+++ b/src/features/dataflow.ts
@@ -741,11 +741,24 @@ function makeNodeResolver(
   stmts: ReturnType<typeof prepareNodeResolvers>,
   relPath: string,
 ): (funcName: string) => { id: number } | null {
+  // Memoise per (relPath, funcName). buildDataflowVerticesAndEdges resolves the
+  // same handful of function names many times per file — once per param, return,
+  // assignment, argFlow, summary row, and capture — and each miss costs one or
+  // two `nodes` table queries. The nodes table is never mutated during the P6
+  // vertex pass (only dataflow* tables are written), so the lookup is stable for
+  // the lifetime of the resolver; caching collapses tens of thousands of
+  // redundant queries on a full build into one per distinct name (#perf).
+  const cache = new Map<string, { id: number } | null>();
   return (funcName: string): { id: number } | null => {
+    const cached = cache.get(funcName);
+    if (cached !== undefined) return cached;
     const local = stmts.getNodeByNameAndFile.all(funcName, relPath) as { id: number }[];
-    if (local.length > 0) return local[0]!;
-    const global = stmts.getNodeByName.all(funcName) as { id: number }[];
-    return global.length > 0 ? global[0]! : null;
+    const resolved =
+      local.length > 0
+        ? local[0]!
+        : ((stmts.getNodeByName.all(funcName) as { id: number }[])[0] ?? null);
+    cache.set(funcName, resolved);
+    return resolved;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2286,6 +2286,14 @@ export interface NativeAddon {
     filePath: string,
     langId?: string | null,
   ): DataflowResult | null;
+  /**
+   * Batch counterpart to {@link extractDataflowAnalysis}: read and analyse many
+   * files in parallel (rayon) in a single NAPI call. Results are positional —
+   * `null` where the file could not be read or has no dataflow rules. Optional:
+   * older published addons predate this export, so callers must feature-detect
+   * and fall back to per-file `extractDataflowAnalysis`.
+   */
+  extractDataflowAnalysisBatch?(filePaths: string[]): (DataflowResult | null)[];
   ParseTreeCache: new () => NativeParseTreeCache;
   NativeDatabase: {
     openReadWrite(dbPath: string): NativeDatabase;


### PR DESCRIPTION
## Problem

The pre-publish benchmark gate failed on the native **full build** regressing **3012 → 4504 ms (+50%)** vs the 3.13.0 baseline (threshold +25%). The regression is native-only — WASM full build *improved* in the same run (14214 → 13107 ms) — and the corpus is smaller (629 vs 695 files), so it's a genuine per-file slowdown, not corpus growth or runner noise.

## Root cause

Profiling a freshly-built main native addon on codegraph's own source showed the cost is dominated by the **P6 dataflow vertex pass** (`runDataflowVertexPass` → `buildDataflowVerticesFromMap`), which runs *untimed* so it never surfaced in `result.phases`. Two inefficiencies, both pre-existing but amplified as the dynamic-call resolution phases (0–6) added more tracked dataflow:

1. **Redundant `nodes`-table queries** — `makeNodeResolver` ran 1–2 uncached queries *per call* and was invoked repeatedly for the same function names within each file (per param, return, assignment, argFlow, summary, capture). On a full build that's tens of thousands of redundant queries.
2. **Serial re-parse** — the Rust orchestrator writes dataflow *edges* but not *vertices*, so P6 re-derives a `DataflowResult` for every dataflow file by calling `extractDataflowAnalysis` once per file — hundreds of synchronous parses on the event loop.

## Fix

- **Memoise the node resolver** per `(relPath, funcName)`. The `nodes` table is never mutated during P6 (only `dataflow*` tables are written), so the lookup is stable for the resolver's lifetime.
- **`extract_dataflow_analysis_batch`** — a new addon export that reads + parses every requested file across the rayon thread pool in one NAPI call (each `parse_source` builds its own tree-sitter `Parser`, so it's embarrassingly parallel). `runDataflowVertexPass` feature-detects it and falls back to the per-file path on older addons.

Vertex/edge building stays entirely in TS (shared with the WASM engine) — the batch only changes how the `DataflowResult`s are *obtained*, not how vertices are built from them, so there is **no second implementation to keep in parity**.

## Verification

- **Result-preserving / parity-safe**: a same-process batch-vs-per-file A/B on codegraph's corpus produces **byte-identical** dataflow output — `dataflow_vertices` (12200), `dataflow_summary` (5839), and every dataflow edge kind (`arg_in`/`def_use`/`return_out`/…) match, as does the inter-procedural edge semantic fingerprint.
- All **136 dataflow tests pass**.
- **Perf** (idle-machine 4-way interleaved A/B, median of 6 full builds):

  | arm | median | saved |
  |---|---|---|
  | no fix | 3215 ms | — |
  | memoise only | 2751 ms | 464 ms |
  | batch only | 2879 ms | 336 ms |
  | **both** | **2487 ms** | **728 ms (−22.6%)** |

  Applying −22.6% to the CI figure (4504 ms) → ~3486 ms, under the 3765 ms (+25%) threshold. The query-elimination should amplify on CI's slower I/O. The pre-publish gate is the final verifier.