### PR TITLE
chore: gitignore __pycache__ under tests/benchmarks/resolution/fixtures/python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ generated/DEPENDENCIES.json
 artifacts/
 pkg/
 target/
+__pycache__/


### PR DESCRIPTION
## Summary
- Add `__pycache__/` to `.gitignore` so it no longer shows up as untracked noise after running the Python resolution benchmark fixtures locally.

Closes #1715

## Test plan
- [x] `git check-ignore -v tests/benchmarks/resolution/fixtures/python/__pycache__/foo.pyc` confirms the new rule matches
- [x] `git status` no longer reports the directory as untracked