### PR TITLE
fix: thread configured busyTimeoutMs through remaining read-only query call sites

### DIFF
--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { openReadonlyOrFail } from '../../db/index.js';
+import { openReadonlyOrFail, resolveBusyTimeoutMs } from '../../db/index.js';
 import { getEmbeddingMeta } from '../../db/repository/embeddings.js';
 import {
   buildEmbeddings,
@@ -13,7 +13,7 @@ import type { CommandDefinition } from '../types.js';
 
 function resolveStickyModel(dbPath: string | undefined): string | null {
   try {
-    const db = openReadonlyOrFail(dbPath);
+    const db = openReadonlyOrFail(dbPath, resolveBusyTimeoutMs(dbPath));
     try {
       const storedName = getEmbeddingMeta(db, 'model');
       if (!storedName) return null;

--- a/src/cli/shared/open-graph.ts
+++ b/src/cli/shared/open-graph.ts
@@ -1,4 +1,4 @@
-import { openReadonlyOrFail } from '../../db/index.js';
+import { openReadonlyOrFail, resolveBusyTimeoutMs } from '../../db/index.js';
 import type { BetterSqlite3Database } from '../../types.js';
 
 /**
@@ -8,6 +8,6 @@ export function openGraph(opts: { db?: string } = {}): {
   db: BetterSqlite3Database;
   close: () => void;
 } {
-  const db = openReadonlyOrFail(opts.db);
+  const db = openReadonlyOrFail(opts.db, resolveBusyTimeoutMs(opts.db));
   return { db, close: () => db.close() };
 }

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -387,6 +387,18 @@ interface ResolvedDbSettings {
 }
 
 /**
+ * Derive the project rootDir from a possibly-custom DB path, for loadConfig().
+ * Using findDbPath (not path.resolve(customDbPath)) ensures directory inputs like
+ * --db /path/to/repo are normalised to .codegraph/graph.db before we strip two levels.
+ * Convention: resolvedDbPath = <rootDir>/.codegraph/graph.db
+ * Shared by resolveDbSettings() and resolveBusyTimeoutMs() so rootDir derivation can't drift.
+ */
+function deriveRootDirFromDbPath(customDbPath: string | undefined): string | undefined {
+  const resolvedDbPath = customDbPath ? findDbPath(customDbPath) : undefined;
+  return resolvedDbPath ? path.dirname(path.dirname(resolvedDbPath)) : undefined;
+}
+
+/**
  * Resolve the effective engine for DB access (explicit opts.engine > config.build.engine >
  * 'auto') alongside config.db.busyTimeoutMs, in a single loadConfig() call.
  * Derives rootDir from the resolved DB path so loadConfig reads the right project config.
@@ -400,18 +412,29 @@ function resolveDbSettings(
   customDbPath: string | undefined,
   engineOpt: 'native' | 'wasm' | 'auto' | undefined,
 ): ResolvedDbSettings {
-  // Using findDbPath (not path.resolve(customDbPath)) ensures directory inputs like
-  // --db /path/to/repo are normalised to .codegraph/graph.db before we strip two levels.
-  // Convention: resolvedDbPath = <rootDir>/.codegraph/graph.db
-  const resolvedDbPath = customDbPath ? findDbPath(customDbPath) : undefined;
-  const rootDir = resolvedDbPath ? path.dirname(path.dirname(resolvedDbPath)) : undefined;
-  const config = loadConfig(rootDir);
+  const config = loadConfig(deriveRootDirFromDbPath(customDbPath));
   // config.build.engine is already populated from CODEGRAPH_ENGINE env by applyEnvOverrides,
   // so this covers both the env-var path and the .codegraphrc.json config-file path.
   return {
     engine: engineOpt ?? config.build.engine ?? 'auto',
     busyTimeoutMs: config.db.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
   };
+}
+
+/**
+ * Resolve config.db.busyTimeoutMs alone, for the ad-hoc read-only query call
+ * sites (features/*, domain/analysis/*, domain/search/*) that call
+ * openReadonlyOrFail() directly and don't need engine selection. Shares
+ * rootDir derivation with resolveDbSettings() so the two can't drift.
+ *
+ * MUST be called before opening any DB handle, for the same reason as
+ * resolveDbSettings(): loadConfig can throw (e.g. ConfigError via
+ * resolveSecrets on a malformed llm.apiKeyCommand config), and an
+ * already-open handle at that point would never be closed.
+ */
+export function resolveBusyTimeoutMs(customDbPath?: string): number {
+  const config = loadConfig(deriveRootDirFromDbPath(customDbPath));
+  return config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs;
 }
 
 /** Open a NativeRepository via rusqlite, throwing DbError if the DB file is missing. */

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -6,7 +6,7 @@ import { DEFAULTS, loadConfig } from '../infrastructure/config.js';
 import { debug, warn } from '../infrastructure/logger.js';
 import { getNative, isNativeAvailable } from '../infrastructure/native.js';
 import { DbError, toErrorMessage } from '../shared/errors.js';
-import type { BetterSqlite3Database, NativeDatabase } from '../types.js';
+import type { BetterSqlite3Database, CodegraphConfig, NativeDatabase } from '../types.js';
 import { getDatabase } from './better-sqlite3.js';
 import { Repository } from './repository/base.js';
 import { NativeRepository } from './repository/native-repository.js';
@@ -422,19 +422,28 @@ function resolveDbSettings(
 }
 
 /**
- * Resolve config.db.busyTimeoutMs alone, for the ad-hoc read-only query call
- * sites (features/*, domain/analysis/*, domain/search/*) that call
- * openReadonlyOrFail() directly and don't need engine selection. Shares
- * rootDir derivation with resolveDbSettings() so the two can't drift.
+ * Resolve the full config for a given DB path, deriving rootDir the same way
+ * resolveDbSettings()/resolveBusyTimeoutMs() do. Exported so callers that need
+ * both the busy-timeout and other config values (e.g. withReadonlyDb()) can
+ * share a single loadConfig() call instead of resolving it twice.
  *
  * MUST be called before opening any DB handle, for the same reason as
  * resolveDbSettings(): loadConfig can throw (e.g. ConfigError via
  * resolveSecrets on a malformed llm.apiKeyCommand config), and an
  * already-open handle at that point would never be closed.
  */
+export function resolveDbConfig(customDbPath?: string): CodegraphConfig {
+  return loadConfig(deriveRootDirFromDbPath(customDbPath));
+}
+
+/**
+ * Resolve config.db.busyTimeoutMs alone, for the ad-hoc read-only query call
+ * sites (features/*, domain/analysis/*, domain/search/*) that call
+ * openReadonlyOrFail() directly and don't need engine selection. Shares
+ * rootDir derivation with resolveDbSettings() so the two can't drift.
+ */
 export function resolveBusyTimeoutMs(customDbPath?: string): number {
-  const config = loadConfig(deriveRootDirFromDbPath(customDbPath));
-  return config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs;
+  return resolveDbConfig(customDbPath).db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs;
 }
 
 /** Open a NativeRepository via rusqlite, throwing DbError if the DB file is missing. */

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -15,6 +15,7 @@ export {
   openReadonlyWithNative,
   openRepo,
   releaseAdvisoryLock,
+  resolveBusyTimeoutMs,
 } from './connection.js';
 export { getBuildMeta, initSchema, MIGRATIONS, setBuildMeta } from './migrations.js';
 export {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -16,6 +16,7 @@ export {
   openRepo,
   releaseAdvisoryLock,
   resolveBusyTimeoutMs,
+  resolveDbConfig,
 } from './connection.js';
 export { getBuildMeta, initSchema, MIGRATIONS, setBuildMeta } from './migrations.js';
 export {

--- a/src/domain/analysis/context.ts
+++ b/src/domain/analysis/context.ts
@@ -438,12 +438,15 @@ export function contextData(
     config?: any;
   } = {},
 ) {
-  return withReadonlyDb(customDbPath, (db) => {
+  return withReadonlyDb(customDbPath, (db, config) => {
     const depth = opts.depth || 0;
     const noSource = opts.noSource || false;
     const includeTests = opts.includeTests || false;
 
-    const { noTests, displayOpts } = resolveAnalysisOpts(opts);
+    const { noTests, displayOpts } = resolveAnalysisOpts({
+      ...opts,
+      config: opts.config ?? config,
+    });
 
     const dbPath = findDbPath(customDbPath);
     const repoRoot = path.resolve(path.dirname(dbPath), '..');
@@ -510,11 +513,14 @@ export function explainData(
     config?: any;
   } = {},
 ) {
-  return withReadonlyDb(customDbPath, (db) => {
+  return withReadonlyDb(customDbPath, (db, config) => {
     const depth = opts.depth || 0;
     const kind = isFileLikeTarget(target) ? 'file' : 'function';
 
-    const { noTests, displayOpts } = resolveAnalysisOpts(opts);
+    const { noTests, displayOpts } = resolveAnalysisOpts({
+      ...opts,
+      config: opts.config ?? config,
+    });
 
     const dbPath = findDbPath(customDbPath);
     const repoRoot = path.resolve(path.dirname(dbPath), '..');

--- a/src/domain/analysis/diff-impact.ts
+++ b/src/domain/analysis/diff-impact.ts
@@ -6,7 +6,7 @@ import { cachedStmt } from '../../db/repository/cached-stmt.js';
 import { evaluateBoundaries } from '../../features/boundaries.js';
 import { coChangeForFiles } from '../../features/cochange.js';
 import { ownersForFiles } from '../../features/owners.js';
-import { loadConfig } from '../../infrastructure/config.js';
+import { DEFAULTS, loadConfig } from '../../infrastructure/config.js';
 import { debug } from '../../infrastructure/logger.js';
 import { isTestFile } from '../../infrastructure/test-filter.js';
 import { paginateResult } from '../../shared/paginate.js';
@@ -269,10 +269,17 @@ export function diffImpactData(
     config?: any;
   } = {},
 ) {
-  const db = openReadonlyOrFail(customDbPath);
+  // Resolve config before opening the DB so config.db.busyTimeoutMs can be
+  // threaded through to openReadonlyOrFail() (mirrors resolveDbSettings()'s
+  // ordering in db/connection.ts — loadConfig can throw, and an already-open
+  // handle at that point would never be closed).
+  const config = opts.config || loadConfig();
+  const db = openReadonlyOrFail(
+    customDbPath,
+    config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
+  );
   try {
     const noTests = opts.noTests || false;
-    const config = opts.config || loadConfig();
     const maxDepth = opts.depth || config.analysis?.impactDepth || 3;
 
     const dbPath = findDbPath(customDbPath);

--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -32,8 +32,11 @@ export function exportsData(
     config?: any;
   } = {},
 ) {
-  return withReadonlyDb(customDbPath, (db) => {
-    const { noTests, displayOpts } = resolveAnalysisOpts(opts);
+  return withReadonlyDb(customDbPath, (db, config) => {
+    const { noTests, displayOpts } = resolveAnalysisOpts({
+      ...opts,
+      config: opts.config ?? config,
+    });
 
     const dbFilePath = findDbPath(customDbPath);
     const repoRoot = path.resolve(path.dirname(dbFilePath), '..');

--- a/src/domain/analysis/module-map.ts
+++ b/src/domain/analysis/module-map.ts
@@ -1,5 +1,10 @@
 import path from 'node:path';
-import { openReadonlyOrFail, openReadonlyWithNative, testFilterSQL } from '../../db/index.js';
+import {
+  openReadonlyOrFail,
+  openReadonlyWithNative,
+  resolveBusyTimeoutMs,
+  testFilterSQL,
+} from '../../db/index.js';
 import { loadConfig } from '../../infrastructure/config.js';
 import { debug } from '../../infrastructure/logger.js';
 import { isTestFile } from '../../infrastructure/test-filter.js';
@@ -307,7 +312,7 @@ function getComplexitySummary(db: BetterSqlite3Database, testFilter: string) {
 // ---------------------------------------------------------------------------
 
 export function moduleMapData(customDbPath: string, limit = 20, opts: { noTests?: boolean } = {}) {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
 

--- a/src/domain/analysis/query-helpers.ts
+++ b/src/domain/analysis/query-helpers.ts
@@ -1,24 +1,25 @@
-import {
-  openReadonlyOrFail,
-  openRepo,
-  type Repository,
-  resolveBusyTimeoutMs,
-} from '../../db/index.js';
-import { loadConfig } from '../../infrastructure/config.js';
+import { openReadonlyOrFail, openRepo, type Repository, resolveDbConfig } from '../../db/index.js';
+import { DEFAULTS, loadConfig } from '../../infrastructure/config.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../types.js';
 
 /**
  * Open a readonly DB connection, run `fn`, and close the DB on completion.
  * Eliminates the duplicated `openReadonlyOrFail` + `try/finally/db.close()` pattern
  * that appears in every analysis query function.
+ *
+ * Resolves the config once and passes it to `fn` so callers that also need
+ * `resolveAnalysisOpts` can reuse it as `opts.config` instead of triggering a
+ * second `loadConfig()` for the same rootDir (#1763 review).
  */
 export function withReadonlyDb<T>(
   customDbPath: string | undefined,
-  fn: (db: BetterSqlite3Database) => T,
+  fn: (db: BetterSqlite3Database, config: CodegraphConfig) => T,
 ): T {
-  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
+  const config = resolveDbConfig(customDbPath);
+  const busyTimeoutMs = config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs;
+  const db = openReadonlyOrFail(customDbPath, busyTimeoutMs);
   try {
-    return fn(db);
+    return fn(db, config);
   } finally {
     db.close();
   }

--- a/src/domain/analysis/query-helpers.ts
+++ b/src/domain/analysis/query-helpers.ts
@@ -1,4 +1,9 @@
-import { openReadonlyOrFail, openRepo, type Repository } from '../../db/index.js';
+import {
+  openReadonlyOrFail,
+  openRepo,
+  type Repository,
+  resolveBusyTimeoutMs,
+} from '../../db/index.js';
 import { loadConfig } from '../../infrastructure/config.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../types.js';
 
@@ -11,7 +16,7 @@ export function withReadonlyDb<T>(
   customDbPath: string | undefined,
   fn: (db: BetterSqlite3Database) => T,
 ): T {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     return fn(db);
   } finally {

--- a/src/domain/analysis/roles.ts
+++ b/src/domain/analysis/roles.ts
@@ -1,4 +1,4 @@
-import { openReadonlyOrFail } from '../../db/index.js';
+import { openReadonlyOrFail, resolveBusyTimeoutMs } from '../../db/index.js';
 import { buildFileConditionSQL } from '../../db/query-builder.js';
 import { isTestFile } from '../../infrastructure/test-filter.js';
 import { DEAD_ROLE_PREFIX } from '../../shared/kinds.js';
@@ -13,7 +13,7 @@ export interface DynamicCallCount {
 
 /** Return a count of flagged dynamic call sink edges, grouped by kind. */
 export function dynamicCallsData(customDbPath: string): DynamicCallCount[] {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     return db
       .prepare(
@@ -39,7 +39,7 @@ export function rolesData(
     offset?: number;
   } = {},
 ) {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
     const filterRole = opts.role || null;

--- a/src/domain/analysis/symbol-lookup.ts
+++ b/src/domain/analysis/symbol-lookup.ts
@@ -13,6 +13,7 @@ import {
   listFunctionNodes,
   openReadonlyOrFail,
   Repository,
+  resolveBusyTimeoutMs,
 } from '../../db/index.js';
 import { debug } from '../../infrastructure/logger.js';
 import { isTestFile } from '../../infrastructure/test-filter.js';
@@ -95,7 +96,7 @@ export function queryNameData(
   customDbPath: string,
   opts: { noTests?: boolean; limit?: number; offset?: number } = {},
 ) {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
     let nodes = db.prepare(`SELECT * FROM nodes WHERE name LIKE ?`).all(`%${name}%`) as NodeRow[];
@@ -195,7 +196,7 @@ export function whereData(
   customDbPath: string,
   opts: { noTests?: boolean; file?: boolean; limit?: number; offset?: number } = {},
 ) {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
     const fileMode = opts.file || false;
@@ -219,7 +220,7 @@ export function listFunctionsData(
     offset?: number;
   } = {},
 ) {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
 
@@ -241,7 +242,7 @@ export function childrenData(
   customDbPath: string,
   opts: { noTests?: boolean; file?: string; kind?: string; limit?: number; offset?: number } = {},
 ) {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
 

--- a/src/domain/search/search/hybrid.ts
+++ b/src/domain/search/search/hybrid.ts
@@ -1,5 +1,5 @@
 import { openReadonlyOrFail } from '../../../db/index.js';
-import { loadConfig } from '../../../infrastructure/config.js';
+import { DEFAULTS, loadConfig } from '../../../infrastructure/config.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../../../types.js';
 import { hasFtsIndex } from '../stores/fts5.js';
 import { ftsSearchData } from './keyword.js';
@@ -184,7 +184,10 @@ export async function hybridSearchData(
   const k = opts.rrfK ?? searchCfg.rrfK ?? 60;
   const topK = (opts.limit ?? searchCfg.topK ?? 15) * 5;
 
-  const checkDb = openReadonlyOrFail(customDbPath) as BetterSqlite3Database;
+  const checkDb = openReadonlyOrFail(
+    customDbPath,
+    config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
+  ) as BetterSqlite3Database;
   const ftsAvailable = hasFtsIndex(checkDb);
   checkDb.close();
   if (!ftsAvailable) return null;

--- a/src/domain/search/search/keyword.ts
+++ b/src/domain/search/search/keyword.ts
@@ -1,4 +1,4 @@
-import { openReadonlyOrFail } from '../../../db/index.js';
+import { openReadonlyOrFail, resolveBusyTimeoutMs } from '../../../db/index.js';
 import { buildFileConditionSQL } from '../../../db/query-builder.js';
 import type { BetterSqlite3Database } from '../../../types.js';
 import { normalizeSymbol } from '../../queries.js';
@@ -41,7 +41,10 @@ export function ftsSearchData(
 ): FtsSearchResult | null {
   const limit = opts.limit || 15;
 
-  const db = openReadonlyOrFail(customDbPath) as BetterSqlite3Database;
+  const db = openReadonlyOrFail(
+    customDbPath,
+    resolveBusyTimeoutMs(customDbPath),
+  ) as BetterSqlite3Database;
 
   try {
     if (!hasFtsIndex(db)) {

--- a/src/domain/search/search/prepare.ts
+++ b/src/domain/search/search/prepare.ts
@@ -1,4 +1,4 @@
-import { openReadonlyOrFail } from '../../../db/index.js';
+import { openReadonlyOrFail, resolveBusyTimeoutMs } from '../../../db/index.js';
 import { buildFileConditionSQL } from '../../../db/query-builder.js';
 import { getEmbeddingCount, getEmbeddingMeta } from '../../../db/repository/embeddings.js';
 import { info } from '../../../infrastructure/logger.js';
@@ -43,7 +43,10 @@ export function prepareSearch(
   customDbPath: string | undefined,
   opts: PrepareSearchOpts = {},
 ): PreparedSearch | null {
-  const db = openReadonlyOrFail(customDbPath) as BetterSqlite3Database;
+  const db = openReadonlyOrFail(
+    customDbPath,
+    resolveBusyTimeoutMs(customDbPath),
+  ) as BetterSqlite3Database;
 
   try {
     const count = getEmbeddingCount(db);

--- a/src/features/ast.ts
+++ b/src/features/ast.ts
@@ -8,7 +8,7 @@ import {
 import { buildExtensionSet } from '../ast-analysis/shared.js';
 import { walkWithVisitors } from '../ast-analysis/visitor.js';
 import { createAstStoreVisitor } from '../ast-analysis/visitors/ast-store-visitor.js';
-import { bulkNodeIdsByFile, openReadonlyOrFail } from '../db/index.js';
+import { bulkNodeIdsByFile, openReadonlyOrFail, resolveBusyTimeoutMs } from '../db/index.js';
 import { buildFileConditionSQL } from '../db/query-builder.js';
 import { debug } from '../infrastructure/logger.js';
 import { outputResult } from '../infrastructure/result-formatter.js';
@@ -304,7 +304,7 @@ export function astQueryData(
     limit: number;
   };
 } {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   const { kind, file, noTests, limit, offset } = opts;
 
   let where = 'WHERE 1=1';

--- a/src/features/audit.ts
+++ b/src/features/audit.ts
@@ -3,7 +3,7 @@ import { openReadonlyOrFail } from '../db/index.js';
 import { normalizeFileFilter } from '../db/query-builder.js';
 import { bfsTransitiveCallers } from '../domain/analysis/impact.js';
 import { explainData } from '../domain/queries.js';
-import { loadConfig } from '../infrastructure/config.js';
+import { DEFAULTS, loadConfig } from '../infrastructure/config.js';
 import { debug } from '../infrastructure/logger.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
 import { toErrorMessage } from '../shared/errors.js';
@@ -170,7 +170,10 @@ export function auditData(
   }
 
   // 2. Open DB for enrichment
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(
+    customDbPath,
+    config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
+  );
   const thresholds = resolveThresholds(customDbPath, opts.config);
 
   let functions: AuditFunctionEntry[];

--- a/src/features/cfg.ts
+++ b/src/features/cfg.ts
@@ -15,6 +15,7 @@ import {
   getFunctionNodeId,
   hasCfgTables,
   openReadonlyOrFail,
+  resolveBusyTimeoutMs,
 } from '../db/index.js';
 import { debug, info } from '../infrastructure/logger.js';
 import { paginateResult } from '../shared/paginate.js';
@@ -609,7 +610,7 @@ export function cfgData(
   customDbPath: string | undefined,
   opts: CfgOpts = {},
 ): CfgDataResult {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
 

--- a/src/features/check.ts
+++ b/src/features/check.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { findDbPath, openReadonlyOrFail } from '../db/index.js';
 import { bfsTransitiveCallers } from '../domain/analysis/impact.js';
 import { findCycles } from '../domain/graph/cycles.js';
-import { loadConfig } from '../infrastructure/config.js';
+import { DEFAULTS, loadConfig } from '../infrastructure/config.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
 import type { BetterSqlite3Database, CodegraphConfig } from '../types.js';
 import { matchOwners, parseCodeowners } from './owners.js';
@@ -718,15 +718,23 @@ function makeEmptyCheck(): CheckResult {
 }
 
 export function checkData(customDbPath: string | undefined, opts: CheckOpts = {}): CheckResult {
-  const db = openReadonlyOrFail(customDbPath);
+  // Resolve repoRoot + config before opening the DB so config.db.busyTimeoutMs
+  // can be threaded through to openReadonlyOrFail() (mirrors resolveDbSettings()'s
+  // ordering in db/connection.ts — loadConfig can throw, and an already-open
+  // handle at that point would never be closed). repoRoot only depends on
+  // findDbPath(), not on the DB actually existing, so this reorder is safe.
+  const dbPath = findDbPath(customDbPath);
+  const repoRoot = path.resolve(path.dirname(dbPath), '..');
+  const config = opts.config || loadConfig(repoRoot);
+  const db = openReadonlyOrFail(
+    customDbPath,
+    config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
+  );
 
   try {
-    const dbPath = findDbPath(customDbPath);
-    const repoRoot = path.resolve(path.dirname(dbPath), '..');
     const noTests = opts.noTests || false;
     const maxDepth = opts.depth || 3;
 
-    const config = opts.config || loadConfig(repoRoot);
     const flags = resolveCheckFlags(opts, config);
 
     const gitRoot = findGitRoot(repoRoot);

--- a/src/features/cochange.ts
+++ b/src/features/cochange.ts
@@ -8,7 +8,14 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { closeDb, findDbPath, initSchema, openDb, openReadonlyOrFail } from '../db/index.js';
+import {
+  closeDb,
+  findDbPath,
+  initSchema,
+  openDb,
+  openReadonlyOrFail,
+  resolveBusyTimeoutMs,
+} from '../db/index.js';
 import { DEFAULTS } from '../infrastructure/config.js';
 import { debug, warn } from '../infrastructure/logger.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
@@ -407,7 +414,7 @@ export function coChangeData(
   customDbPath?: string,
   opts: { limit?: number; minJaccard?: number; noTests?: boolean; offset?: number } = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   const limit = opts.limit || 20;
   const minJaccard = opts.minJaccard ?? DEFAULTS.coChange.minJaccard;
   const noTests = opts.noTests || false;
@@ -479,7 +486,7 @@ export function coChangeTopData(
   customDbPath?: string,
   opts: { limit?: number; minJaccard?: number; noTests?: boolean; offset?: number } = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   const limit = opts.limit || 20;
   const minJaccard = opts.minJaccard ?? DEFAULTS.coChange.minJaccard;
   const noTests = opts.noTests || false;

--- a/src/features/complexity-query.ts
+++ b/src/features/complexity-query.ts
@@ -285,6 +285,7 @@ function resolveComplexityQueryOptions(opts: ComplexityQueryOpts): {
   noTests: boolean;
   aboveThreshold: boolean;
   thresholds: any;
+  busyTimeoutMs: number;
 } {
   const config = opts.config || loadConfig(process.cwd());
   return {
@@ -292,6 +293,7 @@ function resolveComplexityQueryOptions(opts: ComplexityQueryOpts): {
     noTests: opts.noTests || false,
     aboveThreshold: opts.aboveThreshold || false,
     thresholds: config.manifesto?.rules || DEFAULTS.manifesto.rules,
+    busyTimeoutMs: config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
   };
 }
 
@@ -320,10 +322,13 @@ export function complexityData(
   customDbPath?: string,
   opts: ComplexityQueryOpts = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(customDbPath);
+  // Resolve config (and thus busyTimeoutMs) before opening the DB — mirrors
+  // resolveDbSettings()'s ordering in db/connection.ts, since loadConfig can
+  // throw and an already-open handle at that point would never be closed.
+  const { sort, noTests, aboveThreshold, thresholds, busyTimeoutMs } =
+    resolveComplexityQueryOptions(opts);
+  const db = openReadonlyOrFail(customDbPath, busyTimeoutMs);
   try {
-    const { sort, noTests, aboveThreshold, thresholds } = resolveComplexityQueryOptions(opts);
-
     const { where, params } = buildComplexityWhere({
       noTests,
       target: opts.target || null,

--- a/src/features/dataflow.ts
+++ b/src/features/dataflow.ts
@@ -18,7 +18,12 @@ import {
 } from '../ast-analysis/shared.js';
 import { walkWithVisitors } from '../ast-analysis/visitor.js';
 import { createDataflowVisitor } from '../ast-analysis/visitors/dataflow-visitor.js';
-import { hasDataflowTable, openReadonlyOrFail, openReadonlyWithNative } from '../db/index.js';
+import {
+  hasDataflowTable,
+  openReadonlyOrFail,
+  openReadonlyWithNative,
+  resolveBusyTimeoutMs,
+} from '../db/index.js';
 import { ALL_SYMBOL_KINDS, normalizeSymbol } from '../domain/queries.js';
 import { debug, info } from '../infrastructure/logger.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
@@ -1531,7 +1536,7 @@ export function dataflowPathData(
     offset?: number;
   } = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const noTests = opts.noTests || false;
     const maxDepth = opts.maxDepth || 10;
@@ -1632,7 +1637,7 @@ export function dataflowImpactData(
     offset?: number;
   } = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const maxDepth = opts.depth || 5;
     const noTests = opts.noTests || false;

--- a/src/features/flow.ts
+++ b/src/features/flow.ts
@@ -5,7 +5,7 @@
  * framework entry points (routes, commands, events) through their call chains.
  */
 
-import { openReadonlyOrFail } from '../db/index.js';
+import { openReadonlyOrFail, resolveBusyTimeoutMs } from '../db/index.js';
 import { CORE_SYMBOL_KINDS, findMatchingNodes } from '../domain/queries.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
 import { toSymbolRef } from '../shared/normalize.js';
@@ -33,7 +33,7 @@ export function listEntryPointsData(
   dbPath?: string,
   opts: { noTests?: boolean; limit?: number; offset?: number } = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(dbPath);
+  const db = openReadonlyOrFail(dbPath, resolveBusyTimeoutMs(dbPath));
   try {
     const noTests = opts.noTests || false;
 
@@ -255,7 +255,7 @@ export function flowData(
     offset?: number;
   } = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(dbPath);
+  const db = openReadonlyOrFail(dbPath, resolveBusyTimeoutMs(dbPath));
   try {
     const maxDepth = opts.depth || 10;
     const noTests = opts.noTests || false;

--- a/src/features/manifesto.ts
+++ b/src/features/manifesto.ts
@@ -1,7 +1,7 @@
 import { openReadonlyOrFail } from '../db/index.js';
 import { buildFileConditionSQL } from '../db/query-builder.js';
 import { findCycles } from '../domain/graph/cycles.js';
-import { loadConfig } from '../infrastructure/config.js';
+import { DEFAULTS, loadConfig } from '../infrastructure/config.js';
 import { debug } from '../infrastructure/logger.js';
 import { paginateResult } from '../shared/paginate.js';
 import type { BetterSqlite3Database, CodegraphConfig, ThresholdRule } from '../types.js';
@@ -469,10 +469,17 @@ export function manifestoData(
   customDbPath?: string,
   opts: ManifestoOpts = {},
 ): Record<string, unknown> {
-  const db = openReadonlyOrFail(customDbPath);
+  // Resolve config before opening the DB so config.db.busyTimeoutMs can be
+  // threaded through to openReadonlyOrFail() (mirrors resolveDbSettings()'s
+  // ordering in db/connection.ts — loadConfig can throw, and an already-open
+  // handle at that point would never be closed).
+  const config = opts.config || loadConfig(process.cwd());
+  const db = openReadonlyOrFail(
+    customDbPath,
+    config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
+  );
 
   try {
-    const config = opts.config || loadConfig(process.cwd());
     const rules = resolveRules(
       config.manifesto?.rules as unknown as Record<string, Partial<ThresholdRule>>,
     );

--- a/src/features/owners.ts
+++ b/src/features/owners.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { findDbPath, openReadonlyOrFail } from '../db/index.js';
+import { findDbPath, openReadonlyOrFail, resolveBusyTimeoutMs } from '../db/index.js';
 import { normalizeFileFilter } from '../db/query-builder.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
 
@@ -320,7 +320,7 @@ function buildOwnersSummary(
 }
 
 export function ownersData(customDbPath?: string, opts: OwnersDataOpts = {}): OwnersDataResult {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const dbPath = findDbPath(customDbPath);
     const repoRoot = path.resolve(path.dirname(dbPath), '..');

--- a/src/features/structure-query.ts
+++ b/src/features/structure-query.ts
@@ -7,8 +7,13 @@
  * role classification).
  */
 
-import { openReadonlyOrFail, openReadonlyWithNative, testFilterSQL } from '../db/index.js';
-import { loadConfig } from '../infrastructure/config.js';
+import {
+  openReadonlyOrFail,
+  openReadonlyWithNative,
+  resolveBusyTimeoutMs,
+  testFilterSQL,
+} from '../db/index.js';
+import { DEFAULTS, loadConfig } from '../infrastructure/config.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
 import { normalizePath } from '../shared/constants.js';
 import { paginateResult } from '../shared/paginate.js';
@@ -138,7 +143,7 @@ export function structureData(
   suppressed?: number;
   warning?: string;
 } {
-  const db = openReadonlyOrFail(customDbPath);
+  const db = openReadonlyOrFail(customDbPath, resolveBusyTimeoutMs(customDbPath));
   try {
     const rawDir = opts.directory || null;
     const filterDir = rawDir && normalizePath(rawDir) !== '.' ? rawDir : null;
@@ -376,9 +381,16 @@ export function moduleBoundariesData(
   }[];
   count: number;
 } {
-  const db = openReadonlyOrFail(customDbPath);
+  // Resolve config before opening the DB so config.db.busyTimeoutMs can be
+  // threaded through to openReadonlyOrFail() (mirrors resolveDbSettings()'s
+  // ordering in db/connection.ts — loadConfig can throw, and an already-open
+  // handle at that point would never be closed).
+  const config = opts.config || loadConfig();
+  const db = openReadonlyOrFail(
+    customDbPath,
+    config.db?.busyTimeoutMs ?? DEFAULTS.db.busyTimeoutMs,
+  );
   try {
-    const config = opts.config || loadConfig();
     const threshold =
       opts.threshold ??
       (config as unknown as { structure?: { cohesionThreshold?: number } }).structure

--- a/src/shared/generators.ts
+++ b/src/shared/generators.ts
@@ -1,4 +1,4 @@
-import { iterateFunctionNodes, openReadonlyOrFail } from '../db/index.js';
+import { iterateFunctionNodes, openReadonlyOrFail, resolveBusyTimeoutMs } from '../db/index.js';
 import { buildFileConditionSQL } from '../db/query-builder.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
 import type { BetterSqlite3Database, NodeRow } from '../types.js';
@@ -26,7 +26,10 @@ export function* iterListFunctions(
   customDbPath?: string,
   opts: IterListOpts = {},
 ): Generator<ListFunctionResult> {
-  const db = openReadonlyOrFail(customDbPath) as BetterSqlite3Database;
+  const db = openReadonlyOrFail(
+    customDbPath,
+    resolveBusyTimeoutMs(customDbPath),
+  ) as BetterSqlite3Database;
   try {
     const noTests = opts.noTests || false;
 
@@ -68,7 +71,10 @@ interface IterRolesOpts {
  * Generator: stream role-classified symbols one-by-one.
  */
 export function* iterRoles(customDbPath?: string, opts: IterRolesOpts = {}): Generator<RoleResult> {
-  const db = openReadonlyOrFail(customDbPath) as BetterSqlite3Database;
+  const db = openReadonlyOrFail(
+    customDbPath,
+    resolveBusyTimeoutMs(customDbPath),
+  ) as BetterSqlite3Database;
   try {
     const noTests = opts.noTests || false;
     const conditions = ['role IS NOT NULL'];
@@ -133,7 +139,10 @@ export function* iterWhere(
   customDbPath?: string,
   opts: IterWhereOpts = {},
 ): Generator<WhereResult> {
-  const db = openReadonlyOrFail(customDbPath) as BetterSqlite3Database;
+  const db = openReadonlyOrFail(
+    customDbPath,
+    resolveBusyTimeoutMs(customDbPath),
+  ) as BetterSqlite3Database;
   try {
     const noTests = opts.noTests || false;
     const placeholders = ALL_SYMBOL_KINDS.map(() => '?').join(', ');

--- a/tests/unit/busy-timeout-query-sites.test.ts
+++ b/tests/unit/busy-timeout-query-sites.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for issue #1763: the ad-hoc read-only query call sites in
+ * features/*, domain/analysis/*, and domain/search/* must thread the
+ * user-configured `db.busyTimeoutMs` through to their `openReadonlyOrFail()`
+ * call, instead of silently falling back to the DEFAULTS.db.busyTimeoutMs
+ * hardcoded default.
+ *
+ * Covers the shared `resolveBusyTimeoutMs()` helper directly, plus a
+ * representative sample of call sites from each category identified while
+ * fixing the issue:
+ *   - category (c), never loaded config before this fix: ownersData, cfgData
+ *   - category (b), loaded config AFTER opening the db (now reordered): manifestoData
+ *   - category (a), already loaded config before opening the db: hybridSearchData
+ *   - the shared withReadonlyDb() wrapper (also covers exports/dependencies/context)
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { closeDb, initSchema, openDb, resolveBusyTimeoutMs } from '../../src/db/index.js';
+import { withReadonlyDb } from '../../src/domain/analysis/query-helpers.js';
+import { hybridSearchData } from '../../src/domain/search/search/hybrid.js';
+import { cfgData } from '../../src/features/cfg.js';
+import { manifestoData } from '../../src/features/manifesto.js';
+import { ownersData } from '../../src/features/owners.js';
+import { DEFAULTS } from '../../src/infrastructure/config.js';
+
+const CUSTOM_BUSY_TIMEOUT_MS = 42424;
+
+let tmpDir: string;
+let dbPath: string;
+
+/** Capture every `busy_timeout = N` pragma issued against a real Database instance. */
+function captureBusyTimeoutPragmas(): { calls: string[]; restore: () => void } {
+  const original = Database.prototype.pragma;
+  const calls: string[] = [];
+  const spy = vi.spyOn(Database.prototype, 'pragma').mockImplementation(function (
+    this: unknown,
+    sql: string,
+    ...rest: unknown[]
+  ) {
+    if (typeof sql === 'string' && sql.startsWith('busy_timeout')) calls.push(sql);
+    return original.apply(this, [sql, ...rest] as Parameters<typeof original>);
+  });
+  return { calls, restore: () => spy.mockRestore() };
+}
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-busy-threading-'));
+  dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+  const db = openDb(dbPath);
+  initSchema(db);
+  closeDb(db);
+  fs.writeFileSync(
+    path.join(tmpDir, '.codegraphrc.json'),
+    JSON.stringify({ db: { busyTimeoutMs: CUSTOM_BUSY_TIMEOUT_MS } }),
+  );
+});
+
+afterAll(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('resolveBusyTimeoutMs', () => {
+  it('reads db.busyTimeoutMs from the project config nearest the resolved DB path', () => {
+    expect(resolveBusyTimeoutMs(dbPath)).toBe(CUSTOM_BUSY_TIMEOUT_MS);
+  });
+
+  it('falls back to DEFAULTS.db.busyTimeoutMs when no project config sets it', () => {
+    const bareDir = fs.mkdtempSync(path.join(tmpDir, 'bare-'));
+    const bareDbPath = path.join(bareDir, '.codegraph', 'graph.db');
+    const db = openDb(bareDbPath);
+    initSchema(db);
+    closeDb(db);
+
+    expect(resolveBusyTimeoutMs(bareDbPath)).toBe(DEFAULTS.db.busyTimeoutMs);
+    expect(resolveBusyTimeoutMs(bareDbPath)).not.toBe(CUSTOM_BUSY_TIMEOUT_MS);
+  });
+});
+
+describe('configured busyTimeoutMs reaches PRAGMA busy_timeout at ad-hoc read-only call sites', () => {
+  it('ownersData (never loaded config before this fix) applies the configured busy_timeout', () => {
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      ownersData(dbPath);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('cfgData (never loaded config before this fix) applies the configured busy_timeout', () => {
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      cfgData('nonexistent-symbol', dbPath);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('manifestoData (config load reordered to before the db opens) applies the configured busy_timeout', () => {
+    // manifestoData resolves its config via loadConfig(process.cwd()) — a
+    // pre-existing, cwd-based resolution this fix intentionally preserves
+    // (only the *timing* of the call moved, not what it resolves) — so the
+    // project config must be visible from process.cwd() here, not from dbPath.
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      manifestoData(dbPath);
+    } finally {
+      capture.restore();
+      cwdSpy.mockRestore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('hybridSearchData (already loaded config before the db opens) applies the configured busy_timeout', async () => {
+    // Same pre-existing cwd-based config resolution as manifestoData (bare
+    // loadConfig() defaults to process.cwd()) — preserved, not introduced, by
+    // this fix.
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      await hybridSearchData('nonexistent-query', dbPath);
+    } finally {
+      capture.restore();
+      cwdSpy.mockRestore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('withReadonlyDb (shared helper backing exports/dependencies/context) applies the configured busy_timeout', () => {
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      withReadonlyDb(dbPath, (db) => db.prepare('SELECT 1').get());
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Re-grepped and found the call-site list had grown to ~32 (not ~15 as originally filed, given how much this batch has touched these files). Categorized and fixed all of them:
  - Already loaded config before opening the DB → threaded through directly (2 sites).
  - Loaded config only after opening the DB → reordered, verified safe (`loadConfig()` only throws for one narrow case — non-string `llm.apiKeyCommand` — and no existing test pins error ordering for any of these sites; mirrors the precedent already established by `resolveDbSettings()`).
  - Never loaded config at all → added a new `resolveBusyTimeoutMs(customDbPath?)` helper call, including `query-helpers.ts`'s shared `withReadonlyDb()` which transitively fixes `exports.ts`/`dependencies.ts`/`context.ts` for free.
- The Rust native DB layer gap (hardcoded `PRAGMA busy_timeout = 5000`, no config awareness) is genuinely out of scope per the issue's own framing — investigated briefly, doesn't need config-loading capability (JS already resolves the value) but does need a new FFI parameter across 6 call sites + a napi rebuild. Filed as #1882 rather than attempted here. Using `Refs #1763` rather than `Closes` since this issue named both the TS wiring and the Rust layer as its scope — only the former is done.

Refs #1763

## Test plan
- `npm test` — full suite green (3528 passed, 0 failed) — caught and fixed a real bug during the gate: 26 tests in `complexity.test.ts` mock `loadConfig()` to return `{}`, and non-optional-chained `config.db.busyTimeoutMs` crashed on the missing key; fixed with `config.db?.busyTimeoutMs` matching the existing defensive pattern elsewhere
- `npm run lint` / `npx tsc --noEmit` / `npm run build` — clean
- New `tests/unit/busy-timeout-query-sites.test.ts` (7 tests) spies on `Database.prototype.pragma` to assert the configured value is actually applied
- Real end-to-end CLI verification: scratch project with `.codegraphrc.json` (`db.busyTimeoutMs: 424242`), ran 16 different commands, confirmed every one used the configured value; confirmed default (5000) still applies with no override

Filed #1881 for an out-of-scope finding: several functions resolve config via `process.cwd()` rather than the resolved `--db` path (pre-existing, not introduced here — preserved each function's existing resolution mechanism). Filed #1882 for the Rust layer.

Stacked on #1880 (base branch `fix/issue-1762-titan-grind-dead-symbol-shape`) — only this diff is this issue's change.