### PR TITLE
fix: update titan-grind's dead-symbol script for current roles --json object shape

### DIFF
--- a/.claude/skills/titan-grind/SKILL.md
+++ b/.claude/skills/titan-grind/SKILL.md
@@ -109,7 +109,7 @@ Forge shapes the metal. Grind smooths the rough edges. Your goal: find helpers t
 
 12. **Capture dead-symbol baseline** (only if `grind.deadSymbolBaseline` is null):
     ```bash
-    codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count,byRole:data.summary}));})"
+    codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{try{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count??0,byRole:data.summary??{}}));}catch(e){console.error('Failed to parse roles --json output: '+e.message);process.exit(1);}})"
     ```
     `codegraph roles --json` returns `{ count, summary, symbols }` (not a bare array) — `summary` is already the per-role breakdown (e.g. `dead-leaf`, `dead-entry`, `dead-ffi`, `dead-unresolved`), so no manual reduce is needed.
     Store the total in `grind.deadSymbolBaseline`. Write `titan-state.json` immediately.
@@ -580,7 +580,7 @@ After all targets in the phase are processed:
 
 ```bash
 codegraph build
-codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count,byRole:data.summary}));})"
+codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{try{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count??0,byRole:data.summary??{}}));}catch(e){console.error('Failed to parse roles --json output: '+e.message);process.exit(1);}})"
 ```
 
 Store in `grind.deadSymbolCurrent`. Write `titan-state.json`.

--- a/.claude/skills/titan-grind/SKILL.md
+++ b/.claude/skills/titan-grind/SKILL.md
@@ -109,8 +109,9 @@ Forge shapes the metal. Grind smooths the rough edges. Your goal: find helpers t
 
 12. **Capture dead-symbol baseline** (only if `grind.deadSymbolBaseline` is null):
     ```bash
-    codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const items=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:items.length,byRole:items.reduce((a,i)=>{a[i.role]=(a[i.role]||0)+1;return a},{})}));})"
+    codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count,byRole:data.summary}));})"
     ```
+    `codegraph roles --json` returns `{ count, summary, symbols }` (not a bare array) — `summary` is already the per-role breakdown (e.g. `dead-leaf`, `dead-entry`, `dead-ffi`, `dead-unresolved`), so no manual reduce is needed.
     Store the total in `grind.deadSymbolBaseline`. Write `titan-state.json` immediately.
 
 13. **Drift detection.** Compare `titan-state.json → mainSHA` against current origin/main:
@@ -304,8 +305,8 @@ const tokens = helperName
   .slice(0, 3);
 const d=[];process.stdin.on('data',c=>d.push(c));
 process.stdin.on('end',()=>{ try {
-  const items=JSON.parse(Buffer.concat(d));
-  const candidates = items.filter(i =>
+  const data=JSON.parse(Buffer.concat(d));
+  const candidates = (data.symbols || []).filter(i =>
     i.name !== helperName &&
     tokens.some(t => i.name.toLowerCase().includes(t))
   );
@@ -579,7 +580,7 @@ After all targets in the phase are processed:
 
 ```bash
 codegraph build
-codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const items=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:items.length,byRole:items.reduce((a,i)=>{a[i.role]=(a[i.role]||0)+1;return a},{})}));})"
+codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count,byRole:data.summary}));})"
 ```
 
 Store in `grind.deadSymbolCurrent`. Write `titan-state.json`.


### PR DESCRIPTION
## Summary
- Confirmed `codegraph roles --role dead --json`'s `{ count, summary, symbols }` shape is original, intentional design present since the very first commit that introduced the `roles` command — not a regression from #1723 (which only changed which nodes get classified dead, not the output shape). Traced via `git log --follow -p` and pickaxe search.
- Fixed 3 spots in `.claude/skills/titan-grind/SKILL.md` that assumed a bare array: Step 0.12 (baseline) and Step 4 (delta gate), both updated to read `.count`/`.summary`; Step 2c (duplicate scan) updated to guard `.symbols`. Step 2c was worse than the reported crash — its `TypeError` was silently swallowed by a try/catch falling back to `console.log('[]')`, so that "mandatory" scan has always been a silent no-op.
- No `docs/examples/claude-code-skills/titan-grind/` mirror exists to sync (titan-grind is the only titan-* skill without one — filed separately).

Closes #1762

## Test plan
- `npm test` — full suite green (3521 passed, 0 failed) — no `src/` changes, this is a skill-doc-only fix
- `npm run lint` — clean
- Extracted and ran each corrected one-liner standalone against real CLI output: old scripts reproduced the exact reported crash + the silent Step 2c failure; new scripts produce correct output

Filed #1879 for an out-of-scope finding: titan-grind is the only titan-* skill with no docs mirror and no README table entry.

Stacked on #1878 (base branch `fix/issue-1761-parsediff-hunk-scoped-headers`) — only the SKILL.md diff is this issue's change.