### PR TITLE
fix: log statSync failures in findDbPath instead of silently swallowing them

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -278,8 +278,11 @@ function resolveCustomDbPath(customPath: string): string {
       }
       return path.join(resolved, '.codegraph', 'graph.db');
     }
-  } catch {
+  } catch (e) {
     // Path doesn't exist yet — return as-is (e.g. a future custom DB path).
+    debug(
+      `findDbPath: statSync failed for ${resolved}, treating as non-existent: ${toErrorMessage(e)}`,
+    );
   }
   return resolved;
 }


### PR DESCRIPTION
## Summary
- `resolveCustomDbPath`'s catch block silently swallowed all `fs.statSync` errors, unlike every other catch block in this file (18 of them), leaving no diagnostic trail for a genuine unexpected error (EACCES, symlink loop) vs. the expected "not found yet" case.
- Added a `debug(...)` call matching the file's existing convention. Behavior unchanged — still falls through to treat the path as not-yet-existing.

Closes #1750

## Test plan
- `npm test` — full suite green (3490 passed, 0 failed)
- `npm run lint` — clean

Stacked on #1860 (base branch `fix/issue-1749-connection-busytimeout-regex-dedupe`) — only the connection.ts diff is this issue's change.