### PR TITLE
fix(cli): scaffold embeddings section in config --init

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -123,6 +123,15 @@ function buildInitTemplate(): string {
       apiKeyCommand: DEFAULTS.llm.apiKeyCommand,
     },
 
+    // Embedding backend for `codegraph embed`/`search`. Leave provider null
+    // for the local bundled model, or set it to "openai" to call a remote
+    // OpenAI-compatible endpoint configured via llm.baseUrl/apiKeyCommand.
+    embeddings: {
+      model: DEFAULTS.embeddings.model,
+      llmProvider: DEFAULTS.embeddings.llmProvider,
+      provider: DEFAULTS.embeddings.provider,
+    },
+
     query: {
       defaultDepth: DEFAULTS.query.defaultDepth,
       defaultLimit: DEFAULTS.query.defaultLimit,

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -335,19 +335,36 @@ describe('Registry CLI commands', () => {
 
 describe('Config CLI commands', () => {
   let tmpHome: string;
+  let userConfigPath: string;
 
-  /** Run CLI with isolated HOME so --init doesn't touch the real global config */
+  /**
+   * Run CLI with isolated HOME *and* an explicit CODEGRAPH_USER_CONFIG so
+   * --init doesn't touch the real global config. HOME/USERPROFILE alone
+   * aren't sufficient: getDefaultUserConfigPath() prefers XDG_CONFIG_HOME
+   * (ambiently set on GitHub Actions ubuntu-latest runners) and, on Windows,
+   * APPDATA (always set) ahead of the HOME-derived fallback — so on CI the
+   * scaffolded file can land outside tmpHome unless the path is pinned
+   * explicitly, same as tests/unit/config-user.test.ts does.
+   */
   function runCfg(...args) {
     return execFileSync('node', [...NODE_TS_FLAGS, CLI, ...args], {
       cwd: tmpDir,
       encoding: 'utf-8',
       timeout: 30_000,
-      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        USERPROFILE: tmpHome,
+        CODEGRAPH_USER_CONFIG: userConfigPath,
+        XDG_CONFIG_HOME: undefined,
+        APPDATA: undefined,
+      },
     });
   }
 
   beforeAll(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-cfghome-'));
+    userConfigPath = path.join(tmpHome, '.config', 'codegraph', 'config.json');
   });
 
   afterAll(() => {
@@ -356,8 +373,7 @@ describe('Config CLI commands', () => {
 
   test('config --init scaffolds an embeddings section alongside llm', () => {
     runCfg('config', '--init');
-    const configPath = path.join(tmpHome, '.config', 'codegraph', 'config.json');
-    const scaffolded = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const scaffolded = JSON.parse(fs.readFileSync(userConfigPath, 'utf-8'));
 
     expect(scaffolded.embeddings).toEqual({ model: null, llmProvider: null, provider: null });
     expect(scaffolded.llm).toHaveProperty('baseUrl');

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -330,3 +330,37 @@ describe('Registry CLI commands', () => {
     expect(out2).toContain('"api-2"');
   });
 });
+
+// ─── Config CLI ───────────────────────────────────────────────────────
+
+describe('Config CLI commands', () => {
+  let tmpHome: string;
+
+  /** Run CLI with isolated HOME so --init doesn't touch the real global config */
+  function runCfg(...args) {
+    return execFileSync('node', [...NODE_TS_FLAGS, CLI, ...args], {
+      cwd: tmpDir,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+    });
+  }
+
+  beforeAll(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-cfghome-'));
+  });
+
+  afterAll(() => {
+    if (tmpHome) fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test('config --init scaffolds an embeddings section alongside llm', () => {
+    runCfg('config', '--init');
+    const configPath = path.join(tmpHome, '.config', 'codegraph', 'config.json');
+    const scaffolded = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+    expect(scaffolded.embeddings).toEqual({ model: null, llmProvider: null, provider: null });
+    expect(scaffolded.llm).toHaveProperty('baseUrl');
+    expect(scaffolded.llm).toHaveProperty('apiKeyCommand');
+  });
+});


### PR DESCRIPTION
## Summary
- `buildInitTemplate()` in `src/cli/commands/config.ts` never included an `embeddings` block, so `codegraph config --init` scaffolded `llm`, `query`, `build`, `ci`, and `search` but omitted `embeddings` entirely — including the `provider` field added in #1716 for the remote embedding backend.
- Adds an `embeddings` block (`model`, `llmProvider`, `provider`) mirroring `DEFAULTS.embeddings`, placed next to `llm` since the remote provider option relies on `llm.baseUrl`/`apiKeyCommand`.

Closes #1718

## Test plan
- [x] Added `Config CLI commands > config --init scaffolds an embeddings section alongside llm` in `tests/integration/cli.test.ts`, verifying the scaffolded file contains `embeddings: { model: null, llmProvider: null, provider: null }`
- [x] `npx vitest run tests/integration/cli.test.ts` — 30/30 passed
- [x] `npx vitest run tests/unit/config.test.ts tests/unit/config-user.test.ts` — 88/88 passed
- [x] `npm run lint` — clean
- [x] `codegraph diff-impact --staged -T` — change contained to `buildInitTemplate` and its 2 transitive callers