### PR TITLE
fix: credit import-type usages as exports consumers

### DIFF
--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -164,11 +164,24 @@ function exportsFileImpl(
         "SELECT * FROM nodes WHERE file = ? AND kind != 'file' AND exported = 1 ORDER BY line",
       )
     : null;
+  // Consumers include real call/construct edges plus `imports-type` edges —
+  // the symbol-level edge emitted for `import type { X }` statements (source
+  // is the importing *file* node, since the import statement references the
+  // type rather than a specific function). Without this, interfaces/types
+  // that are only ever used as type annotations are misclassified as dead
+  // exports even though `codegraph deps` already reports the importing file
+  // via this same edge (#1724).
+  //
+  // `extends`/`implements` edges are deliberately NOT included here: they are
+  // resolved by symbol name only, with no file/import scoping (see
+  // buildClassHierarchyEdges), so they can link same-named declarations
+  // across unrelated files — crediting them as consumers would surface false
+  // positives instead of fixing false negatives.
   const consumersStmt = cachedStmt(
     _consumersStmtCache,
     db,
     `SELECT n.name, n.file, n.line FROM edges e JOIN nodes n ON e.source_id = n.id
-         WHERE e.target_id = ? AND e.kind = 'calls'`,
+         WHERE e.target_id = ? AND e.kind IN ('calls', 'imports-type')`,
   );
   const reexportsFromStmt = cachedStmt(
     _reexportsFromStmtCache,

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -298,6 +298,10 @@ describe('exportsData — import type consumer crediting (#1724)', () => {
     expect(config.consumerCount).toBe(1);
     expect(config.consumers.length).toBe(1);
     expect(config.consumers[0].file).toBe('consumer.ts');
+    // imports-type edges source from the importing *file* node, not a
+    // function — so name/line carry file-level values, not a call site.
+    expect(config.consumers[0].name).toBe('consumer.ts');
+    expect(config.consumers[0].line).toBe(0);
   });
 
   test('interface consumed only via `import type` is excluded from --unused', () => {

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -240,3 +240,76 @@ describe('exportsData', () => {
     expect(data.totalReexportedUnused).toBe(0);
   });
 });
+
+// ─── import type / type-only consumer crediting (#1724) ──────────────────
+//
+// Regression coverage for: interfaces/types that are only ever consumed via
+// `import type { X }` (never called/constructed) were reported as zero-
+// consumer dead exports, even though the builder already emits a
+// symbol-level `imports-type` edge (source = importing file node, target =
+// the specific imported symbol) for exactly this case. `codegraph deps`
+// already surfaced the file-level import correctly; `exportsData`'s
+// per-symbol consumer query only looked at `kind = 'calls'` and missed it.
+
+describe('exportsData — import type consumer crediting (#1724)', () => {
+  let tmpDir2: string, dbPath2: string;
+
+  beforeAll(() => {
+    tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-exports-typeonly-'));
+    fs.mkdirSync(path.join(tmpDir2, '.codegraph'));
+    dbPath2 = path.join(tmpDir2, '.codegraph', 'graph.db');
+
+    const db = new Database(dbPath2);
+    db.pragma('journal_mode = WAL');
+    initSchema(db);
+
+    // File nodes
+    insertNode(db, 'types.ts', 'file', 'types.ts', 0);
+    const fConsumer = insertNode(db, 'consumer.ts', 'file', 'consumer.ts', 0);
+
+    // Interface exported from types.ts, referenced elsewhere only via a type
+    // annotation (never called/constructed).
+    const configIface = insertNode(db, 'Config', 'interface', 'types.ts', 1);
+    // Interface exported from types.ts, genuinely never referenced anywhere.
+    const unusedIface = insertNode(db, 'Unused', 'interface', 'types.ts', 10);
+
+    const markExported = db.prepare('UPDATE nodes SET exported = 1 WHERE id = ?');
+    markExported.run(configIface);
+    markExported.run(unusedIface);
+
+    // consumer.ts does `import type { Config } from './types'`. The builder
+    // emits the symbol-level edge with the importing *file* as source (see
+    // emitTypeOnlySymbolEdges in domain/graph/builder/stages/build-edges.ts
+    // and incremental.ts) since the import statement — not a specific
+    // function — is what references the type.
+    insertEdge(db, fConsumer, configIface, 'imports-type');
+
+    db.close();
+  });
+
+  afterAll(() => {
+    if (tmpDir2) fs.rmSync(tmpDir2, { recursive: true, force: true });
+  });
+
+  test('interface consumed only via `import type` is credited with a consumer', () => {
+    const data = exportsData('types.ts', dbPath2);
+    const config = data.results.find((r) => r.name === 'Config');
+    expect(config).toBeDefined();
+    expect(config.consumerCount).toBe(1);
+    expect(config.consumers.length).toBe(1);
+    expect(config.consumers[0].file).toBe('consumer.ts');
+  });
+
+  test('interface consumed only via `import type` is excluded from --unused', () => {
+    const data = exportsData('types.ts', dbPath2, { unused: true });
+    expect(data.results.find((r) => r.name === 'Config')).toBeUndefined();
+  });
+
+  test('interface with no references anywhere is still classified unused', () => {
+    const data = exportsData('types.ts', dbPath2, { unused: true });
+    const unused = data.results.find((r) => r.name === 'Unused');
+    expect(unused).toBeDefined();
+    expect(unused.consumerCount).toBe(0);
+    expect(unused.consumers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- `domain/analysis/exports.ts`'s consumer query only matched `kind = 'calls'` edges, so interfaces/types consumed only via `import type { X }` + type-annotation usage showed `consumerCount: 0` even though `codegraph deps` correctly tracked the file-level import.
- The builder already emits symbol-level `imports-type` edges (`emitTypeOnlySymbolEdges`) — widened the consumer query to `kind IN ('calls', 'imports-type')`, matching the edge-kind set already used elsewhere (structure.ts, graph-enrichment.ts, boundaries.ts).

Closes #1724

## Test plan
- `npm test` — full suite green (3359 passed, 0 failed)
- `npm run lint` — clean
- Repro: `codegraph exports src/domain/graph/builder/cha.ts -T --json` now shows `ChaContext` with `consumerCount: 2` (was 0)
- Negative case: genuinely-unused exports still show `consumerCount: 0`

Note: deliberately did NOT extend this to `extends`/`implements` edges — investigation found those resolve by symbol name with no file scoping, producing real false positives (e.g. unrelated same-named `Repository`/`UserRepository` fixtures across languages). Filed #1812 for that, and #1813 for a separate gap (`import { type X }` inline modifier not tracked as type-only in either engine's extractor).

Stacked on #1811 (base branch `fix/issue-1723-roles-dead-params-interfaces`) — only the exports.ts/test diff is this issue's change.