### PR TITLE
chore: sync Cargo.lock codegraph-core version to 3.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codegraph-core"
-version = "3.13.0"
+version = "3.15.0"
 dependencies = [
  "globset",
  "ignore",


### PR DESCRIPTION
## Summary
- Sync `Cargo.lock`'s pinned `codegraph-core` version to match `package.json` (3.15.0), which had drifted to a stale 3.13.0 lockfile entry.

## Titan Audit Context
- **Phase:** chore
- **Domain:** build metadata
- **Commits:** 1
- **Depends on:** none

## Changes
- `Cargo.lock`

## Test plan
- [ ] CI passes (lint + build + tests)
