### PR TITLE
refactor: dedupe computeSavings via pct helper and persist partial token-benchmark results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ crates/codegraph-core/*.node
 .claude/worktrees/
 generated/DEPENDENCIES.md
 generated/DEPENDENCIES.json
+token-benchmark.partial.json
 artifacts/
 pkg/
 target/

--- a/scripts/token-benchmark.ts
+++ b/scripts/token-benchmark.ts
@@ -520,10 +520,14 @@ function writePartialResults(results, totalIssues) {
 		aggregate: computeAggregate(results),
 		perfBenchmarks: null,
 	};
-	fs.writeFileSync(PARTIAL_RESULTS_PATH, JSON.stringify(partialOutput, null, 2));
-	console.error(
-		`  Partial results written to ${PARTIAL_RESULTS_PATH} (${results.length}/${totalIssues} issues)`,
-	);
+	try {
+		fs.writeFileSync(PARTIAL_RESULTS_PATH, JSON.stringify(partialOutput, null, 2));
+		console.error(
+			`  Partial results written to ${PARTIAL_RESULTS_PATH} (${results.length}/${totalIssues} issues)`,
+		);
+	} catch (err) {
+		console.error(`  Warning: could not write partial results — ${err.message}`);
+	}
 }
 
 async function main() {

--- a/scripts/token-benchmark.ts
+++ b/scripts/token-benchmark.ts
@@ -81,6 +81,11 @@ function round2(n) {
 	return Math.round(n * 100) / 100;
 }
 
+/** Percentage reduction from `a` to `b` (e.g. token/cost savings). Returns 0 when `a <= 0`. */
+function pct(a, b) {
+	return a > 0 ? Math.round(((a - b) / a) * 100) : 0;
+}
+
 function git(args, cwd) {
 	return execFileSync('git', args, { cwd, stdio: 'pipe', encoding: 'utf8' }).trim();
 }
@@ -423,19 +428,9 @@ function medianForRuns(runs) {
 /** Token + cost savings (% reduction) between two median objects. */
 function computeSavings(baselineMedian, codegraphMedian) {
 	if (!baselineMedian || !codegraphMedian || baselineMedian.inputTokens <= 0) return null;
-	const tokenSavings =
-		((baselineMedian.inputTokens - codegraphMedian.inputTokens) /
-			baselineMedian.inputTokens) *
-		100;
-	const costSavings =
-		baselineMedian.totalCostUsd > 0
-			? ((baselineMedian.totalCostUsd - codegraphMedian.totalCostUsd) /
-					baselineMedian.totalCostUsd) *
-				100
-			: 0;
 	return {
-		inputTokensPct: Math.round(tokenSavings),
-		costPct: Math.round(costSavings),
+		inputTokensPct: pct(baselineMedian.inputTokens, codegraphMedian.inputTokens),
+		costPct: pct(baselineMedian.totalCostUsd, codegraphMedian.totalCostUsd),
 	};
 }
 
@@ -484,7 +479,6 @@ function computeAggregate(results) {
 	const totalCodegraphTokens = sum((r) => r.codegraph.median.inputTokens);
 	const totalBaselineCost = sum((r) => r.baseline.median.totalCostUsd);
 	const totalCodegraphCost = sum((r) => r.codegraph.median.totalCostUsd);
-	const pct = (a, b) => (a > 0 ? Math.round(((a - b) / a) * 100) : 0);
 
 	return {
 		savings: {
@@ -501,6 +495,36 @@ function computeAggregate(results) {
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────
+
+/** Where in-progress results are (re)written after each issue completes. */
+const PARTIAL_RESULTS_PATH = path.join(root, 'token-benchmark.partial.json');
+
+/**
+ * Overwrite the partial-results snapshot with the results collected so far.
+ * Called after each issue completes so a later crash (another issue
+ * throwing, or `runPerfBenchmarks` failing) doesn't discard the
+ * already-computed results for the issues that already finished (#1757).
+ */
+function writePartialResults(results, totalIssues) {
+	const partialOutput = {
+		version: benchVersion,
+		date: new Date().toISOString().slice(0, 10),
+		model: MODEL,
+		runsPerIssue: RUNS,
+		maxTurns: MAX_TURNS,
+		maxBudgetUsd: MAX_BUDGET,
+		partial: true,
+		completedIssues: results.length,
+		totalIssues,
+		issues: results,
+		aggregate: computeAggregate(results),
+		perfBenchmarks: null,
+	};
+	fs.writeFileSync(PARTIAL_RESULTS_PATH, JSON.stringify(partialOutput, null, 2));
+	console.error(
+		`  Partial results written to ${PARTIAL_RESULTS_PATH} (${results.length}/${totalIssues} issues)`,
+	);
+}
 
 async function main() {
 	// Resolve Next.js directory
@@ -522,6 +546,7 @@ async function main() {
 	const results = [];
 	for (const issue of selectedIssues) {
 		results.push(await runIssueExperiment(issue, nextjsDir));
+		writePartialResults(results, selectedIssues.length);
 	}
 
 	const aggregate = computeAggregate(results);
@@ -549,6 +574,11 @@ async function main() {
 	};
 
 	console.log(JSON.stringify(output, null, 2));
+
+	// Full run (including perf benchmarks, if requested) succeeded — the
+	// complete results are now in the stdout output above, so the partial
+	// snapshot is no longer needed.
+	fs.rmSync(PARTIAL_RESULTS_PATH, { force: true });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- `computeSavings` reimplemented the percentage-reduction formula inline instead of using the `pct` helper already defined for `computeAggregate`. Promoted `pct` to module level and adopted it in both places — confirmed bit-for-bit identical behavior via a 10-case equivalence harness (normal, zero-cost, negative savings, zero/negative baseline, rounding edge cases).
- `main()`'s per-issue loop only serialized `results` after the full loop completed, so a crash partway through discarded all already-computed results. Added `writePartialResults`, called after each issue, overwriting a `token-benchmark.partial.json` snapshot; removed only after the full run (including optional perf benchmarks) succeeds, so a late failure still leaves the per-issue safety net intact.

Closes #1757

## Test plan
- `npm test` — full suite green (3519 passed, 0 failed) — this script has no existing test coverage (confirmed via grep)
- `npx tsc --noEmit` — clean
- `scripts/` is outside Biome's lint scope by design (`biome.json`'s `files.includes` is `src/**`/`tests/**`) — confirmed no lint tool applies here
- Built throwaway verification harnesses (not committed): formula-equivalence (10 cases, byte-for-byte match old vs new) and persistence-mechanism (3 scenarios — full success, crash mid-run, crash on first issue — all 13 assertions passed)
- Ran the real script directly to confirm no syntax/reference errors; skipped the actual multi-issue benchmark run since it requires network + an API key + real spend

Stacked on #1874 (base branch `fix/issue-1756-dedupe-impact-level-rendering`) — only the token-benchmark.ts/.gitignore diff is this issue's change.