### PR TITLE
refactor: dedupe busy/locked error detection into isBusyOrLockedError

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -438,6 +438,16 @@ function openRepoNative(customDbPath?: string): { repo: Repository; close(): voi
   }
 }
 
+/**
+ * True when an error message indicates the SQLite database is busy or locked
+ * (SQLITE_BUSY/SQLITE_LOCKED). Shared by openRepo()'s and
+ * openReadonlyWithNative()'s native-path catch blocks so the two call sites
+ * can't drift.
+ */
+function isBusyOrLockedError(msg: string): boolean {
+  return /\b(busy|locked|SQLITE_BUSY|SQLITE_LOCKED)\b/i.test(msg);
+}
+
 /** Validate and wrap an injected `opts.repo` Repository instance (no DB opened). */
 function wrapInjectedRepo(repo: Repository): { repo: Repository; close(): void } {
   if (!(repo instanceof Repository)) {
@@ -468,7 +478,7 @@ function tryOpenRepoNative(
     // Re-throw locking/busy errors — falling back to better-sqlite3 would
     // hit the same contention (and potentially hang without busy_timeout).
     const msg = toErrorMessage(e);
-    if (/\b(busy|locked|SQLITE_BUSY|SQLITE_LOCKED)\b/i.test(msg)) {
+    if (isBusyOrLockedError(msg)) {
       throw new DbError(`Database is busy (another process may be writing): ${msg}`, {});
     }
     debug(`openRepo: native path failed, falling back to better-sqlite3: ${msg}`);
@@ -553,7 +563,7 @@ export function openReadonlyWithNative(
       nativeDb = native.NativeDatabase.openReadonly(dbPath);
     } catch (e) {
       const msg = toErrorMessage(e);
-      if (/\b(busy|locked|SQLITE_BUSY|SQLITE_LOCKED)\b/i.test(msg)) {
+      if (isBusyOrLockedError(msg)) {
         debug(`openReadonlyWithNative: native path busy, skipping native DB: ${msg}`);
       } else {
         debug(`openReadonlyWithNative: native path failed: ${msg}`);


### PR DESCRIPTION
## Summary
- Of the two cleanups in #1749, the `DEFAULTS.db.busyTimeoutMs` registration was already done by an earlier commit in this batch (PR #1788) — confirmed no hardcoded `'busy_timeout = 5000'` literal remains.
- The remaining duplication — `/\b(busy|locked|SQLITE_BUSY|SQLITE_LOCKED)\b/i` inline in both `tryOpenRepoNative` and `openReadonlyWithNative`'s catch blocks — extracted into a shared `isBusyOrLockedError(msg)` helper. Regex behavior unchanged.

Closes #1749

## Test plan
- `npm test` — full suite green (3490 passed, 0 failed)
- `npm run lint` — clean
- `codegraph diff-impact --staged -T` — 3 functions changed, 27 callers affected, consistent with a non-behavioral helper extraction

For #1763's benefit: confirmed `crates/codegraph-core/src/db/connection.rs` has the identical hardcoded `busy_timeout = 5000` literal duplicated at two call sites (`open_read_write`, `open_readonly`). No Rust equivalent of the busy/locked regex exists — rusqlite surfaces `SQLITE_BUSY`/`SQLITE_LOCKED` as typed error variants, not string matching.

Stacked on #1859 (base branch `fix/issue-1748-connection-halstead-effort`) — only the connection.ts diff is this issue's change.